### PR TITLE
Change product name per new guidelines

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![Build Status](https://travis-ci.org/F5Networks/k8s-bigip-ctlr.svg?branch=master)](https://travis-ci.org/F5Networks/k8s-bigip-ctlr) [![Coverage Status](https://coveralls.io/repos/github/F5Networks/k8s-bigip-ctlr/badge.svg?branch=master)](https://coveralls.io/github/F5Networks/k8s-bigip-ctlr?branch=master)
 
-F5 Kubernetes BIG-IP Controller
-===============================
+F5 BIG-IP Controller for Kubernetes
+===================================
 
 The F5 BIG-IP Controller for [Kubernetes](http://kubernetes.io/) makes F5 BIG-IP
 [Local Traffic Manager](<https://f5.com/products/big-ip/local-traffic-manager-ltm)
@@ -11,10 +11,11 @@ Documentation
 -------------
 
 For instruction on how to use this component, see the
-[F5 Kubernetes BIG-IP Controller docs](http://clouddocs.f5.com/products/connectors/k8s-bigip-ctlr/latest/).
+[docs](http://clouddocs.f5.com/products/connectors/k8s-bigip-ctlr/latest/)
+for F5 BIG-IP Controller for Kubernetes.
 
 For guides on this and other solutions for Kubernetes, see the
-[F5 Kubernetes Solution Guides](http://clouddocs.f5.com/containers/latest/kubernetes).
+[F5 Solution Guides for Kubernetes](http://clouddocs.f5.com/containers/latest/kubernetes).
 
 
 Running

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -1,5 +1,5 @@
-F5 Kubernetes BIG-IP Controller
-===============================
+F5 BIG-IP Controller for Kubernetes
+===================================
 
 .. toctree::
     :hidden:
@@ -8,7 +8,7 @@ F5 Kubernetes BIG-IP Controller
     RELEASE-NOTES
     /_static/ATTRIBUTIONS
 
-F5 Kubernetes BIG-IP Controller manages F5 BIG-IP `Local Traffic Manager <https://f5.com/products/big-ip/local-traffic-manager-ltm>`_ (LTM) objects from `Kubernetes`_.
+The |project| manages F5 BIG-IP `Local Traffic Manager <https://f5.com/products/big-ip/local-traffic-manager-ltm>`_ (LTM) objects from `Kubernetes`_.
 
 |release-notes|
 
@@ -25,28 +25,28 @@ Features
 Guides
 ------
 
-See the `F5 Kubernetes Container Connector user documentation </containers/v1/kubernetes/>`_.
+See the `F5 Container Connector for Kubernetes user documentation </containers/v1/kubernetes/>`_.
 
 Overview
 --------
 
-F5 Kubernetes BIG-IP Controller is a Docker container that runs in a `Kubernetes`_ Pod.
+The |project| is a Docker container that runs in a `Kubernetes`_ Pod.
 It uses an F5 Resource to determine:
 
 - what objects to configure on your BIG-IP, and
 - to which `Kubernetes Service`_ the BIG-IP objects belong.
 
-The F5 Kubernetes BIG-IP Controller watches the Kubernetes API for the creation and modification of F5 resources.
-When it discovers changes, the F5 Kubernetes BIG-IP Controller modifies the BIG-IP accordingly.
+The |project| watches the Kubernetes API for the creation and modification of F5 resources.
+When it discovers changes, the |project| modifies the BIG-IP accordingly.
 
 
 For example:
 
-#. F5 Kubernetes BIG-IP Controller discovers a new F5 ``virtualServer`` resource.
-#. F5 Kubernetes BIG-IP Controller creates a new virtual server object on the BIG-IP. [#objectpartition]_
-#. F5 Kubernetes BIG-IP Controller creates a pool member on the virtual server for each node in the cluster. [#nodeport]_
-#. F5 Kubernetes BIG-IP Controller monitors F5 resources, and linked Kubernetes resources, for changes.
-#. F5 Kubernetes BIG-IP Controller reconfigures the BIG-IP when it discovers changes.
+#. |project| discovers a new F5 ``virtualServer`` resource.
+#. |project| creates a new virtual server object on the BIG-IP. [#objectpartition]_
+#. |project| creates a pool member on the virtual server for each node in the cluster. [#nodeport]_
+#. |project| monitors F5 resources, and linked Kubernetes resources, for changes.
+#. |project| reconfigures the BIG-IP when it discovers changes.
 
 The BIG-IP handles traffic for the Service the specified virtual address and load-balances to all nodes in the cluster. Within the cluster, the allocated NodePort load balances traffic to all pods.
 
@@ -305,8 +305,8 @@ Example Configuration Files
 - `example-advanced-vs-resource-iapp.json <./_static/config_examples/example-advanced-vs-resource-iapp.json>`_
 
 
-.. [#objectpartition]  The F5 Kubernetes BIG-IP Controller creates and manages objects in the BIG-IP partition defined in the `F5 resource </containers/v1/kubernetes/index.html#f5-resource-properties>`_ ConfigMap.
-.. [#nodeport]  The F5 Kubernetes BIG-IP Controller forwards traffic to the NodePort assigned to the service by Kubernetes; see the Kubernetes `Services <http://kubernetes.io/docs/user-guide/services/>`_ documentation for more information.
+.. [#objectpartition]  The |project| creates and manages objects in the BIG-IP partition defined in the `F5 resource </containers/v1/kubernetes/index.html#f5-resource-properties>`_ ConfigMap.
+.. [#nodeport]  The |project| forwards traffic to the NodePort assigned to the service by Kubernetes; see the Kubernetes `Services <http://kubernetes.io/docs/user-guide/services/>`_ documentation for more information.
 .. [#secrets]  You can store sensitive information as a `Kubernetes Secret <http://kubernetes.io/docs/user-guide/secrets/>`_. See the `user documentation <#>`_ for instructions.
 
 

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,5 +1,5 @@
-Release Notes for K8S BIG-IP Controller
-=======================================
+Release Notes for BIG-IP Controller for Kubernetes
+==================================================
 
 |release|
 ---------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -69,7 +69,7 @@ source_encoding = 'utf-8-sig'
 master_doc = 'index'
 
 # General information about the project. 
-project = u'F5 Kubernetes BIG-IP Controller'
+project = u'F5 BIG-IP Controller for Kubernetes'
 copyright = u'2017 F5 Networks Inc'
 author = u'F5 Networks'
 
@@ -190,7 +190,7 @@ html_title = "{} {}".format(project, version)
 
 # A shorter title for the navigation bar.  Default is the same as html_title.
 #
-#html_short_title = u'F5 Kubernetes BIG-IP Controller'
+#html_short_title = u'F5 BIG-IP Controller for Kubernetes'
 
 # The name of an image file (relative to this directory) to place at the top
 # of the sidebar.
@@ -315,7 +315,7 @@ latex_elements = {
 #  author, documentclass [howto, manual, or own class]).
 latex_documents = [
     (master_doc, 'F5 Kubernetes BIG-IP Controller.tex',
-     u'F5 Kubernetes BIG-IP Controller - Documentation',
+     u'F5 BIG-IP Controller for Kubernetes - Documentation',
      'F5 Networks', 'manual'),
 ]
 
@@ -365,8 +365,8 @@ latex_toplevel_sectioning = 'section'
 # One entry per manual page. List of tuples
 # (source start file, name, description, authors, manual section).
 man_pages = [
-    (master_doc, 'F5 Kubernetes BIG-IP Controller',
-     u'F5 Kubernetes BIG-IP Controller - Documentation',
+    (master_doc, 'F5 BIG-IP Controller for Kubernetes',
+     u'F5 BIG-IP Controller for Kubernetes - Documentation',
      [author], 1)
 ]
 
@@ -381,9 +381,9 @@ man_pages = [
 # (source start file, target name, title, author,
 #  dir menu entry, description, category)
 texinfo_documents = [
-    (master_doc, 'F5 Kubernetes BIG-IP Controller',
-     u'F5 Kubernetes BIG-IP Controller Documentation',
-     author, 'F5 Kubernetes BIG-IP Controller', 'manual'),
+    (master_doc, 'F5 BIG-IP Controller for Kubernetes',
+     u'F5 BIG-IP Controller for Kubernetes - Documentation',
+     author, 'F5 BIG-IP Controller for Kubernetes', 'manual'),
 ]
 
 # Documents to append as an appendix to all manuals.


### PR DESCRIPTION
Problem:
Product names were not meeting F5 guidelines.

Solution:
Changed product name references in all documentation per guidelines
using templates when available.