### PR TITLE
Integrate Kubernetes BIG-IP Controller to use CCCL and CCCL Schema

### DIFF
--- a/python/bigipconfigdriver.py
+++ b/python/bigipconfigdriver.py
@@ -33,10 +33,9 @@ import urllib
 import pyinotify
 
 from urlparse import urlparse
-from f5_cccl._f5 import CloudBigIP, get_protocol, has_partition, log_sequence
-from f5_cccl.common import extract_partition_and_name, ipv4_to_mac,\
-    list_diff_exclusive, IPV4FormatError, PartitionNameError
 from f5.bigip import ManagementRoot
+from f5_cccl.api import F5CloudServiceManager
+from f5_cccl.exceptions import F5CcclError
 
 log = logging.getLogger(__name__)
 console = logging.StreamHandler()
@@ -44,6 +43,24 @@ console.setFormatter(
     logging.Formatter("[%(asctime)s %(name)s %(levelname)s] %(message)s"))
 root_logger = logging.getLogger()
 root_logger.addHandler(console)
+
+SCHEMA_PATH = "./src/f5-cccl/f5_cccl/schemas/cccl-api-schema.yml"
+
+
+class PartitionNameError(Exception):
+    """Exception type for F5 resource name."""
+
+    def __init__(self, msg):
+        """Create partition name exception object."""
+        Exception.__init__(self, msg)
+
+
+class IPV4FormatError(Exception):
+    """Exception type for improperly formatted IPv4 address."""
+
+    def __init__(self, msg):
+        """Create ipv4 format exception object."""
+        Exception.__init__(self, msg)
 
 
 class ResponseStatusFilter(logging.Filter):
@@ -65,12 +82,72 @@ root_logger.addFilter(ResponseStatusFilter())
 root_logger.addFilter(CertFilter())
 root_logger.addFilter(KeyFilter())
 
+
+def list_diff_exclusive(list1, list2):
+    """Return items found only in list1 or list2."""
+    return list(set(list1) ^ set(list2))
+
+
+def ipv4_to_mac(ip_str):
+    """Convert an IPV4 string to a fake MAC address."""
+    ip = ip_str.split('.')
+    if len(ip) != 4:
+        raise IPV4FormatError('Bad IPv4 address format specified for '
+                              'FDB record: {}'.format(ip_str))
+
+    return "0a:0a:%02x:%02x:%02x:%02x" % (
+        int(ip[0]), int(ip[1]), int(ip[2]), int(ip[3]))
+
+
+def extract_partition_and_name(f5_partition_name):
+    """Separate partition and name components for a Big-IP resource."""
+    parts = f5_partition_name.split('/')
+    count = len(parts)
+    if f5_partition_name[0] == '/' and count == 3:
+        # leading slash
+        partition = parts[1]
+        name = parts[2]
+    elif f5_partition_name[0] != '/' and count == 2:
+        # leading slash missing
+        partition = parts[0]
+        name = parts[1]
+    else:
+        raise PartitionNameError('Bad F5 resource name encountered: '
+                                 '{}'.format(f5_partition_name))
+    return partition, name
+
+
+def log_sequence(prefix, sequence_to_log):
+    """Helper function to log a sequence.
+
+    Dump a sequence to the logger, skip if it is empty
+
+    Args:
+        prefix: The prefix string to describe what's being logged
+        sequence_to_log: The sequence being logged
+    """
+    if sequence_to_log:
+        log.debug(prefix + ': %s', (', '.join(sequence_to_log)))
+
+
+def get_protocol(protocol):
+    """Return the protocol (tcp or udp)."""
+    if str(protocol).lower() == 'tcp':
+        return 'tcp'
+    if str(protocol).lower() == 'http':
+        return 'tcp'
+    if str(protocol).lower() == 'udp':
+        return 'udp'
+    else:
+        return None
+
+
 DEFAULT_LOG_LEVEL = logging.INFO
 DEFAULT_VERIFY_INTERVAL = 30.0
 
 
-class K8sCloudBigIP(CloudBigIP):
-    """K8sCloudBigIP class.
+class K8sCloudServiceManager():
+    """K8sCloudServiceManager class.
 
     Generates a configuration for a BigIP based upon the apps/tasks managed
     by services/pods/nodes in Kubernetes.
@@ -80,26 +157,32 @@ class K8sCloudBigIP(CloudBigIP):
       BigIP partition
     - For each backend (task, node, or pod), it creates a pool member and adds
       the member to the pool
-    - If the app has a Marathon Health Monitor configured, create a
-      corresponding health monitor for the BigIP pool member
     - Token-based authentication is used by specifying a token named 'tmos'.
       This will allow non-admin users to use the API (BIG-IP must configure
       the accounts with proper permissions, for either local or remote auth).
 
     Args:
-        hostname: IP address of BIG-IP
-        username: BIG-IP username
-        password: BIG-IP password
-        partitions: List of BIG-IP partitions to manage
+        bigip: ManagementRoot object
+        partition: BIG-IP partition to manage
+        schema_path: Path to the CCCL schema
     """
 
-    def __init__(self, hostname, port, username, password, partitions,
-                 manage_types):
-        """Initialize the K8sCloudBigIP object."""
-        super(K8sCloudBigIP, self).__init__(hostname, port, username,
-                                            password, partitions,
-                                            token="tmos",
-                                            manage_types=manage_types)
+    def __init__(self, bigip, partition, schema_path):
+        """Initialize the K8sCloudServiceManager object."""
+        self._mgmt_root = bigip
+        self._cccl = F5CloudServiceManager(
+            bigip,
+            partition,
+            prefix="",
+            schema_path=schema_path)
+
+    def mgmt_root(self):
+        """ Return the BIG-IP ManagementRoot object"""
+        return self._mgmt_root
+
+    def get_partition(self):
+        """ Return the managed partition."""
+        return self._cccl.get_partition()
 
     def _apply_config(self, config):
         """Apply the configuration to the BIG-IP.
@@ -107,10 +190,13 @@ class K8sCloudBigIP(CloudBigIP):
         Args:
             config: BIG-IP config dict
         """
+        incomplete = 0
         if 'ltm' in config:
-            CloudBigIP._apply_config(self, config['ltm'])
+            incomplete = self._cccl.apply_config(config['ltm'])
         if 'network' in config:
-            self._apply_network_config(config['network'])
+            incomplete += self._apply_network_config(config['network'])
+
+        return incomplete
 
     def _apply_network_config(self, config):
         """Apply the network configuration to the BIG-IP.
@@ -119,7 +205,9 @@ class K8sCloudBigIP(CloudBigIP):
             config: BIG-IP network config dict
         """
         if 'fdb' in config:
-            self._apply_network_fdb_config(config['fdb'])
+            return self._apply_network_fdb_config(config['fdb'])
+
+        return 0
 
     def _apply_network_fdb_config(self, fdb_config):
         """Apply the network fdb configuration to the BIG-IP.
@@ -141,12 +229,14 @@ class K8sCloudBigIP(CloudBigIP):
                                    req_fdb_record_endpoint_list):
                 self.fdb_records_update(req_vxlan_name,
                                         req_fdb_record_endpoint_list)
+            return 0
         except (PartitionNameError, IPV4FormatError) as e:
             log.error(e)
-            return
+            return 0
         except Exception as e:
             log.error('Failed to configure the FDB for VxLAN tunnel '
                       '{}: {}'.format(req_vxlan_name, e))
+            return 1
 
     def get_vxlan_tunnel(self, vxlan_name):
         """Get a vxlan tunnel object.
@@ -155,7 +245,7 @@ class K8sCloudBigIP(CloudBigIP):
             vxlan_name: Name of the vxlan tunnel
         """
         partition, name = extract_partition_and_name(vxlan_name)
