### PR TITLE
Add support for SSL passthrough termination

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1037,7 +1037,7 @@ func (appMgr *Manager) syncRoutes(
 			// The information stored in the internal data groups can span multiple
 			// namespaces, so we need to keep dgMap updated with all current routes
 			// regardless of anything that happens below.
-			updateDataGroupForRoute(route, DEFAULT_PARTITION, dgMap)
+			updateDataGroupForPassthroughRoute(route, DEFAULT_PARTITION, dgMap)
 		}
 		if route.ObjectMeta.Namespace != sKey.Namespace {
 			continue

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -316,6 +316,8 @@ when CLIENT_DATA {
 	return iRuleCode
 }
 
+// Update a specific datagroup for passthrough routes, indicating if
+// something had changed.
 func (appMgr *Manager) updatePassthroughRouteDataGroups(
 	partition string,
 	poolName string,
@@ -343,7 +345,8 @@ func (appMgr *Manager) updatePassthroughRouteDataGroups(
 	return changed, nil
 }
 
-func updateDataGroupForRoute(
+// Update a data group map based on a passthrough route object.
+func updateDataGroupForPassthroughRoute(
 	route *routeapi.Route,
 	partition string,
 	dgMap InternalDataGroupMap,
@@ -354,6 +357,7 @@ func updateDataGroupForRoute(
 		partition, hostName, poolName)
 }
 
+// Add or update a data group record
 func updateDataGroup(
 	intDgMap InternalDataGroupMap,
 	name string,
@@ -378,6 +382,8 @@ func updateDataGroup(
 	}
 }
 
+// Update the appMgr datagroup cache for passthrough routes, indicating if
+// something had changed by updating 'stats', which should rewrite the config.
 func (appMgr *Manager) updateRouteDataGroups(
 	stats *vsSyncStats,
 	dgMap InternalDataGroupMap,

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
+	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -27,10 +28,19 @@ import (
 
 	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
 
+	routeapi "github.com/openshift/origin/pkg/route/api"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 )
 
 const httpRedirectRuleName = "http-redirect"
+const sslPassthroughIRuleName = "openshift_passthrough_irule"
+
+// Internal data group for passthrough routes to map server names to pools.
+const passthroughHostsDgName = "ssl_passthrough_servername_dg"
+
+// Internal data group for reencrypt routes.
+// FIXME: Only used by the iRule below until reencrypt is supported.
+const reencryptHostsDgName = "ssl_reencrypt_servername_dg"
 
 func (r Rules) Len() int           { return len(r) }
 func (r Rules) Less(i, j int) bool { return r[i].FullURI < r[j].FullURI }
@@ -200,4 +210,194 @@ func newHttpRedirectPolicyRule(httpsPort int32) *Rule {
 		Ordinal: 0,
 	}
 	return &rule
+}
+
+func sslPassthroughIRule() string {
+	iRuleCode := `
+when CLIENT_ACCEPTED {
+	TCP::collect
+}
+
+when CLIENT_DATA {
+	# Byte 0 is the content type.
+	# Bytes 1-2 are the TLS version.
+	# Bytes 3-4 are the TLS payload length.
+	# Bytes 5-$tls_payload_len are the TLS payload.
+	binary scan [TCP::payload] cSS tls_content_type tls_version tls_payload_len
+
+	switch $tls_version {
+		"769" -
+		"770" -
+		"771" {
+			# Content type of 22 indicates the TLS payload contains a handshake.
+			if { $tls_content_type == 22 } {
+				# Byte 5 (the first byte of the handshake) indicates the handshake
+				# record type, and a value of 1 signifies that the handshake record is
+				# a ClientHello.
+				binary scan [TCP::payload] @5c tls_handshake_record_type
+				if { $tls_handshake_record_type == 1 } {
+					# Bytes 6-8 are the handshake length (which we ignore).
+					# Bytes 9-10 are the TLS version (which we ignore).
+					# Bytes 11-42 are random data (which we ignore).
+
+					# Byte 43 is the session ID length.  Following this are three
+					# variable-length fields which we shall skip over.
+					set record_offset 43
+
+					# Skip the session ID.
+					binary scan [TCP::payload] @${record_offset}c tls_session_id_len
+					incr record_offset [expr {1 + $tls_session_id_len}]
+
+					# Skip the cipher_suites field.
+					binary scan [TCP::payload] @${record_offset}S tls_cipher_suites_len
+					incr record_offset [expr {2 + $tls_cipher_suites_len}]
+
+					# Skip the compression_methods field.
+					binary scan [TCP::payload] @${record_offset}c tls_compression_methods_len
+					incr record_offset [expr {1 + $tls_compression_methods_len}]
+
+					# Get the number of extensions, and store the extensions.
+					binary scan [TCP::payload] @${record_offset}S tls_extensions_len
+					incr record_offset 2
+					binary scan [TCP::payload] @${record_offset}a* tls_extensions
+
+					for { set extension_start 0 }
+							{ $tls_extensions_len - $extension_start == abs($tls_extensions_len - $extension_start) }
+							{ incr extension_start 4 } {
+						# Bytes 0-1 of the extension are the extension type.
+						# Bytes 2-3 of the extension are the extension length.
+						binary scan $tls_extensions @${extension_start}SS extension_type extension_len
+
+						# Extension type 00 is the ServerName extension.
+						if { $extension_type == "00" } {
+							# Bytes 4-5 of the extension are the SNI length (we ignore this).
+
+							# Byte 6 of the extension is the SNI type.
+							set sni_type_offset [expr {$extension_start + 6}]
+							binary scan $tls_extensions @${sni_type_offset}S sni_type
+
+							# Type 0 is host_name.
+							if { $sni_type == "0" } {
+								# Bytes 7-8 of the extension are the SNI data (host_name)
+								# length.
+								set sni_len_offset [expr {$extension_start + 7}]
+								binary scan $tls_extensions @${sni_len_offset}S sni_len
+
+								# Bytes 9-$sni_len are the SNI data (host_name).
+								set sni_start [expr {$extension_start + 9}]
+								binary scan $tls_extensions @${sni_start}A${sni_len} tls_servername
+							}
+						}
+
+						incr extension_start $extension_len
+					}
+
+					if { [info exists tls_servername] } {
+						set servername_lower [string tolower $tls_servername]
+						SSL::disable serverside
+						if { [class match $servername_lower equals ssl_passthrough_servername_dg] } {
+							pool [class match -value $servername_lower equals ssl_passthrough_servername_dg]
+							SSL::disable
+							HTTP::disable
+						}
+						elseif { [class match $servername_lower equals ssl_reencrypt_servername_dg] } {
+							pool [class match -value $servername_lower equals ssl_reencrypt_servername_dg]
+							SSL::enable serverside
+						}
+					}
+				}
+			}
+		}
+	}
+
+	TCP::release
+}
+`
+	return iRuleCode
+}
+
+func (appMgr *Manager) updatePassthroughRouteDataGroups(
+	partition string,
+	poolName string,
+	hostName string,
+) (bool, error) {
+
+	changed := false
+	key := nameRef{
+		Name:      passthroughHostsDgName,
+		Partition: partition,
+	}
+
+	appMgr.intDgMutex.Lock()
+	defer appMgr.intDgMutex.Unlock()
+	hostDg, found := appMgr.intDgMap[key]
+	if false == found {
+		return false, fmt.Errorf("Internal Data-group /%s/%s does not exist.",
+			partition, passthroughHostsDgName)
+	}
+
+	if hostDg.AddOrUpdateRecord(hostName, poolName) {
+		changed = true
+	}
+
+	return changed, nil
+}
+
+func updateDataGroupForRoute(
+	route *routeapi.Route,
+	partition string,
+	dgMap InternalDataGroupMap,
+) {
+	hostName := route.Spec.Host
+	poolName := formatRoutePoolName(route)
+	updateDataGroup(dgMap, passthroughHostsDgName,
+		partition, hostName, poolName)
+}
+
+func updateDataGroup(
+	intDgMap InternalDataGroupMap,
+	name string,
+	partition string,
+	key string,
+	value string,
+) {
+	mapKey := nameRef{
+		Name:      name,
+		Partition: partition,
+	}
+	dg, found := intDgMap[mapKey]
+	if found {
+		dg.AddOrUpdateRecord(key, value)
+	} else {
+		newDg := InternalDataGroup{
+			Name:      name,
+			Partition: partition,
+		}
+		newDg.AddOrUpdateRecord(key, value)
+		intDgMap[mapKey] = &newDg
+	}
+}
+
+func (appMgr *Manager) updateRouteDataGroups(
+	stats *vsSyncStats,
+	dgMap InternalDataGroupMap,
+) {
+	appMgr.intDgMutex.Lock()
+	defer appMgr.intDgMutex.Unlock()
+
+	for _, grp := range dgMap {
+		mapKey := nameRef{
+			Name:      grp.Name,
+			Partition: grp.Partition,
+		}
+		dg, found := appMgr.intDgMap[mapKey]
+		if found {
+			if !reflect.DeepEqual(dg.Records, grp.Records) {
+				dg.Records = grp.Records
+				stats.dgUpdated += 1
+			}
+		} else {
+			appMgr.intDgMap[mapKey] = grp
+		}
+	}
 }

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -19,11 +19,13 @@ package appmanager
 type (
 	// Config of all resources to configure on the BIG-IP
 	BigIPConfig struct {
-		Virtuals       []Virtual       `json:"virtualServers,omitempty"`
-		Pools          []Pool          `json:"pools,omitempty"`
-		Monitors       []Monitor       `json:"monitors,omitempty"`
-		Policies       []Policy        `json:"l7Policies,omitempty"`
-		CustomProfiles []CustomProfile `json:"customProfiles,omitempty"`
+		Virtuals           []Virtual           `json:"virtualServers,omitempty"`
+		Pools              []Pool              `json:"pools,omitempty"`
+		Monitors           []Monitor           `json:"monitors,omitempty"`
+		Policies           []Policy            `json:"l7Policies,omitempty"`
+		CustomProfiles     []CustomProfile     `json:"customProfiles,omitempty"`
+		IRules             []IRule             `json:"iRules,omitempty"`
+		InternalDataGroups []InternalDataGroup `json:"internalDataGroups,omitempty"`
 	}
 
 	// Config for a single resource (ConfigMap or Ingress)
@@ -55,6 +57,7 @@ type (
 		VirtualAddress *virtualAddress `json:"virtualAddress,omitempty"`
 		SslProfile     *sslProfile     `json:"sslProfile,omitempty"`
 		Policies       []nameRef       `json:"policies,omitempty"`
+		IRules         []string        `json:"rules,omitempty"`
 
 		// iApp parameters
 		IApp                string                    `json:"iapp,omitempty"`
@@ -228,4 +231,27 @@ type (
 		ServicePort int32
 		Namespace   string
 	}
+
+	// iRules
+	IRule struct {
+		Name      string `json:"name"`
+		Partition string `json:"partition"`
+		Code      string `json:"apiAnonymous"`
+	}
+
+	IRulesMap map[nameRef]*IRule
+
+	InternalDataGroup struct {
+		Name      string                   `json:"name"`
+		Partition string                   `json:"partition"`
+		Records   InternalDataGroupRecords `json:"records"`
+	}
+
+	InternalDataGroupRecord struct {
+		Name string `json:"name"`
+		Data string `json:"data"`
+	}
+	InternalDataGroupRecords []InternalDataGroupRecord
+
+	InternalDataGroupMap map[nameRef]*InternalDataGroup
 )

--- a/python/bigipconfigdriver.py
+++ b/python/bigipconfigdriver.py
@@ -487,7 +487,9 @@ def create_ltm_config_kubernetes(partition, config):
         'l7Policies': [],
         'pools': [],
         'monitors': [],
-        'iapps': []
+        'iapps': [],
+        'iRules': [],
+        'internalDataGroups': []
     }
 
     f5_services = {}
@@ -507,6 +509,18 @@ def create_ltm_config_kubernetes(partition, config):
             del monitor['partition']
 
             configuration['monitors'].append(monitor)
+
+    # reformat iRules
+    for irule in config.get('iRules', []):
+        if irule.get('partition', None) == partition:
+            del irule['partition']
+            configuration['iRules'].append(irule)
+
+    # reformat internalDataGroups
+    for idg in config.get('internalDataGroups', []):
+        if idg.get('partition', None) == partition:
+            del idg['partition']
+            configuration['internalDataGroups'].append(idg)
 
     svcs = config['virtualServers']
     for svc in svcs:
@@ -534,6 +548,7 @@ def create_ltm_config_kubernetes(partition, config):
             continue
 
         f5_service['name'] = vs_name
+        f5_service['rules'] = svc.get('rules', [])
 
         if 'iapp' in svc:
             cfg = {'tables': []}

--- a/python/tests/kubernetes_invalid_svcs_expected.json
+++ b/python/tests/kubernetes_invalid_svcs_expected.json
@@ -1,6 +1,8 @@
 {
     "ltm": {
         "iapps": [],
+        "internalDataGroups": [],
+        "iRules": [],
         "l7Policies": [],
         "monitors": [],
         "pools": [
@@ -41,6 +43,7 @@
                         "partition": "Common"
                     }
                 ],
+                "rules": [],
                 "sourceAddressTranslation": {
                     "type": "automap"
                 },
@@ -54,6 +57,7 @@
                 "policies": [],
                 "pool": "invalid_sslProfile1_configmap",
                 "profiles": [],
+                "rules": [],
                 "sourceAddressTranslation": {
                     "type": "automap"
                 },

--- a/python/tests/kubernetes_no_apps_expected.json
+++ b/python/tests/kubernetes_no_apps_expected.json
@@ -1,6 +1,8 @@
 {
     "ltm": {
         "iapps": [],
+        "internalDataGroups": [],
+        "iRules": [],
         "l7Policies": [],
         "monitors": [],
         "pools": [],

--- a/python/tests/kubernetes_one_iapp_expected.json
+++ b/python/tests/kubernetes_one_iapp_expected.json
@@ -63,6 +63,8 @@
                 ]
             }
         ],
+        "internalDataGroups": [],
+        "iRules": [],
         "l7Policies": [],
         "monitors": [],
         "pools": [],

--- a/python/tests/kubernetes_one_svc_four_nodes_expected.json
+++ b/python/tests/kubernetes_one_svc_four_nodes_expected.json
@@ -1,6 +1,8 @@
 {
     "ltm": {
         "iapps": [],
+        "internalDataGroups": [],
+        "iRules": [],
         "l7Policies": [],
         "monitors": [],
         "pools": [
@@ -45,6 +47,7 @@
                         "partition": "Common"
                     }
                 ],
+                "rules": [],
                 "sourceAddressTranslation": {
                     "type": "automap"
                 },

--- a/python/tests/kubernetes_one_svc_one_node_expected.json
+++ b/python/tests/kubernetes_one_svc_one_node_expected.json
@@ -1,6 +1,8 @@
 {
     "ltm": {
         "iapps": [],
+        "internalDataGroups": [],
+        "iRules": [],
         "l7Policies": [],
         "monitors": [],
         "pools": [
@@ -30,6 +32,7 @@
                         "partition": "Common"
                     }
                 ],
+                "rules": [],
                 "sourceAddressTranslation": {
                     "type": "automap"
                 },

--- a/python/tests/kubernetes_one_svc_two_nodes.json
+++ b/python/tests/kubernetes_one_svc_two_nodes.json
@@ -52,6 +52,8 @@
         "send": "GET /",
         "timeout": 5
       }
-    ]
+    ],
+    "iRules": [],
+    "internalDataGroups": []
   }
 }

