### PR TITLE
Fixed backoff timer exception handling.

### DIFF
--- a/python/bigipconfigdriver.py
+++ b/python/bigipconfigdriver.py
@@ -513,11 +513,7 @@ class ConfigHandler():
                         # Error occurred, perform retries
                         log.warning(
                             'regenerate operation failed, restarting')
-
-                        if (self._interval and self._interval.is_running() is
-                                True):
-                            self._interval.stop()
-                        self.retry_backoff(self.notify_reset)
+                        self.handle_backoff()
                     else:
                         if (self._interval and self._interval.is_running() is
                                 False):
@@ -548,9 +544,17 @@ class ConfigHandler():
                               time.time() - start_time)
                 except Exception:
                     log.exception('Unexpected error')
+                    self.handle_backoff()
 
         if self._interval:
             self._interval.stop()
+
+    def handle_backoff(self):
+        """Wrapper for calls to retry_backoff."""
+        if (self._interval and self._interval.is_running() is
+                True):
+            self._interval.stop()
+        self.retry_backoff(self.notify_reset)
 
     def retry_backoff(self, func):
         """Add a backoff timer to retry in case of failure."""


### PR DESCRIPTION
Problem:
 Current exception handling will cause the backoff timer to not be reset
 correctly when broken configs are fixed and then broken again.

Solution:
 Increment the backoff timer when exceptions occur with configs so now
 it is incremented if an exception occurs or if regenerate_config_f5
 fails.

affects-branches: master