### PR TITLE
SSL certificates from k8s secrets

### DIFF
--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -55,6 +55,9 @@ func (appMgr *Manager) outputConfigLocked() {
 			}
 		}
 	})
+	for _, profile := range appMgr.customProfiles.profs {
+		resources.CustomProfiles = append(resources.CustomProfiles, profile)
+	}
 	if appMgr.vsQueue.Len() == 0 && appMgr.nsQueue.Len() == 0 ||
 		appMgr.initialState == true {
 		doneCh, errCh, err := appMgr.ConfigWriter().SendSection("resources", resources)
@@ -65,6 +68,8 @@ func (appMgr *Manager) outputConfigLocked() {
 			case <-doneCh:
 				log.Infof("Wrote %v Virtual Server configs", len(resources.Virtuals))
 				if log.LL_DEBUG == log.GetLogLevel() {
+					// Remove customProfiles from output
+					resources.CustomProfiles = []CustomProfile{}
 					output, err := json.Marshal(resources)
 					if nil != err {
 						log.Warningf("Failed creating output debug log: %v", err)

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -184,15 +184,26 @@ func formatIngressSslProfileName(secret string) string {
 	case 1:
 		// This is technically supported on the Big-IP, but will fail in the
 		// python driver. Issue a warning here for better context.
-		log.Warningf("WARNING: TLS secret '%v' does not contain a full path.",
-			secret)
+		log.Warningf("TLS secret '%v' does not contain a full path.", secret)
 	default:
 		// This is almost certainly an error, but again issue a warning for
 		// improved context here and pass it through to be handled elsewhere.
-		log.Warningf("WARNING: TLS secret '%v' is formatted incorrectly.",
-			secret)
+		log.Warningf("TLS secret '%v' is formatted incorrectly.", secret)
 	}
 	return profName
+}
+
+// Store of CustomProfiles
+type CustomProfileStore struct {
+	sync.Mutex
+	profs map[secretKey]CustomProfile
+}
+
+// Contructor for CustomProfiles
+func NewCustomProfiles() CustomProfileStore {
+	var cps CustomProfileStore
+	cps.profs = make(map[secretKey]CustomProfile)
+	return cps
 }
 
 type ResourceConfigMap map[string]*ResourceConfig

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -19,10 +19,11 @@ package appmanager
 type (
 	// Config of all resources to configure on the BIG-IP
 	BigIPConfig struct {
-		Virtuals []Virtual `json:"virtualServers,omitempty"`
-		Pools    []Pool    `json:"pools,omitempty"`
-		Monitors []Monitor `json:"monitors,omitempty"`
-		Policies []Policy  `json:"l7Policies,omitempty"`
+		Virtuals       []Virtual       `json:"virtualServers,omitempty"`
+		Pools          []Pool          `json:"pools,omitempty"`
+		Monitors       []Monitor       `json:"monitors,omitempty"`
+		Policies       []Policy        `json:"l7Policies,omitempty"`
+		CustomProfiles []CustomProfile `json:"customProfiles,omitempty"`
 	}
 
 	// Config for a single resource (ConfigMap or Ingress)
@@ -174,6 +175,14 @@ type (
 	iappTableEntry struct {
 		Columns []string   `json:"columns,omitempty"`
 		Rows    [][]string `json:"rows,omitempty"`
+	}
+
+	// Client SSL Profile loaded from Secret
+	CustomProfile struct {
+		Name      string `json:"name"`
+		Partition string `json:"partition"`
+		Cert      []byte `json:"cert"`
+		Key       []byte `json:"key"`
 	}
 
 	// Used to unmarshal ConfigMap data


### PR DESCRIPTION
Problem: The controller needs to be able to load SSL certificates from
Kubernetes Secrets and configure custom profiles on the BIG-IP.

Solution: Enable the controller to search for Secrets in Kubernetes, as defined in the sslProfile field in ConfigMaps,
or tls secretName field in Ingresses. Process the cert and key from the secret and manually create an SSL-profile on
the BIG-IP.