--- a/python/tests/kubernetes_one_svc_two_nodes_expected.json
+++ b/python/tests/kubernetes_one_svc_two_nodes_expected.json
@@ -1,6 +1,8 @@
 {
     "ltm": {
         "iapps": [],
+        "internalDataGroups": [],
+        "iRules": [],
         "l7Policies": [],
         "monitors": [
             {
@@ -62,6 +64,7 @@
                         "partition": "Common"
                     }
                 ],
+                "rules": [],
                 "sourceAddressTranslation": {
                     "type": "automap"
                 },

--- a/python/tests/kubernetes_one_svc_two_nodes_pool_only_expected.json
+++ b/python/tests/kubernetes_one_svc_two_nodes_pool_only_expected.json
@@ -1,6 +1,8 @@
 {
     "ltm": {
         "iapps": [],
+        "internalDataGroups": [],
+        "iRules": [],
         "l7Policies": [],
         "monitors": [
             {


### PR DESCRIPTION
Problem:
The controller needs to support SSL passthrough termination to achieve
paritiy with the OpenShift F5 Router.

Solution:
SSL passthrough is achieved by using an iRule to look at the SNI
information to get the target server name. The iRule uses internal
data groups that contain information that allows the iRule to map the
server name to the correct pool and then pass the connection through
unencrypted to that pool. The iRule itself was copied from the
OpenShift F5 Router verbatim. To support all of this new functionality,
the controller was modified as follows:
1. Added support for the 'iRules' section in the output configuration.
2. Updated the Virtual struct to include an array of fully-qualified
   iRule names in the form of '/Partition/iRuleName'.
3. Added support for the 'internalDataGroups' section in the output
   configuration.
4. Create an up to date list for the mapping of server name to pool
   every time a route may have changed, which may trigger a new config
   to be written.
5. Added the appropriate handling of 'termination-type' ==
   'passthrough', which exposed some cases where type 'edge' was being
   incorrectly assumed.
6. Updated the bigipconfigdriver to pass the new iRule and internal
data group information through to CCCL.

Fixes VEL-1012

affects-branches: master