### PR TITLE
Add combined Go/Python coveralls

### DIFF
--- a/build-tools/python-tests.sh
+++ b/build-tools/python-tests.sh
@@ -10,7 +10,18 @@ CURDIR="$(dirname $BASH_SOURCE)"
 . $CURDIR/_build-lib.sh
 BUILDDIR=$(get_builddir)
 
-echo "BUILDDIR: as seen from python-tests -- $BUILDDIR"
+export BUILDDIR=$BUILDDIR
 
 (cd python && flake8 . --exclude src,lib,go,bin,docs,cmd)
-(cd python && pytest . -slvv --ignore=src/ -p no:cacheprovider)
+(cd python && pytest . -slvv --ignore=src/ -p no:cacheprovider --cov)
+
+if [ "$TRAVIS_REPO_SLUG" != "" ]; then
+  if [ "$COVERALLS_TOKEN" ]; then
+    echo "Converting python coverage to goveralls format..."
+    (cd python && coveralls --output=$BUILDDIR/coverage.json)
+    python build-tools/python-coverage.py $BUILDDIR/coverage.json $BUILDDIR/python-coverage.txt
+  else
+    echo "[INFO] Not an 'F5Networks' commit, coverage optional."
+    echo "[INFO] See README.md section 'build' to configure travis with coveralls."
+  fi
+fi

--- a/build-tools/rel-build.sh
+++ b/build-tools/rel-build.sh
@@ -8,6 +8,8 @@ CURDIR="$(dirname $BASH_SOURCE)"
 . $CURDIR/_build-lib.sh
 BUILDDIR=$(get_builddir)
 
+export BUILDDIR=$BUILDDIR
+
 for pkg in $(all_cmds) $(all_pkgs); do
   test_pkg "$pkg"
 done
@@ -19,3 +21,12 @@ gather_coverage
 
 # run python tests
 ./build-tools/python-tests.sh
+
+# push coverage data to coveralls if F5 repo or if configured for fork.
+if [ "$COVERALLS_TOKEN" ]; then
+  cat $BUILDDIR/test/merged-coverage.out >> $BUILDDIR/merged-coverage.out
+  cat $BUILDDIR/python-coverage.txt >> $BUILDDIR/merged-coverage.out
+  goveralls \
+    -coverprofile=$BUILDDIR/merged-coverage.out \
+    -service=travis-ci
+fi

--- a/python/.coveragerc
+++ b/python/.coveragerc
@@ -1,0 +1,9 @@
+# .coveragerc to control coverage.py for build
+
+[run]
+omit =
+  */lib/*
+  */tests/*
+  */go/src/f5-cccl/*
+
+data_file = ${BUILDDIR}/python-coverage.out


### PR DESCRIPTION
Problem:
- Repository did not post coverage to coveralls.

Solution:
- Updated build-tools to support coverage data using BUILDDIR variable to produce coverage data for coveralls on builds.
- Added coveragerc file to set python coverage data configs.

fixes #221

affects-branches: master