### PR TITLE
Upgrade client-go to v3.0.0 release

### DIFF
--- a/.f5license
+++ b/.f5license
@@ -26,7 +26,7 @@
 
 # The client-go module contains a proper LICENSE file.
 - name: client-go
-  version: v3.0.0-beta.0
+  version: v3.0.0
   attribution_text: |
     Copyright 2014 The Kubernetes Authors.
 
@@ -44,7 +44,7 @@
 
 # The apimachinery module contains a proper LICENSE file.
 - name: apimachinery
-  version: 75b8dd2
+  version: 85ace53
   attribution_text: |
     Copyright 2014 The Kubernetes Authors.
 
@@ -80,7 +80,7 @@
 
 # The docker/distribution project has a large number of authors.
 - name: docker/distribution
-  version: v2.4.0-rc.1-38-gcd27f17
+  version: v2.4.0-rc.1-38-gcd27f179
   license: Apache-2.0
   author:
     name: Contributing authors
@@ -170,7 +170,7 @@
 
 # The gogo/protobuf module contains a proper LICENSE file.
 - name: gogo/protobuf
-  version: v0.2-33-ge18d7aa
+  version: v0.2-33-ge18d7aa8
   attribution_text: |
     Extensions for Protocol Buffers to create more go like structures.
 

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -29,12 +29,12 @@
 		},
 		{
 			"ImportPath": "github.com/docker/distribution/digest",
-			"Comment": "v2.4.0-rc.1-38-gcd27f17",
+			"Comment": "v2.4.0-rc.1-38-gcd27f179",
 			"Rev": "cd27f179f2c10c5d300e6d09025b538c475b0d51"
 		},
 		{
 			"ImportPath": "github.com/docker/distribution/reference",
-			"Comment": "v2.4.0-rc.1-38-gcd27f17",
+			"Comment": "v2.4.0-rc.1-38-gcd27f179",
 			"Rev": "cd27f179f2c10c5d300e6d09025b538c475b0d51"
 		},
 		{
@@ -74,12 +74,12 @@
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/proto",
-			"Comment": "v0.2-33-ge18d7aa",
+			"Comment": "v0.2-33-ge18d7aa8",
 			"Rev": "e18d7aa8f8c624c915db340349aad4c49b10d173"
 		},
 		{
 			"ImportPath": "github.com/gogo/protobuf/sortkeys",
-			"Comment": "v0.2-33-ge18d7aa",
+			"Comment": "v0.2-33-ge18d7aa8",
 			"Rev": "e18d7aa8f8c624c915db340349aad4c49b10d173"
 		},
 		{
@@ -228,696 +228,696 @@
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/errors",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/meta",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/resource",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apimachinery",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apimachinery/announced",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apimachinery/registered",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/conversion/queryparams",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/fields",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/labels",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/openapi",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/schema",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/json",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/protobuf",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/recognizer",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/streaming",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/runtime/serializer/versioning",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/selection",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/types",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/diff",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/errors",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/framer",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/intstr",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/json",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/mergepatch",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/net",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/rand",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/runtime",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/sets",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/strategicpatch",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/validation/field",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/wait",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/util/yaml",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/version",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/watch",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/json",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/third_party/forked/golang/reflect",
-			"Rev": "75b8dd260ef0469d96d578705a87cffd0e09dab8"
+			"Rev": "85ace5365f33b16fc735c866a12e3c765b9700f2"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/discovery/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/scheme",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/apps/v1beta1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authentication/v1beta1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/authorization/v1beta1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v2alpha1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/autoscaling/v2alpha1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v2alpha1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/batch/v2alpha1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/certificates/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/certificates/v1beta1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/core/v1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/core/v1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/extensions/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/extensions/v1beta1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/policy/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/policy/v1beta1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1alpha1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1alpha1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/rbac/v1beta1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/settings/v1alpha1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/settings/v1alpha1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/kubernetes/typed/storage/v1beta1/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/api",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/api/install",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/api/v1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/apps",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/apps/install",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/apps/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authentication",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authentication/install",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authentication/v1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authentication/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authorization",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authorization/install",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authorization/v1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/authorization/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling/install",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling/v1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/autoscaling/v2alpha1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/batch",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/batch/install",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/batch/v1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/batch/v2alpha1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/certificates",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/certificates/install",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/certificates/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/extensions",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/extensions/install",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/extensions/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/policy",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/policy/install",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/policy/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/rbac",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/rbac/install",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/rbac/v1alpha1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/rbac/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/settings",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/settings/install",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/settings/v1alpha1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/storage",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/storage/install",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/storage/v1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/apis/storage/v1beta1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/util",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/util/parsers",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/pkg/version",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest/fake",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/rest/watch",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/testing",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/auth",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/cache",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/latest",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/clientcmd/api/v1",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/metrics",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/tools/record",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/transport",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/cert",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/clock",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/flowcontrol",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/homedir",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/integer",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		},
 		{
 			"ImportPath": "k8s.io/client-go/util/workqueue",
-			"Comment": "v3.0.0-beta.0",
-			"Rev": "3627aeb7d4f6ade38f995d2c923e459146493c7e"
+			"Comment": "v3.0.0",
+			"Rev": "21300e3e11c918b8e6a70fb7293b310683d6c046"
 		}
 	]
 }

