### PR TITLE
add slack build notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,3 +46,8 @@ deploy:
       repo: F5Networks/k8s-bigip-ctlr
     script:
       - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/k8s-bigip-ctlr v1.1
+
+notifications:
+  slack:
+    rooms:
+      secure: mStBSaHe009xjilMEq5YwRmiYAB+oWZkKe1nk6rYebxw1uxVSe18lXkq9dhmX9a7nvko1iLvVYeXhmwE4ZWfnYVeMkaWq5/P3Rx0f453oEeM5SvqgoJfDPFyKqwBQgeIcOkZ+RMXiJRynPhb8BvnVMi24ZYUUpNP45TWWoBXHXg3xaPaFXQucZpHpPFYKZt8V5/aRhLTDhzvNP1o//ijgTuKDp2zuRSmVin5ofCEi78fDVIX5UXxvK47xx0dM5Lg8JFx/Tz9NcLreWsnz2NrRHxFwaxvGQiZAIamUwGCJKAoS+WlRVtcLuyB+FFfwaO0EaTKJr/5OWv8uhpK7pZfvfL//ShIHIf4FeCiOZG6s+PNiwzmxjVsX8CkZDqIvW+arGYA9OcYwKzLKBi5fR0SQzr2Eu+w53BhvutHzl7uok8XcxIzlo6zNaR23kYR9chnnIFvAwhugHa2iSoilAohsrf0nBNdDj0G2ObZSi4j68mQhn3fTHZzEDE3TddwnHcMgHOSkPFIZZJJZ4MrY5Ky1MuaZocOqCSPJlpPpd5EoJdBjozR5Coqsek3W1iaEgKVKsDuCvqsEHpI5JTLrJb9Q7g47O0dmDDOteQWDY6BJB/oFKjg5E+uN4qWCP99ydCS8UMTEdedZ/MZu2uGHeNgchRSsiLpFSOwoR/QlC2ezGQ=


### PR DESCRIPTION
Problem:
Travis builds did not post to repo slack channel.

Analysis:
Notifications are configured for the F5Networks namespace, meaning that pushes to branches on a pull request will send notifications, but pushes to branches pre-pull request will not. Notifications are sent on success as well as failure since there is not a "merge when build succeeds" as in GitLab.

Solution:
Generated "secure" key using travis cli tool and added notifiaction section to `.travis.yml` to post build notices to repo slack channel.