### PR TITLE
add redundancy to gpg key retrieval

### DIFF
--- a/build-tools/Dockerfile.builder.dbg
+++ b/build-tools/Dockerfile.builder.dbg
@@ -10,7 +10,11 @@ RUN set -x \
   && wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch" \
   && wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc" \
   && export GNUPGHOME="$(mktemp -d)" \
-  && gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+  && key=B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+  && ( gpg --keyserver pool.sks-keyservers.net --recv-keys $key || \
+    gpg --keyserver ipv4.pool.sks-keyservers.net --recv-keys $key || \
+    gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys $key || \
+    gpg --keyserver pool.sks-keyservers.net:80 --recv-keys $key ) \
   && gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
   && rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
   && chmod +x /usr/local/bin/gosu \


### PR DESCRIPTION
Problem:
Builds can fail due to gpg key server errors.

Solution:
Add redundancy to the gpg key retrieval step so that a reasonable number of servers are tried in succession, with the build proceeding at first successful retrieval.

Tests
In addition to CI builds on k8s-bigip-ctlr, also confirmed local builds using top of tree for k8s-bigip-ctlr and f5-cccl succeed:
- in f5-cccl ` ./build-tools/system-test-img.sh michaeldayreads/k8s-bigip-ctlr 6c160ec "make prod" michaeldayreads f5devcentral/f5-cccl.git@02e2160124e208dfec5a1ac657b8ba6f078d3907`
- img at https://hub.docker.com/r/michaeldayreads/cccl/tags/