### PR TITLE
Configure IPv6 Adddresses properly

### DIFF
--- a/python/k8s-build-requirements.txt
+++ b/python/k8s-build-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@662b8f2f1df0180938a46f7b6078973a37f824eb#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@5c74e82ba7fdbf846c50bae838578f2bdb8521ed#egg=f5-cccl
 pytest==3.0.2
 mock
 flake8

--- a/python/k8s-runtime-requirements.txt
+++ b/python/k8s-runtime-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@662b8f2f1df0180938a46f7b6078973a37f824eb#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@5c74e82ba7fdbf846c50bae838578f2bdb8521ed#egg=f5-cccl
 f5-icontrol-rest==1.3.0
 f5-sdk==2.2.2
 pyinotify==0.9.6

--- a/python/tests/kubernetes_one_svc_two_nodes.json
+++ b/python/tests/kubernetes_one_svc_two_nodes.json
@@ -7,7 +7,7 @@
         "mode": "http",
         "balance": "round-robin",
         "virtualAddress": {
-          "bindAddr": "10.128.10.240",
+          "bindAddr": "FE80::1",
           "port": 5051
         },
         "sslProfile": {

--- a/python/tests/test_k8scloudbigip.py
+++ b/python/tests/test_k8scloudbigip.py
@@ -426,7 +426,7 @@ class KubernetesTest(BigIPTest):
         virtual_data_unchanged = {'enabled': True,
                                   'disabled': False,
                                   'ipProtocol': 'tcp',
-                                  'destination': '/k8s/10.128.10.240:5051',
+                                  'destination': '/k8s/FE80::1.5051',
                                   'pool': '/k8s/default_configmap',
                                   'sourceAddressTranslation':
                                   {'type': 'automap'},


### PR DESCRIPTION
Problem: The config driver only handled IPv4 Addresses, which ended in the form
':port', whereas IPv6 Addresses end in the form '.port'.

Solution: Correctly configure IPv4 vs IPv6 addresses.