### PR TITLE
Move Dockerfile common steps towards end of file

### DIFF
--- a/build-tools/Dockerfile.runtime
+++ b/build-tools/Dockerfile.runtime
@@ -8,14 +8,15 @@ RUN mkdir -p "$APPPATH/bin" \
  
 WORKDIR $APPPATH
 
-COPY k8s-bigip-ctlr $APPPATH/bin
-COPY python/ $APPPATH/python
-COPY bigip-virtual-server_v*.json $APPPATH/vendor/src/f5/schemas/
 COPY k8s-runtime-requirements.txt /tmp/k8s-runtime-requirements.txt
 
 RUN apk --no-cache --update add --virtual pip-install-deps git && \
     pip install -r /tmp/k8s-runtime-requirements.txt && \
     apk del pip-install-deps
+
+COPY k8s-bigip-ctlr $APPPATH/bin
+COPY python/ $APPPATH/python
+COPY bigip-virtual-server_v*.json $APPPATH/vendor/src/f5/schemas/
 
 USER ctlr
 


### PR DESCRIPTION
Problem: Dockerfile steps that would change most often were being called
in the middle of the Docker build process, before dependency installation.
This caused dependencies to be installed every time a change in our code happened.

Solution: Take advantage of Docker caching and install dependencies first, before
any copying of files.