### PR TITLE
remove references to gitlab registry

### DIFF
--- a/build-tools/attributions-generator.sh
+++ b/build-tools/attributions-generator.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
-# 
+#
 # Run the arrtibutions generator container
 #
 
 set -e
 set -x
 
-ATTR_GEN_IMG=docker-registry.pdbld.f5net.com/velcro/attributions-generator:master
+ATTR_GEN_IMG=f5devcentral/attributions-generator:latest
 docker pull ${ATTR_GEN_IMG}
 
 RUN_ARGS=( \

--- a/build-tools/docker-docs.sh
+++ b/build-tools/docker-docs.sh
@@ -2,8 +2,8 @@
 
 set -x
 
-: ${DOC_IMG:=docker-registry.pdbld.f5net.com/tools/containthedocs:master}
- 
+: ${DOC_IMG:=f5devcentral/containthedocs:latest}
+
 RUN_ARGS=( \
   --rm
   -v $PWD:$PWD


### PR DESCRIPTION
Problem:
Build supporting images need to pull from DockerHub for GitHub build

Solution:
Changed references in to use DockerHub image.