--- a/vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
+++ b/vendor/k8s.io/apimachinery/pkg/util/strategicpatch/patch.go
@@ -476,6 +476,7 @@ func StrategicMergePatch(original, patch []byte, dataStruct interface{}) ([]byte
 // StrategicMergePatch applies a strategic merge patch. The original and patch documents
 // must be JSONMap. A patch can be created from an original and modified document by
 // calling CreateTwoWayMergeMapPatch.
+// Warning: the original and patch JSONMap objects are mutated by this function and should not be reused.
 func StrategicMergeMapPatch(original, patch JSONMap, dataStruct interface{}) (JSONMap, error) {
 	t, err := getTagStructType(dataStruct)
 	if err != nil {

--- a/vendor/k8s.io/client-go/pkg/api/helpers.go
+++ b/vendor/k8s.io/client-go/pkg/api/helpers.go
@@ -246,6 +246,7 @@ func IsServiceIPRequested(service *Service) bool {
 var standardFinalizers = sets.NewString(
 	string(FinalizerKubernetes),
 	metav1.FinalizerOrphanDependents,
+	metav1.FinalizerDeleteDependents,
 )
 
 // HasAnnotation returns a bool if passed in annotation exists

--- a/vendor/k8s.io/client-go/pkg/api/v1/helpers.go
+++ b/vendor/k8s.io/client-go/pkg/api/v1/helpers.go
@@ -276,10 +276,10 @@ const (
 	AffinityAnnotationKey string = "scheduler.alpha.kubernetes.io/affinity"
 )
 
-// Tries to add a toleration to annotations list. Returns true if something was updated
-// false otherwise.
-func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) {
-	podTolerations := pod.Spec.Tolerations
+// AddOrUpdateTolerationInPodSpec tries to add a toleration to the toleration list in PodSpec.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPodSpec(spec *PodSpec, toleration *Toleration) (bool, error) {
+	podTolerations := spec.Tolerations
 
 	var newTolerations []Toleration
 	updated := false
@@ -300,8 +300,14 @@ func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) 
 		newTolerations = append(newTolerations, *toleration)
 	}
 
-	pod.Spec.Tolerations = newTolerations
+	spec.Tolerations = newTolerations
 	return true, nil
+}
+
+// AddOrUpdateTolerationInPod tries to add a toleration to the pod's toleration list.
+// Returns true if something was updated, false otherwise.
+func AddOrUpdateTolerationInPod(pod *Pod, toleration *Toleration) (bool, error) {
+	return AddOrUpdateTolerationInPodSpec(&pod.Spec, toleration)
 }
 
 // MatchToleration checks if the toleration matches tolerationToMatch. Tolerations are unique by <key,effect,operator,value>,

--- a/vendor/k8s.io/client-go/pkg/apis/batch/types.go
+++ b/vendor/k8s.io/client-go/pkg/apis/batch/types.go
@@ -233,6 +233,7 @@ type CronJobSpec struct {
 	StartingDeadlineSeconds *int64
 
 	// ConcurrencyPolicy specifies how to treat concurrent executions of a Job.
+	// Defaults to Allow.
 	// +optional
 	ConcurrencyPolicy ConcurrencyPolicy
 

--- a/vendor/k8s.io/client-go/pkg/apis/batch/v2alpha1/generated.proto
+++ b/vendor/k8s.io/client-go/pkg/apis/batch/v2alpha1/generated.proto
@@ -72,6 +72,7 @@ message CronJobSpec {
   optional int64 startingDeadlineSeconds = 2;
 
   // ConcurrencyPolicy specifies how to treat concurrent executions of a Job.
+  // Defaults to Allow.
   // +optional
   optional string concurrencyPolicy = 3;
 

--- a/vendor/k8s.io/client-go/pkg/apis/batch/v2alpha1/types.go
+++ b/vendor/k8s.io/client-go/pkg/apis/batch/v2alpha1/types.go
@@ -94,6 +94,7 @@ type CronJobSpec struct {
 	StartingDeadlineSeconds *int64 `json:"startingDeadlineSeconds,omitempty" protobuf:"varint,2,opt,name=startingDeadlineSeconds"`
 
 	// ConcurrencyPolicy specifies how to treat concurrent executions of a Job.
+	// Defaults to Allow.
 	// +optional
 	ConcurrencyPolicy ConcurrencyPolicy `json:"concurrencyPolicy,omitempty" protobuf:"bytes,3,opt,name=concurrencyPolicy,casttype=ConcurrencyPolicy"`
 

--- a/vendor/k8s.io/client-go/pkg/apis/batch/v2alpha1/types_swagger_doc_generated.go
+++ b/vendor/k8s.io/client-go/pkg/apis/batch/v2alpha1/types_swagger_doc_generated.go
@@ -52,7 +52,7 @@ var map_CronJobSpec = map[string]string{
 	"":                           "CronJobSpec describes how the job execution will look like and when it will actually run.",
 	"schedule":                   "Schedule contains the schedule in Cron format, see https://en.wikipedia.org/wiki/Cron.",
 	"startingDeadlineSeconds":    "Optional deadline in seconds for starting the job if it misses scheduled time for any reason.  Missed jobs executions will be counted as failed ones.",
-	"concurrencyPolicy":          "ConcurrencyPolicy specifies how to treat concurrent executions of a Job.",
+	"concurrencyPolicy":          "ConcurrencyPolicy specifies how to treat concurrent executions of a Job. Defaults to Allow.",
 	"suspend":                    "Suspend flag tells the controller to suspend subsequent executions, it does not apply to already started executions.  Defaults to false.",
 	"jobTemplate":                "JobTemplate is the object that describes the job that will be created when executing a CronJob.",
 	"successfulJobsHistoryLimit": "The number of successful finished jobs to retain. This is a pointer to distinguish between explicit zero and not specified.",

--- a/vendor/k8s.io/client-go/pkg/version/base.go
+++ b/vendor/k8s.io/client-go/pkg/version/base.go
@@ -51,7 +51,7 @@ var (
 	// semantic version is a git hash, but the version itself is no
 	// longer the direct output of "git describe", but a slight
 	// translation to be semver compliant.
-	gitVersion   string = "v1.6.1-beta.0+$Format:%h$"
+	gitVersion   string = "v1.6.8-beta.0+$Format:%h$"
 	gitCommit    string = "$Format:%H$"    // sha1 from git, output of $(git rev-parse HEAD)
 	gitTreeState string = "not a git tree" // state of git tree, either "clean" or "dirty"
 

--- a/vendor/k8s.io/client-go/tools/clientcmd/client_config.go
+++ b/vendor/k8s.io/client-go/tools/clientcmd/client_config.go
@@ -482,13 +482,13 @@ func (config *inClusterClientConfig) Namespace() (string, bool, error) {
 	// This way assumes you've set the POD_NAMESPACE environment variable using the downward API.
 	// This check has to be done first for backwards compatibility with the way InClusterConfig was originally set up
 	if ns := os.Getenv("POD_NAMESPACE"); ns != "" {
-		return ns, true, nil
+		return ns, false, nil
 	}
 
 	// Fall back to the namespace associated with the service account token, if available
 	if data, err := ioutil.ReadFile("/var/run/secrets/kubernetes.io/serviceaccount/namespace"); err == nil {
 		if ns := strings.TrimSpace(string(data)); len(ns) > 0 {
-			return ns, true, nil
+			return ns, false, nil
 		}
 	}
 

--- a/vendor/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
+++ b/vendor/k8s.io/client-go/tools/clientcmd/merged_client_builder.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/golang/glog"
 
+	"k8s.io/client-go/pkg/api"
 	restclient "k8s.io/client-go/rest"
 	clientcmdapi "k8s.io/client-go/tools/clientcmd/api"
 )
@@ -134,12 +135,26 @@ func (config *DeferredLoadingClientConfig) Namespace() (string, bool, error) {
 		return "", false, err
 	}
 
-	ns, ok, err := mergedKubeConfig.Namespace()
+	ns, overridden, err := mergedKubeConfig.Namespace()
 	// if we get an error and it is not empty config, or if the merged config defined an explicit namespace, or
 	// if in-cluster config is not possible, return immediately
-	if (err != nil && !IsEmptyConfig(err)) || ok || !config.icc.Possible() {
+	if (err != nil && !IsEmptyConfig(err)) || overridden || !config.icc.Possible() {
 		// return on any error except empty config
-		return ns, ok, err
+		return ns, overridden, err
+	}
+
+	if len(ns) > 0 {
+		// if we got a non-default namespace from the kubeconfig, use it
+		if ns != api.NamespaceDefault {
+			return ns, false, nil
+		}
+
+		// if we got a default namespace, determine whether it was explicit or implicit
+		if raw, err := mergedKubeConfig.RawConfig(); err == nil {
+			if context := raw.Contexts[raw.CurrentContext]; context != nil && len(context.Namespace) > 0 {
+				return ns, false, nil
+			}
+		}
 	}
 
 	glog.V(4).Infof("Using in-cluster namespace")


### PR DESCRIPTION
Problem:
Upgrade the client-go package to the latest release version.

Solution:
The client-go package version used previously was required for the
shared informer functionality, but was a pre-release version. The
release version is now available, and is required to support the
upcoming OpenShift changes we are making.

affects-branches: master