### PR TITLE
travis able to publish docs to aws

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 before_install:
   - docker pull golang:1.7.5
   - docker pull node:6.11.0-slim
+  - docker pull f5devcentral/containthedocs
 
 script:
   - set -e
@@ -36,7 +37,12 @@ script:
       docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
       docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
     fi
-  - |
-    if [ "$TRAVIS_TAG" == "1.0-stable" ]; then
-      docker run -it f5devcentral/containthedocs publish-product-docs-to-prod connectors/k8s-bigip-ctlr v1.0
-    fi
+
+deploy:
+  - provider: script
+    skip_cleanup: true
+    on:
+      branch: 1.1-stable
+      repo: F5Networks/k8s-bigip-ctlr
+    script:
+      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/k8s-bigip-ctlr v1.1

--- a/build-tools/deploy-docs.sh
+++ b/build-tools/deploy-docs.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+# Don't set -x
+# we need to keep the secrets AWS variables out of the logs
+
+exec docker run --rm -it -v $PWD:$PWD --workdir $PWD -e  AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -e AWS_S3_BUCKET=$AWS_S3_BUCKET f5devcentral/containthedocs "$@"

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,7 +1,7 @@
 Release Notes for K8S BIG-IP Controller
 ============================================
 
-v1.1.0-dev
+|release|
 ----------
 
 Added Functionality
@@ -32,7 +32,7 @@ Added Functionality
 * Can manage multiple BIG-IP partitions in the following environments
 
   * Kubernetes
-  * Red Hat OpenShift 
+  * Red Hat OpenShift
 
 * Manages the following LTM resources for the BIG-IP partition(s)
 
@@ -45,7 +45,7 @@ Added Functionality
   * Application Services
 
 * Manages the following Network resource for the BIG-IP partition(s)
-  
+
   * FDB tunnel records (Red Hat OpenShift)
 
 Removed Functionality
@@ -61,4 +61,3 @@ Limitations
 * Parameters other than IPAddress and Port (e.g. Connection Limit) specified in the iApp Pool Member Table apply to all members of the pool.
 * Cannot configure virtual servers with IPv6 addresses in the configmap.
 * The K8S BIG-IP Controller cannot watch more than one namespace.
-


### PR DESCRIPTION
Problem:
- travis-ci lacked ability to push docs to aws for release

Solution:
- added deploy section to .travis.yml
- added deploy-docs.sh

fixes #239 