-        vxlan_tunnel = self.net.fdb.tunnels.tunnel.load(
+        vxlan_tunnel = self._mgmt_root.tm.net.fdb.tunnels.tunnel.load(
             partition=partition, name=urllib.quote(name))
         return vxlan_tunnel
 
@@ -267,7 +357,7 @@ class ConfigError(Exception):
         Exception.__init__(self, msg)
 
 
-def create_config_kubernetes(bigip, config):
+def create_config_kubernetes(partition, config):
     """Create a BIG-IP configuration from the Kubernetes configuration.
 
     Args:
@@ -278,7 +368,8 @@ def create_config_kubernetes(bigip, config):
     if 'openshift-sdn' in config:
         f5['network'] = create_network_config_kubernetes(config)
     if 'resources' in config and 'virtualServers' in config['resources']:
-        f5['ltm'] = create_ltm_config_kubernetes(bigip, config['resources'])
+        f5['ltm'] = create_ltm_config_kubernetes(partition,
+                                                 config['resources'])
 
     return f5
 
@@ -306,34 +397,128 @@ def append_ssl_profile(profiles, profName):
                          'name': profile[1]})
 
 
-def create_ltm_config_kubernetes(bigip, config):
+def iapp_build_definition(config, members):
+    """Create a dict that defines the 'variables' and 'tables' for an iApp.
+
+    Args:
+        config: BIG-IP config dict
+    """
+    # Build variable list
+    variables = []
+    for key, value in config['variables'].items():
+        var = {'name': key, 'value': value}
+        variables.append(var)
+
+    # The schema says only one of poolMemberTable or tableName is
+    # valid, so if the user set both it should have already been rejected.
+    # But if not, prefer the new poolMemberTable over tableName.
+    tables = []
+    if 'poolMemberTable' in config:
+        tableConfig = config['poolMemberTable']
+
+        # Construct columnNames array from the 'name' prop of each column
+        columnNames = []
+        for col in tableConfig['columns']:
+            columnNames.append(col['name'])
+
+        # Construct rows array - one row for each node, interpret the
+        # 'kind' or 'value' from the column spec.
+        rows = []
+        for node in members:
+            row = []
+            for i, col in enumerate(tableConfig['columns']):
+                if 'value' in col:
+                    row.append(col['value'])
+                elif 'kind' in col:
+                    if col['kind'] == 'IPAddress':
+                        row.append(str(node['address']))
+                    elif col['kind'] == 'Port':
+                        row.append(str(node['port']))
+                    else:
+                        raise ValueError('Unknown kind "%s"' % col['kind'])
+                else:
+                    raise ValueError('Column %d has neither value nor kind'
+                                     % i)
+            rows.append({'row': row})
+
+        # Done - add the generated pool member table to the set of tables
+        # we're going to configure.
+        tables.append({
+            'name': tableConfig['name'],
+            'columnNames': columnNames,
+            'rows': rows
+        })
+    elif 'tableName' in config:
+        # Before adding the flexible poolMemberTable mode, we only
+        # supported three fixed columns in order, and connection_limit was
+        # hardcoded to 0 ("no limit")
+        rows = []
+        for node in members:
+            rows.append({'row': [str(node['address']),
+                                 str(node['port']), '0']})
+        tables.append({
+            'name': config['tableName'],
+            'columnNames': ['addr', 'port', 'connection_limit'],
+            'rows': rows
+        })
+
+    # Add other tables
+    for key in config['tables']:
+        data = config['tables'][key]
+        table = {'columnNames': data['columns'],
+                 'name': key,
+                 'rows': []}
+        for row in data['rows']:
+            table['rows'].append({'row': row})
+        tables.append(table)
+
+    return {'variables': variables, 'tables': tables}
+
+
+def create_ltm_config_kubernetes(partition, config):
     """Create a BIG-IP LTM configuration from the Kubernetes configuration.
 
     Args:
         config: Kubernetes BigIP config which contains a svc list
     """
-    configuration = {}
-    configuration['l7Policies'] = config.get('l7Policies', [])
-    configuration['monitors'] = config.get('monitors', [])
-    configuration['pools'] = []
+    # FIXME (darzins): Move all conversion for CCCL schema to the golang
+    # frontend so that we're doing conversion in one step, not two
+    configuration = {
+        'virtualServers': [],
+        'l7Policies': [],
+        'pools': [],
+        'monitors': [],
+        'iapps': []
+    }
 
-    f5_pools = config.get('pools', [])
     f5_services = {}
 
-    # partitions this script is responsible for:
-    partitions = frozenset(bigip.get_partitions())
+    # reformat policies
+    for policy in config.get('l7Policies', []):
+        if policy.get('partition', None) == partition:
+            del policy['partition']
+            configuration['l7Policies'].append(policy)
+
+    # reformat monitors
+    for monitor in config.get('monitors', []):
+        if monitor.get('partition', None) == partition:
+            if 'protocol' in monitor:
+                monitor['type'] = monitor['protocol']
+                del monitor['protocol']
+            del monitor['partition']
+
+            configuration['monitors'].append(monitor)
 
     svcs = config['virtualServers']
     for svc in svcs:
         vs_partition = svc['partition']
         # Only handle application if it's partition is one that this script
         # is responsible for
-        if not has_partition(partitions, vs_partition):
+        if partition != vs_partition:
             continue
 
         f5_service = {}
         vs_name = svc['name']
-        f5_service['balance'] = svc.get('balance', '')
 
         policies = svc.get('policies', [])
         profiles = svc.get('profiles', [])
@@ -350,19 +535,46 @@ def create_ltm_config_kubernetes(bigip, config):
             continue
 
         f5_service['name'] = vs_name
-        f5_service['partition'] = vs_partition
 
         if 'iapp' in svc:
-            f5_service['iapp'] = {'template': svc['iapp'],
-                                  'poolMemberTable':
-                                  svc['iappPoolMemberTable'],
-                                  'variables': svc['iappVariables'],
-                                  'options': svc['iappOptions']}
-            f5_service['iapp']['tables'] = svc.get('iappTables', {})
+            cfg = {'tables': []}
+            for k, v in {'template': 'iapp',
+                         'poolMemberTable': 'iappPoolMemberTable',
+                         'tables': 'iappTables',
+                         'variables': 'iappVariables',
+                         'options': 'iappOptions'}.iteritems():
+                if v in svc:
+                    cfg[k] = svc[v]
+
+            try:
+                members = []
+                for pool in config.get('pools', []):
+                    if pool['name'] == f5_service['name']:
+                        if 'poolMemberAddrs' in pool:
+                            for member in pool['poolMemberAddrs']:
+                                members.append({
+                                    'address': member.split(':')[0],
+                                    'port': int(member.split(':')[1]),
+                                    'session': 'user-enabled'
+                                })
+
+                # format the variables and tables per the schema
+                iapp_def = iapp_build_definition(cfg, members)
+            except ValueError as e:
+                log.error("Invalid pool-member table data: %s", e)
+                continue
+
+            iapp = {
+                'name': f5_service['name'],
+                'template': cfg['template'],
+                'variables': iapp_def['variables'],
+                'tables': iapp_def['tables'],
+                'options': cfg['options']
+            }
+
+            configuration['iapps'].append(iapp)
         else:
-            f5_service['virtual'] = {}
             f5_service['pool'] = {}
-            f5_service['health'] = []
 
             # Parse the SSL profile into partition and name
             if 'sslProfile' in svc:
@@ -401,9 +613,8 @@ def create_ltm_config_kubernetes(bigip, config):
                     destination = ("/%s/%s:%d" %
                                    (vs_partition, addr, port))
 
-                f5_service['virtual'].update({
+                f5_service.update({
                     'enabled': True,
-                    'disabled': False,
                     'ipProtocol': get_protocol(svc['mode']),
                     'destination': destination,
                     'pool': "%s" % (svc['pool']),
@@ -411,21 +622,21 @@ def create_ltm_config_kubernetes(bigip, config):
                     'profiles': profiles,
                     'policies': policies
                 })
-        f5_services.update({vs_name: f5_service})
-    configuration['virtualServers'] = f5_services
+            f5_services.update({vs_name: f5_service})
+
+            if f5_service.get('destination', None) is not None:
+                configuration['virtualServers'].append(f5_service)
 
     # FIXME(garyr): CCCL presently expects pools slightly differently than
     # we get from the controller, so convert to the expected format here.
-    for pool in f5_pools:
+    for pool in config.get('pools', []):
         found_svc = False
         new_pool = {}
-        members = {}
+        members = []
         pname = pool['name']
         new_pool['name'] = pname
-        monitors = None
         if 'monitor' in pool and pool['monitor']:
-            monitors = ' and '.join(pool['monitor'])
-        new_pool['monitor'] = monitors
+            new_pool['monitors'] = pool['monitor']
 
         balance = None
         vname = pname.rsplit('_', 1)[0]
@@ -435,35 +646,56 @@ def create_ltm_config_kubernetes(bigip, config):
         elif vname in f5_services:
             if 'balance' in f5_services[vname]:
                 balance = f5_services[vname]['balance']
-        new_pool['loadBalancingMode'] = balance
-        new_pool['partition'] = pool['partition']
+
+        if balance is not None:
+            new_pool['loadBalancingMode'] = balance
+
         if pool['name'] in f5_services or vname in f5_services:
-            if pool['poolMemberAddrs'] is not None:
+            if pool.get('poolMemberAddrs', None) is not None:
                 found_svc = True
                 for member in pool['poolMemberAddrs']:
-                    members.update({member: {
-                        'state': 'user-up',
+                    members.append({
+                        'address': member.split(':')[0],
+                        'port': int(member.split(':')[1]),
                         'session': 'user-enabled'
-                    }})
-            new_pool['members'] = members
-        configuration['pools'].append(new_pool)
+                    })
+                new_pool['members'] = members
+            configuration['pools'].append(new_pool)
+
         if not found_svc:
             log.info(
                 'Pool "{}" has service "{}", which is empty - '
                 'configuring 0 pool members.'.format(
                     pname, pool['serviceName']))
 
+    # Append the protocol to the monitor names to differentiate them.
+    # Also add a monitor index to the name to be consistent with the
+    # marathon-bigip-ctlr. Since the monitor names are already unique here,
+    # appending a '0' is sufficient.
+    for monitor in configuration.get('monitors', []):
+        old_name = monitor['name']
+        old_path = '/' + partition + '/' + old_name
+        suffix = '_0_' + monitor['type']
+        monitor['name'] += suffix
+
+        for pool in configuration.get('pools', []):
+            if 'monitors' in pool:
+                pool['monitors'] = [mon + suffix if mon == old_path else mon
+                                    for mon in pool['monitors']]
+
+    log.debug("Service Config: %s", json.dumps(configuration))
     return configuration
 
 
-def _create_client_ssl_profile(bigip, profile):
+def _create_client_ssl_profile(mgmt, profile):
+    incomplete = 0
+
     # bigip object is of type f5.bigip.tm;
     # we need f5.bigip.shared for the uploader
-    mgmt = ManagementRoot(bigip.hostname, bigip._username, bigip._password)
     uploader = mgmt.shared.file_transfer.uploads
-    cert_registrar = bigip.sys.crypto.certs
-    key_registrar = bigip.sys.crypto.keys
-    ssl_client_profile = bigip.ltm.profile.client_ssls.client_ssl
+    cert_registrar = mgmt.tm.sys.crypto.certs
+    key_registrar = mgmt.tm.sys.crypto.keys
+    ssl_client_profile = mgmt.tm.ltm.profile.client_ssls.client_ssl
 
     name = profile['name']
     partition = profile['partition']
@@ -507,32 +739,50 @@ def _create_client_ssl_profile(bigip, profile):
                                   defaultsFrom=None)
     except Exception as err:
         log.error("Error creating SSL profile: %s" % err.message)
+        incomplete = 1
+
+    return incomplete
 
 
-def _delete_client_ssl_profiles(bigip, config):
+def _delete_client_ssl_profiles(mgmt, partition, config):
+    incomplete = 0
+
+    try:
+        profiles = mgmt.tm.ltm.profile.client_ssls.get_collection(
+            requests_params={'params': '$filter=partition+eq+%s'
+                             % partition})
+    except Exception as err:
+        log.error("Error reading profiles from BIG-IP: %s" % err.message)
+        incomplete += 1
+        return incomplete
+
     if 'customProfiles' not in config:
-        # delete any profiles in managed partitions
-        for partition in bigip._partitions:
-            for prof in bigip.ltm.profile.client_ssls.get_collection(
-                requests_params={'params': '$filter=partition+eq+%s'
-                                 % partition}):
+        # delete any profiles in managed partition
+        for prof in profiles:
+            try:
                 prof.delete()
+            except Exception as err:
+                log.error("Error deleting SSL profile: %s" % err.message)
+                incomplete += 1
     else:
         # delete profiles no longer in our config
-        for partition in bigip._partitions:
-            for prof in bigip.ltm.profile.client_ssls.get_collection(
-                requests_params={'params': '$filter=partition+eq+%s'
-                                 % partition}):
-                if not any(d['name'] == prof.name and
-                           d['partition'] == partition
-                           for d in config['customProfiles']):
+        for prof in profiles:
+            if not any(d['name'] == prof.name and
+                       d['partition'] == partition
+                       for d in config['customProfiles']):
+                try:
                     prof.delete()
+                except Exception as err:
+                    log.error("Error deleting SSL profile: %s" % err.message)
+                    incomplete += 1
+
+    return incomplete
 
 
 class ConfigHandler():
-    def __init__(self, config_file, bigip, verify_interval):
+    def __init__(self, config_file, managers, verify_interval):
         self._config_file = config_file
-        self._bigip = bigip
+        self._managers = managers
 
         self._condition = threading.Condition()
         self._thread = threading.Thread(target=self._do_reset)
@@ -596,67 +846,87 @@ class ConfigHandler():
                         self.cleanup_backoff()
                     break
 
-                try:
-                    start_time = time.time()
+                start_time = time.time()
 
-                    config = _parse_config(self._config_file)
-                    if 'resources' not in config:
-                        continue
-                    verify_interval, _ = _handle_global_config(config)
-                    _handle_openshift_sdn_config(config)
-                    self.set_interval_timer(verify_interval)
+                config = _parse_config(self._config_file)
+                # No 'resources' indicates that the controller is not
+                # yet ready -- it does not mean to apply an empty config
+                if 'resources' not in config:
+                    continue
+                verify_interval, _ = _handle_global_config(config)
+                _handle_openshift_sdn_config(config)
+                self.set_interval_timer(verify_interval)
 
-                    # Manually create custom profiles;CCCL doesn't yet do this
-                    if 'customProfiles' in config['resources']:
-                        for profile in config['resources']['customProfiles']:
-                            _create_client_ssl_profile(self._bigip, profile)
-                            customProfiles = True
+                incomplete = 0
 
-                    cfg = create_config_kubernetes(self._bigip, config)
-                    if self._bigip.regenerate_config_f5(cfg):
-                        # Error occurred, perform retries
-                        log.warning(
-                            'regenerate operation failed, restarting')
-                        self.handle_backoff()
-                    else:
-                        if (self._interval and self._interval.is_running() is
-                                False):
-                            self._interval.start()
-                        self._backoff_time = 1
-                        if self._backoff_timer is not None:
-                            self.cleanup_backoff()
+                for mgr in self._managers:
+                    cfg = create_config_kubernetes(mgr.get_partition(),
+                                                   config)
+
+                    try:
+                        # Manually create custom profiles;
+                        # CCCL doesn't yet do this
+                        if 'customProfiles' in config['resources']:
+                            for profile in \
+                                    config['resources']['customProfiles']:
+                                if profile['partition'] == \
+                                        mgr.get_partition():
+                                    _create_client_ssl_profile(
+                                        mgr.mgmt_root(),
+                                        profile)
+                                    customProfiles = True
+
+                        # Apply the BIG-IP config after creating profiles
+                        # and before deleting profiles
+                        incomplete += mgr._apply_config(cfg)
 
                         # Manually delete custom profiles (if needed)
                         if customProfiles:
-                            _delete_client_ssl_profiles(self._bigip,
-                                                        config['resources'])
+                            _delete_client_ssl_profiles(
+                                mgr.mgmt_root(),
+                                mgr.get_partition(),
+                                config['resources'])
 
-                        perf_enable = os.environ.get('SCALE_PERF_ENABLE')
-                        if perf_enable:  # pragma: no cover
-                            test_data = {}
-                            app_count = 0
-                            backend_count = 0
-                            for service in config['resources'][
-                                    'virtualServers']:
-                                app_count += 1
-                                backends = 0
-                                for pool in config['resources']['pools']:
-                                    if pool['name'] == service['name']:
-                                        backends = len(pool['poolMemberAddrs'])
-                                        break
-                                test_data[service['name']] = backends
-                                backend_count += backends
-                            test_data['Total_Services'] = app_count
-                            test_data['Total_Backends'] = backend_count
-                            test_data['Time'] = time.time()
-                            json_data = json.dumps(test_data)
-                            log.info('SCALE_PERF: Test data: %s', json_data)
+                    except F5CcclError as e:
+                        # We created an invalid configuration, raise the
+                        # exception and fail
+                        log.error("CCCL Error: %s", e.msg)
+                        raise e
 
-                    log.debug('updating tasks finished, took %s seconds',
-                              time.time() - start_time)
-                except Exception:
-                    log.exception('Unexpected error')
+                if incomplete:
+                    # Error occurred, perform retries
                     self.handle_backoff()
+                else:
+                    if (self._interval and self._interval.is_running()
+                            is False):
+                        self._interval.start()
+                    self._backoff_time = 1
+                    if self._backoff_timer is not None:
+                        self.cleanup_backoff()
+
+                perf_enable = os.environ.get('SCALE_PERF_ENABLE')
+                if perf_enable:  # pragma: no cover
+                    test_data = {}
+                    app_count = 0
+                    backend_count = 0
+                    for service in config['resources']['virtualServers']:
+                        app_count += 1
+                        backends = 0
+                        for pool in config['resources']['pools']:
+                            if pool['name'] == service['name']:
+                                backends = len(pool['poolMemberAddrs'])
+                                break
+                        test_data[service['name']] = backends
+                        backend_count += backends
+                    test_data['Total_Services'] = app_count
+                    test_data['Total_Backends'] = backend_count
+                    test_data['Time'] = time.time()
+                    json_data = json.dumps(test_data)
+                    log.info('SCALE_PERF: Test data: %s',
+                             json_data)
+
+                log.debug('updating tasks finished, took %s seconds',
+                          time.time() - start_time)
 
         if self._interval:
             self._interval.stop()
@@ -692,13 +962,12 @@ class ConfigHandler():
 
 
 class ConfigWatcher(pyinotify.ProcessEvent):
-    def __init__(self, config_file, bigip, on_change):
+    def __init__(self, config_file, on_change):
         basename = os.path.basename(config_file)
         if not basename or 0 == len(basename):
             raise ConfigError('config_file must be a file path')
 
         self._config_file = config_file
-        self._bigip = bigip
         self._on_change = on_change
 
         self._config_dir = os.path.dirname(self._config_file)
@@ -960,23 +1229,32 @@ def main():
         # FIXME (kenr): Big-IP settings are currently static (we ignore any
         #               changes to these fields in subsequent updates). We
         #               may want to make the changes dynamic in the future.
-        bigip = K8sCloudBigIP(host, port,
-                              config['bigip']['username'],
-                              config['bigip']['password'],
-                              config['bigip']['partitions'],
-                              manage_types=[
-                                  '/tm/ltm/virtual',
-                                  '/tm/ltm/pool',
-                                  '/tm/ltm/monitor',
-                                  '/tm/sys/application/service',
-                                  '/tm/ltm/policy'])
 
-        handler = ConfigHandler(args.config_file, bigip, verify_interval)
+        # BIG-IP to manage
+        bigip = ManagementRoot(
+            host,
+            config['bigip']['username'],
+            config['bigip']['password'],
+            port=port,
+            token="tmos")
+
+        k8s_managers = []
+        for partition in config['bigip']['partitions']:
+            # Management for the BIG-IP partitions
+            manager = K8sCloudServiceManager(
+                bigip,
+                partition,
+                schema_path=SCHEMA_PATH)
+            k8s_managers.append(manager)
+
+        handler = ConfigHandler(args.config_file,
+                                k8s_managers,
+                                verify_interval)
 
         if os.path.exists(args.config_file):
             handler.notify_reset()
 
-        watcher = ConfigWatcher(args.config_file, bigip, handler.notify_reset)
+        watcher = ConfigWatcher(args.config_file, handler.notify_reset)
         watcher.loop()
         handler.stop()
     except (IOError, ValueError, ConfigError) as e:

--- a/python/k8s-build-requirements.txt
+++ b/python/k8s-build-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@b886a663fa168b01afd291c2457c7bf7bf34768d#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@8e46ce68011f9d015aa7f63781c9d97e05454b72#egg=f5-cccl
 pytest==3.0.2
 mock
 flake8

--- a/python/k8s-runtime-requirements.txt
+++ b/python/k8s-runtime-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@b886a663fa168b01afd291c2457c7bf7bf34768d#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@8e46ce68011f9d015aa7f63781c9d97e05454b72#egg=f5-cccl
 f5-icontrol-rest==1.3.0
 f5-sdk==2.2.2
 pyinotify==0.9.6

--- a/python/tests/kubernetes_invalid_svcs_expected.json
+++ b/python/tests/kubernetes_invalid_svcs_expected.json
@@ -1,0 +1,63 @@
+{
+    "ltm": {
+        "iapps": [],
+        "l7Policies": [],
+        "monitors": [],
+        "pools": [
+            {
+                "members": [
+                    {
+                        "address": "172.16.0.5",
+                        "port": 30008,
+                        "session": "user-enabled"
+                    }
+                ],
+                "name": "invalid_sslProfile0_configmap"
+            },
+            {
+                "members": [
+                    {
+                        "address": "172.16.0.6",
+                        "port": 30009,
+                        "session": "user-enabled"
+                    }
+                ],
+                "name": "invalid_sslProfile1_configmap"
+            }
+        ],
+        "virtualServers": [
+            {
+                "destination": "/k8s/10.128.10.240:5051",
+                "enabled": true,
+                "ipProtocol": "tcp",
+                "name": "invalid_sslProfile0_configmap",
+                "policies": [],
+                "pool": "invalid_sslProfile0_configmap",
+                "profiles": [
+                    {
+                        "name": "tcp",
+                        "partition": "Common"
+                    }
+                ],
+                "sourceAddressTranslation": {
+                    "type": "automap"
+                },
+                "virtual_address": "10.128.10.240"
+            },
+            {
+                "destination": "/k8s/10.128.10.241:5052",
+                "enabled": true,
+                "ipProtocol": "udp",
+                "name": "invalid_sslProfile1_configmap",
+                "policies": [],
+                "pool": "invalid_sslProfile1_configmap",
+                "profiles": [],
+                "sourceAddressTranslation": {
+                    "type": "automap"
+                },
+                "virtual_address": "10.128.10.241"
+            }
+        ]
+    },
+    "network": {}
+}

--- a/python/tests/kubernetes_no_apps_expected.json
+++ b/python/tests/kubernetes_no_apps_expected.json
@@ -1,0 +1,10 @@
+{
+    "ltm": {
+        "iapps": [],
+        "l7Policies": [],
+        "monitors": [],
+        "pools": [],
+        "virtualServers": []
+    },
+    "network": {}
+}

--- a/python/tests/kubernetes_one_iapp_expected.json
+++ b/python/tests/kubernetes_one_iapp_expected.json
@@ -1,0 +1,72 @@
+{
+    "ltm": {
+        "iapps": [
+            {
+                "name": "default_configmap",
+                "options": {
+                    "description": "This is a test iApp",
+                    "trafficGroup": "/Common/traffic-group-local-only"
+                },
+                "tables": [
+                    {
+                        "columnNames": [
+                            "addr",
+                            "port",
+                            "connection_limit"
+                        ],
+                        "name": "pool__members",
+                        "rows": [
+                            {
+                                "row": [
+                                    "172.16.0.5",
+                                    "30008",
+                                    "0"
+                                ]
+                            }
+                        ]
+                    }
+                ],
+                "template": "/Common/f5.http",
+                "variables": [
+                    {
+                        "name": "monitor__monitor",
+                        "value": "/#create_new#"
+                    },
+                    {
+                        "name": "net__client_mode",
+                        "value": "wan"
+                    },
+                    {
+                        "name": "pool__pool_to_use",
+                        "value": "/#create_new#"
+                    },
+                    {
+                        "name": "net__server_mode",
+                        "value": "lan"
+                    },
+                    {
+                        "name": "pool__addr",
+                        "value": "10.128.10.240"
+                    },
+                    {
+                        "name": "monitor__response",
+                        "value": "none"
+                    },
+                    {
+                        "name": "monitor__uri",
+                        "value": "/"
+                    },
+                    {
+                        "name": "pool__port",
+                        "value": "8080"
+                    }
+                ]
+            }
+        ],
+        "l7Policies": [],
+        "monitors": [],
+        "pools": [],
+        "virtualServers": []
+    },
+    "network": {}
+}

--- a/python/tests/kubernetes_one_svc_four_nodes_expected.json
+++ b/python/tests/kubernetes_one_svc_four_nodes_expected.json
@@ -1,0 +1,55 @@
+{
+    "ltm": {
+        "iapps": [],
+        "l7Policies": [],
+        "monitors": [],
+        "pools": [
+            {
+                "members": [
+                    {
+                        "address": "172.16.0.5",
+                        "port": 30008,
+                        "session": "user-enabled"
+                    },
+                    {
+                        "address": "172.16.0.6",
+                        "port": 30008,
+                        "session": "user-enabled"
+                    },
+                    {
+                        "address": "172.16.0.7",
+                        "port": 30008,
+                        "session": "user-enabled"
+                    },
+                    {
+                        "address": "172.16.0.8",
+                        "port": 30008,
+                        "session": "user-enabled"
+                    }
+                ],
+                "name": "default_configmap"
+            }
+        ],
+        "virtualServers": [
+            {
+                "destination": "/k8s/10.128.10.240:5051",
+                "enabled": true,
+                "ipProtocol": "tcp",
+                "name": "default_configmap",
+                "policies": [],
+                "pool": "/k8s/default_configmap",
+                "profiles": [
+                    {
+                        "name": "http",
+                        "partition": "Common"
+                    }
+                ],
+                "sourceAddressTranslation": {
+                    "type": "automap"
+                },
+                "virtual_address": "10.128.10.240"
+            }
+        ]
+    },
+    "network": {}
+}

--- a/python/tests/kubernetes_one_svc_one_node_expected.json
+++ b/python/tests/kubernetes_one_svc_one_node_expected.json
@@ -1,0 +1,40 @@
+{
+    "ltm": {
+        "iapps": [],
+        "l7Policies": [],
+        "monitors": [],
+        "pools": [
+            {
+                "members": [
+                    {
+                        "address": "172.16.0.5",
+                        "port": 30008,
+                        "session": "user-enabled"
+                    }
+                ],
+                "name": "default_configmap"
+            }
+        ],
+        "virtualServers": [
+            {
+                "destination": "/k8s/10.128.10.240:5051",
+                "enabled": true,
+                "ipProtocol": "tcp",
+                "name": "default_configmap",
+                "policies": [],
+                "pool": "/k8s/default_configmap",
+                "profiles": [
+                    {
+                        "name": "http",
+                        "partition": "Common"
+                    }
+                ],
+                "sourceAddressTranslation": {
+                    "type": "automap"
+                },
+                "virtual_address": "10.128.10.240"
+            }
+        ]
+    },
+    "network": {}
+}

--- a/python/tests/kubernetes_one_svc_two_nodes_expected.json
+++ b/python/tests/kubernetes_one_svc_two_nodes_expected.json
@@ -1,0 +1,72 @@
+{
+    "ltm": {
+        "iapps": [],
+        "l7Policies": [],
+        "monitors": [
+            {
+                "interval": 30,
+                "name": "default_configmap_0_tcp",
+                "send": "GET /",
+                "timeout": 20,
+                "type": "tcp"
+            },
+            {
+                "interval": 10,
+                "name": "default_configmap_1_0_http",
+                "send": "GET /",
+                "timeout": 5,
+                "type": "http"
+            }
+        ],
+        "pools": [
+            {
+                "members": [
+                    {
+                        "address": "172.16.0.5",
+                        "port": 30008,
+                        "session": "user-enabled"
+                    },
+                    {
+                        "address": "172.16.0.6",
+                        "port": 30008,
+                        "session": "user-enabled"
+                    }
+                ],
+                "monitors": [
+                    "/k8s/default_configmap_0_tcp",
+                    "/k8s/default_configmap_1_0_http"
+                ],
+                "name": "default_configmap"
+            }
+        ],
+        "virtualServers": [
+            {
+                "destination": "/k8s/FE80::1.5051",
+                "enabled": true,
+                "ipProtocol": "tcp",
+                "name": "default_configmap",
+                "policies": [],
+                "pool": "/k8s/default_configmap",
+                "profiles": [
+                    {
+                        "name": "clientssl",
+                        "partition": "Common"
+                    },
+                    {
+                        "name": "clientssl-secure",
+                        "partition": "Common"
+                    },
+                    {
+                        "name": "http",
+                        "partition": "Common"
+                    }
+                ],
+                "sourceAddressTranslation": {
+                    "type": "automap"
+                },
+                "virtual_address": "FE80::1"
+            }
+        ]
+    },
+    "network": {}
+}

--- a/python/tests/kubernetes_one_svc_two_nodes_pool_only_expected.json
+++ b/python/tests/kubernetes_one_svc_two_nodes_pool_only_expected.json
@@ -1,0 +1,45 @@
+{
+    "ltm": {
+        "iapps": [],
+        "l7Policies": [],
+        "monitors": [
+            {
+                "interval": 30,
+                "name": "default_configmap_0_tcp",
+                "send": "GET /",
+                "timeout": 20,
+                "type": "tcp"
+            },
+            {
+                "interval": 10,
+                "name": "default_configmap_1_0_http",
+                "send": "GET /",
+                "timeout": 5,
+                "type": "http"
+            }
+        ],
+        "pools": [
+            {
+                "members": [
+                    {
+                        "address": "172.16.0.5",
+                        "port": 30008,
+                        "session": "user-enabled"
+                    },
+                    {
+                        "address": "172.16.0.6",
+                        "port": 30008,
+                        "session": "user-enabled"
+                    }
+                ],
+                "monitors": [
+                    "/k8s/default_configmap_0_tcp",
+                    "/k8s/default_configmap_1_0_http"
+                ],
+                "name": "default_configmap"
+            }
+        ],
+        "virtualServers": []
+    },
+    "network": {}
+}

--- a/python/tests/test_k8scloudbigip.py
+++ b/python/tests/test_k8scloudbigip.py
@@ -20,11 +20,45 @@ Units tests for testing BIG-IP resource management in Kubernetes and OpenShift.
 from __future__ import absolute_import
 
 import unittest
+import json
 from mock import Mock, patch
-from f5_cccl.common import ipv4_to_mac
-from f5.bigip import BigIP
-from f5_cccl.testcommon import BigIPTest, MockIapp
+from f5.bigip import ManagementRoot
+from f5_cccl.exceptions import F5CcclValidationError
+from f5_cccl.exceptions import F5CcclSchemaError
 from .. import bigipconfigdriver as ctlr
+
+SCHEMA_PATH = "/go/src/f5-cccl/f5_cccl/schemas/cccl-api-schema.yml"
+
+
+# Kuberentes app data
+kubernetes_test_data = [
+    'tests/kubernetes_one_svc_two_nodes.json',
+    'tests/kubernetes_invalid_svcs.json',
+    'tests/kubernetes_one_svc_one_node.json',
+    'tests/kubernetes_one_svc_four_nodes.json',
+    'tests/kubernetes_one_iapp.json',
+    'tests/kubernetes_no_apps.json',
+    'tests/kubernetes_one_svc_two_nodes_pool_only.json'
+]
+
+
+class IPV4FormatError(Exception):
+    """Exception type for improperly formatted IPv4 address."""
+
+    def __init__(self, msg):
+        """Create ipv4 format exception object."""
+        Exception.__init__(self, msg)
+
+
+def ipv4_to_mac(ip_str):
+    """Convert an IPV4 string to a fake MAC address."""
+    ip = ip_str.split('.')
+    if len(ip) != 4:
+        raise IPV4FormatError('Bad IPv4 address format specified for '
+                              'FDB record: {}'.format(ip_str))
+
+    return "0a:0a:%02x:%02x:%02x:%02x" % (
+        int(ip[0]), int(ip[1]), int(ip[2]), int(ip[3]))
 
 
 class VxLANTunnel():
@@ -43,7 +77,7 @@ class VxLANTunnel():
             self.records = kwargs['records']
 
 
-class KubernetesTest(BigIPTest):
+class KubernetesTest(unittest.TestCase):
     """Kubernetes/Big-IP configuration tests.
 
     Test BIG-IP configuration given various Kubernetes states and existing
@@ -55,25 +89,39 @@ class KubernetesTest(BigIPTest):
         # Mock the call to _get_tmos_version(), which tries to make a
         # connection
         partition = 'k8s'
-        with patch.object(BigIP, '_get_tmos_version'):
-            bigip = ctlr.K8sCloudBigIP('1.2.3.4', '443', 'admin',
-                                       'default', [partition], manage_types=[
-                                           '/tm/ltm/virtual',
-                                           '/tm/ltm/pool',
-                                           '/tm/ltm/monitor',
-                                           '/tm/sys/application/service'])
-        super(KubernetesTest, self).setUp(partition, bigip)
+        with patch.object(ManagementRoot, '_get_tmos_version'):
+            bigip = ManagementRoot('1.2.3.4', 'admin', 'default')
 
-        self.bigip.fdb_records_update_orig = self.bigip.fdb_records_update
-        self.bigip.get_fdb_records_orig = self.bigip.get_fdb_records
+            self.mgr = ctlr.K8sCloudServiceManager(
+                bigip,
+                partition,
+                schema_path=SCHEMA_PATH)
 
-        # mock out the bigip.net.fdb.tunnels.tunnel resource
-        self.bigip.net = type('', (), {})()
-        self.bigip.net.fdb = type('', (), {})()
-        self.bigip.net.fdb.tunnels = type('', (), {})()
-        self.bigip.net.fdb.tunnels.tunnel = type('', (), {})()
-        self.bigip.net.fdb.tunnels.tunnel.load = \
+        self.cccl = self.mgr._cccl
+        self.cccl._service_manager._service_deployer._bigip.refresh = Mock()
+        self.cccl._service_manager._service_deployer.deploy = \
+            Mock(return_value=0)
+
+        # mock out the bigip.tm.net.fdb.tunnels.tunnel resource
+        bigip.tm = type('', (), {})()
+        bigip.tm.net = type('', (), {})()
+        bigip.tm.net.fdb = type('', (), {})()
+        bigip.tm.net.fdb.tunnels = type('', (), {})()
+        bigip.tm.net.fdb.tunnels.tunnel = \
+            type('', (), {})()
+        bigip.tm.net.fdb.tunnels.tunnel.load = \
             Mock(side_effect=self.mock_net_fdb_tunnels_tunnel_load)
+
+    def read_test_vectors(self, cloud_state, network_state=None):
+        """Read test vectors for the various states."""
+        # Read the Kubernetes state
+        if cloud_state:
+            with open(cloud_state) as json_data:
+                self.cloud_data = json.load(json_data)
+
+        if network_state:
+            with open(network_state) as json_data:
+                self.network_data = json.load(json_data)
 
     def mock_net_fdb_tunnels_tunnel_load(self, partition, name):
         """Mock: Get a mocked vxla tunnel to store the vxlan record config."""
@@ -83,526 +131,69 @@ class KubernetesTest(BigIPTest):
             self.vxlan_tunnel = VxLANTunnel(partition, name, self.network_data)
         return self.vxlan_tunnel
 
-    def test_svc_create(self,
-                        cloud_state='tests/kubernetes_one_svc_two_nodes.json',
-                        bigip_state='tests/bigip_test_blank.json',
-                        hm_state='tests/bigip_test_blank.json'):
-        """Test: Kubernetes service created."""
+    def verify_kubernetes_config(self, cloud_state, expected_state):
+        """Test: Verify expected config created from the Kubernetes state."""
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
+        self.read_test_vectors(cloud_state)
 
         # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
 
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
+        with open(expected_state) as json_data:
+                exp = json.load(json_data)
+        self.assertEqual(cfg, exp)
 
-        self.assertTrue(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertTrue(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
+        self.mgr._apply_config(cfg)
 
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertEqual(self.bigip.member_create.call_count, 2)
-
-        self.assertEquals(2, len(self.test_monitor))
-        expected_names = ['default_configmap', 'default_configmap_1']
-        for mon in self.test_monitor:
-            self.assertTrue(mon['name'] in expected_names)
-            self.assertEqual(self.test_partition, mon['partition'])
-
-    def test_invalid_svcs(self,
-                          cloud_state='tests/kubernetes_invalid_svcs.json',
-                          bigip_state='tests/bigip_test_blank.json',
-                          hm_state='tests/bigip_test_blank.json'):
-        """Test: Kubernetes invalid services are not created."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertTrue(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertTrue(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertEqual(self.bigip.member_create.call_count, 2)
-
-        self.assertEquals(2, len(self.test_virtual))
-        self.assertEquals(2, len(self.test_pool))
-
-        expected_names = ['invalid_sslProfile0_configmap',
-                          'invalid_sslProfile1_configmap']
-        for v in self.test_virtual:
-            self.assertTrue(v['name'] in expected_names)
-            self.assertEquals(self.test_partition, v['partition'])
-        for p in self.test_pool:
-            self.assertTrue(p['name'] in expected_names)
-            self.assertEquals(self.test_partition, p['partition'])
-
-    def test_svc_scaled_down(
+    def test_cccl_exceptions(
             self,
-            cloud_state='tests/kubernetes_one_svc_one_node.json',
-            bigip_state='tests/bigip_test_one_svc_two_nodes.json',
-            hm_state='tests/bigip_test_blank.json'):
-        """Test: Kubernetes service scaled down."""
+            cloud_state='tests/kubernetes_one_svc_two_nodes.json'):
+        """Test: CCCL exceptions."""
+        with patch.object(ManagementRoot, '_get_tmos_version'):
+            bigip = ManagementRoot(
+                '1.2.3.4',
+                'admin',
+                'default',
+                port=443,
+                token='tmos')
+            self.assertRaises(F5CcclSchemaError, ctlr.K8sCloudServiceManager,
+                              bigip,
+                              'test',
+                              schema_path='not/a/valid/path.json')
+
+        cfg = {"ltm": "not valid json"}
+        self.assertRaises(F5CcclValidationError, self.mgr._apply_config, cfg)
+
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
+        self.read_test_vectors(cloud_state)
 
         # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
 
-        # Verify BIG-IP configuration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertTrue(self.bigip.member_update.called)
-        self.assertTrue(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
+        # Corrupt the config
+        del cfg['ltm']['virtualServers'][0]['name']
+        self.assertRaises(F5CcclValidationError, self.mgr._apply_config, cfg)
 
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertTrue(self.bigip.member_delete.called)
-        self.assertEqual(self.bigip.member_delete.call_count, 1)
-
-    def test_svc_scaled_up(
-            self,
-            cloud_state='tests/kubernetes_one_svc_four_nodes.json',
-            bigip_state='tests/bigip_test_one_svc_two_nodes.json',
-            hm_state='tests/bigip_test_blank.json'):
-        """Test: Kubernetes service scaled up."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
-
-        # Verify BIG-IP configuration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertTrue(self.bigip.member_update.called)
-        self.assertTrue(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertEqual(self.bigip.member_create.call_count, 2)
-
-    def test_new_iapp(self, cloud_state='tests/kubernetes_one_iapp.json',
-                      bigip_state='tests/bigip_test_blank.json',
-                      hm_state='tests/bigip_test_blank.json'):
-        """Test: Start Kubernetes app with iApp."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        self.bigip.iapp_create = self.bigip.iapp_create_orig
-        self.bigip.sys.application.services.service.create = \
-            Mock(side_effect=self.mock_iapp_service_create)
-
-        # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-
-        expected_name = 'default_configmap'
-
-        # Verfiy the iapp variables and tables
-        expected_tables = \
-            [{'columnNames': ['addr', 'port', 'connection_limit'], 'rows':
-             [{'row': [u'172.16.0.5', u'30008', '0']}],
-             'name': u'pool__members'}]
-        expected_variables = \
-            [{'name': u'monitor__monitor', 'value': u'/#create_new#'},
-             {'name': u'net__client_mode', 'value': u'wan'},
-             {'name': u'pool__pool_to_use', 'value': u'/#create_new#'},
-             {'name': u'net__server_mode', 'value': u'lan'},
-             {'name': u'pool__addr', 'value': u'10.128.10.240'},
-             {'name': u'monitor__response', 'value': u'none'},
-             {'name': u'monitor__uri', 'value': u'/'},
-             {'name': u'pool__port', 'value': u'8080'}]
-
-        self.assertEquals(expected_name, self.test_iapp.name)
-        self.assertEquals(expected_tables, self.test_iapp.tables)
-        self.assertEquals(expected_variables, self.test_iapp.variables)
-
-    def test_update_iapp(self, cloud_state='tests/kubernetes_one_iapp.json',
-                         bigip_state='tests/kubernetes_one_iapp.json',
-                         hm_state='tests/bigip_test_blank.json'):
-        """Test: Update Kubernetes app with iApp."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        self.bigip.sys.application.services.get_collection = \
-            Mock(side_effect=self.mock_iapp_update_services_get_collection)
-        self.bigip.sys.application.services.service.load = \
-            Mock(side_effect=self.mock_iapp_update_service_load)
-        self.bigip.iapp_update = self.bigip.iapp_update_orig
-        self.bigip.cleanup_nodes = Mock()
-
-        # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-
-        iapp_def = self.bigip.iapp_build_definition(
-            cfg['ltm']['virtualServers']['default_configmap'],
-            cfg['ltm']['pools'][0])
-        self.test_iapp = MockIapp(name='default_configmap',
-                                  partition=self.test_partition,
-                                  variables=iapp_def['variables'],
-                                  tables=iapp_def['tables'])
-
-        self.bigip.regenerate_config_f5(cfg)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-
-        self.assertTrue(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-
-        expected_name = 'default_configmap'
-        self.assertEquals(expected_name, self.test_iapp_list[0].name)
-
-    def test_delete_iapp(self, cloud_state='tests/kubernetes_no_apps.json',
-                         bigip_state='tests/bigip_test_blank.json',
-                         hm_state='tests/bigip_test_blank.json'):
-        """Test: Delete Kubernetes app associated with iApp."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        self.bigip.iapp_delete = self.bigip.iapp_delete_orig
-        self.bigip.sys.application.services.get_collection = \
-            Mock(side_effect=self.mock_iapp_services_get_collection)
-        self.bigip.sys.application.services.service.load = \
-            Mock(side_effect=self.mock_iapp_service_load)
-
-        # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.load.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertFalse(self.bigip.member_delete.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertFalse(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-
-        expected_name = 'server-app2_iapp_10000_vs'
-        self.assertEqual(len(self.test_iapp_list), 1)
-        self.assertEqual(self.test_iapp_list[0].partition,
-                         self.test_partition)
-        self.assertEqual(self.test_iapp_list[0].name, expected_name)
-        self.assertEqual(self.test_iapp.partition, self.test_partition)
-        self.assertEqual(self.test_iapp.name, expected_name)
-
-    def test_updates(self,
-                     cloud_state='tests/kubernetes_one_svc_two_nodes.json',
-                     bigip_state='tests/bigip_test_one_svc_two_nodes.json',
-                     hm_state='tests/bigip_test_blank.json'):
-        """Test: Verify BIG-IP updates.
-
-        Verify that resources are only updated when the state
-        of the resource changes.
-        """
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Restore the mocked 'update' functions to their original state
-        self.bigip.pool_update = self.bigip.pool_update_orig
-        self.bigip.virtual_update = self.bigip.virtual_update_orig
-        self.bigip.member_update = self.bigip.member_update_orig
-
-        # Mock the 'get' resource functions. We will use these to supply
-        # mocked resources
-        self.bigip.get_pool = Mock(side_effect=self.mock_get_pool)
-        self.bigip.get_virtual = Mock(side_effect=self.mock_get_virtual)
-        self.bigip.get_virtual_profiles = Mock(
-            side_effect=self.mock_get_virtual_profiles)
-        self.bigip.get_virtual_policies = Mock(
-            side_effect=self.mock_get_virtual_policies)
-        self.bigip.get_member = Mock(side_effect=self.mock_get_member)
-        self.bigip.get_virtual_address = Mock(
-            side_effect=self.mock_get_virtual_address)
-
-        # Create a mock Pool
-        pool_data_unchanged = {'monitor': '/k8s/default_configmap and '
-                                          '/k8s/default_configmap_1',
-                               'balance': 'round-robin',
-                               'partition': 'k8s',
-                               'members': ['172.16.0.5:30008',
-                                           '172.16.0.6:30008']}
-        pool = self.create_mock_pool('default_configmap',
-                                     **pool_data_unchanged)
-
-        # Create a mock Virtual
-        virtual_data_unchanged = {'enabled': True,
-                                  'disabled': False,
-                                  'ipProtocol': 'tcp',
-                                  'destination': '/k8s/FE80::1.5051',
-                                  'pool': '/k8s/default_configmap',
-                                  'sourceAddressTranslation':
-                                  {'type': 'automap'},
-                                  'profiles': [{'partition': 'Common',
-                                                'name': 'clientssl'},
-                                               {'partition': 'Common',
-                                                'name': 'clientssl-secure'},
-                                               {'partition': 'Common',
-                                                'name': 'http'}],
-                                  'policies': []}
-        virtual = self.create_mock_virtual('default_configmap',
-                                           **virtual_data_unchanged)
-
-        # Create mock Pool Members
-        member_data_unchanged = {'state': 'user-up', 'session': 'user-enabled'}
-        member = self.create_mock_pool_member('172.16.0.5:30008',
-                                              **member_data_unchanged)
-        member = self.create_mock_pool_member('172.16.0.6:30008',
-                                              **member_data_unchanged)
-
-        # Pool, Virtual, and Member are not modified
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
-        self.assertFalse(pool.modify.called)
-        self.assertFalse(virtual.modify.called)
-        self.assertFalse(virtual.profiles_s.profiles.create.called)
-        self.assertFalse(member.modify.called)
-
-        # Pool is modified
-        pool_data_changed = {
-            'balance': 'least-connections'
-        }
-        for key in pool_data_changed:
-            data = pool_data_unchanged.copy()
-            # Change one thing
-            data[key] = pool_data_changed[key]
-            pool = self.create_mock_pool('default_configmap', **data)
-            cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-            self.bigip.regenerate_config_f5(cfg)
-            self.assertTrue(pool.modify.called)
-
-        # Virtual is modified
-        virtual_data_changed = {
-            'enabled': False,
-            'disabled': True,
-            'ipProtocol': 'udp',
-            'destination': '/Common/10.128.10.240:5051',
-            'pool': '/Common/default_configmap',
-            'sourceAddressTranslation': {'type': 'snat'},
-            'profiles': [{'partition': 'Common', 'name': 'clientssl'},
-                         {'partition': 'Common', 'name': 'clientssl-secure'},
-                         {'partition': 'Common', 'name': 'tcp'}]
-        }
-        for key in virtual_data_changed:
-            data = virtual_data_unchanged.copy()
-            # Change one thing
-            data[key] = virtual_data_changed[key]
-            virtual = self.create_mock_virtual('default_configmap',
-                                               **data)
-            cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-            self.bigip.regenerate_config_f5(cfg)
-            self.assertTrue(virtual.modify.called)
-
-        # Make sure virtual server modify is called for policy name changes.
-        policies = [
-            {'partition': 'Common', 'name': 'policy1'},
-            {'partition': 'Common', 'name': 'policy2'},
-            {}
-            ]
-        for pol in policies:
-            data = virtual_data_unchanged.copy()
-            # Change one thing
-            data['policies'] = pol
-            virtual = self.create_mock_virtual('default_configmap',
-                                               **data)
-            cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-            self.bigip.regenerate_config_f5(cfg)
-            self.assertTrue(virtual.modify.called)
-
-        # Member is modified
-        member_data_changed = {
-            'state': 'user-down',
-            'session': 'user-disabled'
-        }
-        for key in member_data_changed:
-            data = member_data_unchanged.copy()
-            # Change one thing
-            data[key] = member_data_changed[key]
-            member = self.create_mock_pool_member('172.16.0.5:30008',
-                                                  **data)
-            cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-            self.bigip.regenerate_config_f5(cfg)
-            self.assertTrue(member.modify.called)
-
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-
-    def test_create_pool_only(
-            self,
-            cloud_state='tests/kubernetes_one_svc_two_nodes_pool_only.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
-        """Test: Marathon app that does not create a virtual server."""
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
-
-        # Verify BIG-IP configuration
-        self.assertFalse(self.bigip.pool_update.called)
-        self.assertFalse(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertTrue(self.bigip.ltm.pools.pool.create.called)
-        self.assertTrue(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertTrue(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertEqual(self.bigip.ltm.virtuals.virtual.create.call_count, 0)
-        self.assertEqual(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.monitor.https.http.create.call_count,
-                         1)
-
-        expected_pool_name = 'default_configmap'
-        expected_names = ['default_configmap', 'default_configmap_1']
-        self.assertEqual(1, len(self.test_pool))
-        self.assertEqual(0, len(self.test_virtual))
-        self.assertEqual(2, len(self.test_monitor))
-        self.assertEqual(expected_pool_name, self.test_pool[0]['name'])
-        self.assertEqual(self.test_partition, self.test_pool[0]['partition'])
-        for mon in self.test_monitor:
-            self.assertTrue(mon['name'] in expected_names)
-            self.assertEqual(self.test_partition, mon['partition'])
+    def test_kubernetes_configs(self):
+        """Test: Verify expected BIG-IP config created from Marathon state."""
+        # Verify configuration
+        for data_file in kubernetes_test_data:
+            expected_file = data_file.replace('.json', '_expected.json')
+            self.verify_kubernetes_config(data_file, expected_file)
 
     def test_pool_only_to_virtual_server(
             self,
-            cloud_state='tests/kubernetes_one_svc_two_nodes_pool_only.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
-        """Test: Marathon app without a virtual server gets virtual server."""
+            cloud_state='tests/kubernetes_one_svc_two_nodes_pool_only.json'):
+        """Test: Kubernetes app without virtual server gets virtual server."""
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Mock out functions not directly under test
-        self.bigip.get_pool_list = Mock(side_effect=self.mock_get_pool_list)
-        self.bigip.get_virtual_list = \
-            Mock(side_effect=self.mock_get_virtual_list)
-        self.bigip.get_healthcheck_list = \
-            Mock(side_effect=self.mock_get_healthcheck_list)
+        self.read_test_vectors(cloud_state)
 
         # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
-
-        # Verify BIG-IP initial configuration
-        self.assertEqual(self.bigip.ltm.virtuals.virtual.create.call_count, 0)
-        self.assertEqual(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.monitor.https.http.create.call_count,
-                         1)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
 
         # Reconfigure BIG-IP by adding virtual server to existing pool
         self.cloud_data['resources']['virtualServers'][0].update(
@@ -615,194 +206,28 @@ class KubernetesTest(BigIPTest):
                         5051
                 }
             })
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
-
-        # Verify BIG-IP reconfiguration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertTrue(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertTrue(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertTrue(self.bigip.ltm.pools.pool.create.called)
-        self.assertTrue(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertTrue(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertEqual(self.bigip.ltm.virtuals.virtual.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.monitor.https.http.create.call_count,
-                         1)
-
-        expected_virtual_name = 'default_configmap'
-        expected_pool_name = 'default_configmap'
-        expected_names = ['default_configmap', 'default_configmap_1']
-        self.assertEqual(1, len(self.test_pool))
-        self.assertEqual(1, len(self.test_virtual))
-        self.assertEqual(2, len(self.test_monitor))
-        self.assertEqual(expected_pool_name, self.test_pool[0]['name'])
-        self.assertEqual(expected_virtual_name, self.test_virtual[0]['name'])
-        self.assertEqual(self.test_partition, self.test_pool[0]['partition'])
-        for mon in self.test_monitor:
-            self.assertTrue(mon['name'] in expected_names)
-            self.assertEqual(self.test_partition, mon['partition'])
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
 
     def test_virtual_server_to_pool_only(
             self,
-            cloud_state='tests/kubernetes_one_svc_two_nodes.json',
-            bigip_state='tests/bigip_test_blank.json',
-            hm_state='tests/bigip_test_blank.json'):
-        """Test: Marathon app with virtual server removes virtual server."""
+            cloud_state='tests/kubernetes_one_svc_two_nodes.json'):
+        """Test: Kubernetes app with virtual server removes virtual server."""
         # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Mock out functions not directly under test
-        self.bigip.get_pool_list = Mock(side_effect=self.mock_get_pool_list)
-        self.bigip.get_virtual_list = \
-            Mock(side_effect=self.mock_get_virtual_list)
-        self.bigip.get_healthcheck_list = \
-            Mock(side_effect=self.mock_get_healthcheck_list)
-        self.bigip.virtual_delete = Mock(side_effect=self.mock_virtual_delete)
+        self.read_test_vectors(cloud_state)
 
         # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
 
-        # Verify BIG-IP initial configuration
-        self.assertEqual(self.bigip.ltm.virtuals.virtual.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.monitor.https.http.create.call_count,
-                         1)
-
-        # Reconfigure BIG-IP by adding virtual server to existing pool
+        # Reconfigure BIG-IP by removing virtual server
         self.cloud_data['resources']['virtualServers'][0].pop(
             unicode('virtualAddress'))
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
-
-        # Verify BIG-IP reconfiguration
-        self.assertTrue(self.bigip.pool_update.called)
-        self.assertTrue(self.bigip.healthcheck_update.called)
-        self.assertFalse(self.bigip.member_update.called)
-        self.assertFalse(self.bigip.virtual_update.called)
-        self.assertFalse(self.bigip.iapp_update.called)
-
-        self.assertTrue(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertTrue(self.bigip.ltm.pools.pool.create.called)
-        self.assertTrue(self.bigip.ltm.monitor.tcps.tcp.create.called)
-        self.assertTrue(self.bigip.ltm.monitor.https.http.create.called)
-        self.assertTrue(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.ltm.monitor.tcps.tcp.load.called)
-        self.assertEqual(self.bigip.ltm.virtuals.virtual.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.pools.pool.create.call_count, 1)
-        self.assertEqual(self.bigip.ltm.monitor.https.http.create.call_count,
-                         1)
-
-        self.assertEqual(1, len(self.test_pool))
-        self.assertEqual(0, len(self.test_virtual))
-        self.assertEqual(2, len(self.test_monitor))
-        expected_names = ['default_configmap', 'default_configmap_1']
-        expected_pool_name = 'default_configmap'
-        self.assertEqual(expected_pool_name, self.test_pool[0]['name'])
-        self.assertEqual(self.test_partition, self.test_pool[0]['partition'])
-        for mon in self.test_monitor:
-            self.assertTrue(mon['name'] in expected_names)
-            self.assertEqual(self.test_partition, mon['partition'])
-
-    def test_updates_pool_only(
-            self,
-            cloud_state='tests/kubernetes_one_svc_two_nodes_pool_only.json',
-            bigip_state='tests/bigip_test_one_svc_two_nodes.json',
-            hm_state='tests/bigip_test_blank.json'):
-        """Test: Verify BIG-IP updates in pool only mode.
-
-        Verify that resources are only updated when the state
-        of the resource changes.
-        """
-        # Get the test data
-        self.read_test_vectors(cloud_state, bigip_state, hm_state)
-
-        # Restore the mocked 'update' functions to their original state
-        self.bigip.pool_update = self.bigip.pool_update_orig
-        self.bigip.member_update = self.bigip.member_update_orig
-        self.bigip.healthcheck_update = self.bigip.healthcheck_update_orig
-
-        # Mock the 'get' resource functions. We will use these to supply
-        # mocked resources
-        self.bigip.get_pool = Mock(side_effect=self.mock_get_pool)
-        self.bigip.get_virtual = Mock(side_effect=self.mock_get_virtual)
-        self.bigip.get_member = Mock(side_effect=self.mock_get_member)
-        self.bigip.get_healthcheck = Mock(
-            side_effect=self.mock_get_healthcheck)
-
-        # Create a mock Pool
-        pool_data_unchanged = {'monitor': '/k8s/default_configmap and '
-                                          '/k8s/default_configmap_1',
-                               'balance': 'round-robin'}
-        pool = self.create_mock_pool('default_configmap',
-                                     **pool_data_unchanged)
-
-        # Create mock Pool Members
-        member_data_unchanged = {'state': 'user-up', 'session': 'user-enabled'}
-        member = self.create_mock_pool_member('172.16.0.5:30008',
-                                              **member_data_unchanged)
-        member = self.create_mock_pool_member('172.16.0.6:30008',
-                                              **member_data_unchanged)
-
-        # Pool, Member, and Healthcheck are not modified
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
-        self.assertFalse(pool.modify.called)
-        self.assertFalse(member.modify.called)
-
-        # Pool is modified
-        pool_data_changed = {
-            'balance': 'least-connections'
-        }
-        for key in pool_data_changed:
-            data = pool_data_unchanged.copy()
-            # Change one thing
-            data[key] = pool_data_changed[key]
-            pool = self.create_mock_pool('default_configmap', **data)
-            self.bigip.regenerate_config_f5(cfg)
-            self.assertTrue(pool.modify.called)
-
-        # Member is modified
-        member_data_changed = {
-            'state': 'user-down',
-            'session': 'user-disabled'
-        }
-        for key in member_data_changed:
-            data = member_data_unchanged.copy()
-            # Change one thing
-            data[key] = member_data_changed[key]
-            member = self.create_mock_pool_member('172.16.0.5:30008',
-                                                  **data)
-            self.bigip.regenerate_config_f5(cfg)
-            self.assertTrue(member.modify.called)
-
-        self.assertFalse(self.bigip.iapp_create.called)
-        self.assertFalse(self.bigip.iapp_delete.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.create.called)
-        self.assertFalse(self.bigip.ltm.virtuals.virtual.load.called)
-        self.assertFalse(self.bigip.ltm.pools.pool.create.called)
-        self.assertFalse(self.bigip.ltm.pools.get_collection.called)
-        self.assertFalse(self.bigip.member_create.called)
-        self.assertFalse(self.bigip.member_delete.called)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
 
     def test_network_0_existing_vxlan_nodes_0_requested_vxlan_nodes(
             self,
@@ -814,12 +239,14 @@ class KubernetesTest(BigIPTest):
                                network_state=network_state)
 
         # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
 
         # Verify we only query bigip once for the initial state and
         # don't try to write an update if nothing has changed.
-        self.assertEqual(self.bigip.net.fdb.tunnels.tunnel.load.call_count, 1)
+        self.assertEqual(self.mgr.mgmt_root().
+                         tm.net.fdb.tunnels.tunnel.load.call_count, 1)
 
         # Compare final content with self.network_state - should be the same
         self.assertEqual(self.compute_fdb_records(), self.vxlan_tunnel.records)
@@ -834,12 +261,14 @@ class KubernetesTest(BigIPTest):
                                network_state=network_state)
 
         # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
 
         # Verify we only query bigip once for the initial state and
         # don't try to write an update if nothing has changed.
-        self.assertEqual(self.bigip.net.fdb.tunnels.tunnel.load.call_count, 1)
+        self.assertEqual(self.mgr.mgmt_root().
+                         tm.net.fdb.tunnels.tunnel.load.call_count, 1)
 
         # Compare final content with self.network_state - should be the same
         self.assertEqual(self.compute_fdb_records(), self.vxlan_tunnel.records)
@@ -854,12 +283,14 @@ class KubernetesTest(BigIPTest):
                                network_state=network_state)
 
         # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
 
         # Verify we first query bigip once for the initial state and
         # then perform an update due to differences
-        self.assertEqual(self.bigip.net.fdb.tunnels.tunnel.load.call_count, 2)
+        self.assertEqual(self.mgr.mgmt_root().
+                         tm.net.fdb.tunnels.tunnel.load.call_count, 2)
 
         # Compare final content with self.network_state - should be the same
         self.assertEqual(self.compute_fdb_records(), self.vxlan_tunnel.records)
@@ -874,12 +305,14 @@ class KubernetesTest(BigIPTest):
                                network_state=network_state)
 
         # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
 
         # Verify we first query bigip once for the initial state and
         # then perform an update due to differences
-        self.assertEqual(self.bigip.net.fdb.tunnels.tunnel.load.call_count, 2)
+        self.assertEqual(self.mgr.mgmt_root().
+                         tm.net.fdb.tunnels.tunnel.load.call_count, 2)
 
         # Compare final content with self.network_state - should be the same
         self.assertEqual(self.compute_fdb_records(), self.vxlan_tunnel.records)
@@ -894,12 +327,14 @@ class KubernetesTest(BigIPTest):
                                network_state=network_state)
 
         # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
 
         # Verify we first query bigip once for the initial state and
         # then perform an update due to differences
-        self.assertEqual(self.bigip.net.fdb.tunnels.tunnel.load.call_count, 2)
+        self.assertEqual(self.mgr.mgmt_root().
+                         tm.net.fdb.tunnels.tunnel.load.call_count, 2)
 
         # Compare final content with self.network_state - should be the same
         self.assertEqual(self.compute_fdb_records(), self.vxlan_tunnel.records)
@@ -914,12 +349,14 @@ class KubernetesTest(BigIPTest):
                                network_state=network_state)
 
         # Do the BIG-IP configuration
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
 
         # Verify we first query bigip once for the initial state and
         # then perform an update due to differences
-        self.assertEqual(self.bigip.net.fdb.tunnels.tunnel.load.call_count, 2)
+        self.assertEqual(self.mgr.mgmt_root().
+                         tm.net.fdb.tunnels.tunnel.load.call_count, 2)
 
         # Compare final content with self.network_state - should be the same
         self.assertEqual(self.compute_fdb_records(), self.vxlan_tunnel.records)
@@ -935,18 +372,21 @@ class KubernetesTest(BigIPTest):
         # Verify original configuration is untouched if we have errors
         # in the cloud config file
         self.cloud_data['openshift-sdn']['vxlan-node-ips'][0] = '55'
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
         self.assertEqual(self.network_data, self.vxlan_tunnel.records)
 
         self.cloud_data['openshift-sdn']['vxlan-node-ips'][0] = 55
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
         self.assertEqual(self.network_data, self.vxlan_tunnel.records)
 
         self.cloud_data['openshift-sdn']['vxlan-node-ips'][0] = 'myaddr'
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
         self.assertEqual(self.network_data, self.vxlan_tunnel.records)
 
     def test_network_bad_partition_name(
@@ -961,19 +401,22 @@ class KubernetesTest(BigIPTest):
         # in the cloud config file
         self.cloud_data['openshift-sdn']['vxlan-name'] = \
             '/bad/partition/name/idf/'
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
         self.assertFalse(hasattr(self, 'vxlan_tunnel'))
 
         self.cloud_data['openshift-sdn']['vxlan-name'] = \
             'bad/partition/name'
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
         self.assertFalse(hasattr(self, 'vxlan_tunnel'))
 
         self.cloud_data['openshift-sdn']['vxlan-name'] = ''
-        cfg = ctlr.create_config_kubernetes(self.bigip, self.cloud_data)
-        self.bigip.regenerate_config_f5(cfg)
+        cfg = ctlr.create_config_kubernetes(self.mgr.get_partition(),
+                                            self.cloud_data)
+        self.mgr._apply_config(cfg)
         self.assertFalse(hasattr(self, 'vxlan_tunnel'))
 
     def compute_fdb_records(self):


### PR DESCRIPTION
Changes to the k8s-bigip-ctlr:
- Creation of a CCCL instance for each managed partition
- Modified create_ltm_config_kubernetes() to create CCCL-compliant schema
- Converted python unit tests

Note: This is an interim step. Currently, the creation of a BIG-IP configuration
occurs in two pieces: the golang frontend creates a config file from the
relevant configmaps and service descriptions, then the python backend performs
another conversion before passing the desired config to CCCL. The goal is to
create the CCCL-compliant BIG-IP config in one step within the golang frontend
of k8s-bigip-ctlr. Most importantly, this commit removes the dependency upon the
legacy f5-cccl/f5_cccl/_f5.py implemention.