### PR TITLE
Fixed test data indexing.

### DIFF
--- a/python/bigipconfigdriver.py
+++ b/python/bigipconfigdriver.py
@@ -533,10 +533,11 @@ class ConfigHandler():
                             test_data = {}
                             app_count = 0
                             backend_count = 0
-                            for service in config['virtualServers']:
+                            for service in config['resources'][
+                                    'virtualServers']:
                                 app_count += 1
                                 backends = 0
-                                for pool in config['pools']:
+                                for pool in config['resources']['pools']:
                                     if pool['name'] == service['name']:
                                         backends = len(pool['poolMemberAddrs'])
                                         break


### PR DESCRIPTION
Problem:
 config object has been changed to config['resources']['<resource>'] and
 the scale test data processing block was not updated causing log time
 out errors during the tests.

Solution:
 change to correct indexing in test data processing block to prevent
 key errors resulting in test failures.

affects-branches: master
Fixes: #235