### PR TITLE
Fix docs config example

### DIFF
--- a/docs/_static/config_examples/example-vs-resource.configmap.yaml
+++ b/docs/_static/config_examples/example-vs-resource.configmap.yaml
@@ -7,7 +7,7 @@ metadata:
     f5type: virtual-server
 data:
   schema: "f5schemadb://bigip-virtual-server_v0.1.3.json"
-  data: |-
+  data: |
     {
       "virtualServer": {
         "frontend": {


### PR DESCRIPTION
The JSON data was incorrectly formatted, causing the config example to be incorrect.

Removed the '-' that was not needed.