### PR TITLE
Update release notes for v1.1.0

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -4,45 +4,61 @@ Release Notes for K8S BIG-IP Controller
 v1.1.0-dev
 ----------
 
-* Features
+Added Functionality
+^^^^^^^^^^^^^^^^^^^
 
-  * Watches all Kubernetes namespaces by default, or can watch a list of namespaces, or namespaces with a customer specified label. This addresses a previous limitation in v1.0.0.
-  * Watches for Kubernetes annotation if virtual address not specified, enabling custom IPAM integration.
-  * Creates detached pools if virtual server bind addresses not specified.
-  * Container image size reduced from 361MB to 123MB.
-  * Can use local and non-local BIG-IP users.
+* Virtual Servers can now be configured on the BIG-IP from Kubernetes Ingress resources.
+* Multiple SSL Profiles can be configured for a Virtual Server.
+* Watches all Kubernetes namespaces by default, or can watch a list of namespaces, or namespaces with a customer specified label. This addresses a previous limitation in v1.0.0.
+* Watches for Kubernetes annotation if virtual address not specified, enabling custom IPAM integration.
+* Creates detached pools if virtual server bind addresses not specified.
+* Container image size reduced from 361MB to 123MB.
+* Can use local and non-local BIG-IP users.
+
+Removed Functionality
+^^^^^^^^^^^^^^^^^^^^^
+
+Limitations
+^^^^^^^^^^^
+
+* The SSL Profiles referenced in Ingress resources must already be configured on the BIG-IP. Any Secret resources configured in Kubernetes are not used.
 
 v1.0.0
 ------
 
-* Capabilities
+Added Functionality
+^^^^^^^^^^^^^^^^^^^
 
-  * Can manage multiple BIG-IP partitions in the following environments
+* Can manage multiple BIG-IP partitions in the following environments
 
-    * Kubernetes
-    * Red Hat OpenShift 
+  * Kubernetes
+  * Red Hat OpenShift 
 
-  * Manages the following LTM resources for the BIG-IP partition(s)
+* Manages the following LTM resources for the BIG-IP partition(s)
 
-    * Virtual Servers
-    * Virtual Addresses
-    * Pools
-    * Pool Members
-    * Nodes
-    * Health Monitors
-    * Application Services
+  * Virtual Servers
+  * Virtual Addresses
+  * Pools
+  * Pool Members
+  * Nodes
+  * Health Monitors
+  * Application Services
 
-  * Manages the following Network resource for the BIG-IP partition(s)
+* Manages the following Network resource for the BIG-IP partition(s)
   
-    * FDB tunnel records (Red Hat OpenShift)
+  * FDB tunnel records (Red Hat OpenShift)
 
-* Limitations
+Removed Functionality
+^^^^^^^^^^^^^^^^^^^^^
 
-  * Cannot share endpoints managed in a partition controlled by the K8S BIG-IP Controller with endpoints managed in another partition.
-  * Kubernetes allows a service to name the individual service ports within a particular service.  However, the K8S BIG-IP Controller requires the virtual server section within the configmap to refer to the port number for the service port, not the name.
-  * Two virtual servers cannot point to the same servicePort.  The last one specified will be the one that remains configured.
-  * The BIG-IP Controller does not handle non-zero route domains.  All managed partitions should use the default route domain (0).
-  * Parameters other than IPAddress and Port (e.g. Connection Limit) specified in the iApp Pool Member Table apply to all members of the pool.
-  * Cannot configure virtual servers with IPv6 addresses in the configmap.
-  * The K8S BIG-IP Controller cannot watch more than one namespace.
+Limitations
+^^^^^^^^^^^
+
+* Cannot share endpoints managed in a partition controlled by the K8S BIG-IP Controller with endpoints managed in another partition.
+* Kubernetes allows a service to name the individual service ports within a particular service.  However, the K8S BIG-IP Controller requires the virtual server section within the configmap to refer to the port number for the service port, not the name.
+* Two virtual servers cannot point to the same servicePort.  The last one specified will be the one that remains configured.
+* The BIG-IP Controller does not handle non-zero route domains.  All managed partitions should use the default route domain (0).
+* Parameters other than IPAddress and Port (e.g. Connection Limit) specified in the iApp Pool Member Table apply to all members of the pool.
+* Cannot configure virtual servers with IPv6 addresses in the configmap.
+* The K8S BIG-IP Controller cannot watch more than one namespace.
 


### PR DESCRIPTION
Problem:
The release notes need to be updated for the new release.

Solution:
Changed the latest release to v1.1.0 and added features new to the
release.