### PR TITLE
Add rbac sample configs

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -359,6 +359,10 @@ Example Configuration Files
 - `simple-ingress-fanout.yaml <./_static/config_examples/simple-ingress-fanout.yaml>`_
 - `name-based-ingress.yaml <./_static/config_examples/name-based-ingress.yaml>`_
 - `ingress-with-health-monitors.yaml <./_static/config_examples/ingress-with-health-monitors.yaml>`_
+- `sample-rbac-clusterrole.yaml <./_static/config_examples/sample-rbac-clusterrole.yaml>`_
+- `sample-rbac-clusterrolebinding.yaml <./_static/config_examples/sample-rbac-clusterrolebinding.yaml>`_
+- `sample-rbac-serviceaccount.yaml <./_static/config_examples/sample-rbac-serviceaccount.yaml>`_
+- `sample-rbac-cc-deployment.yaml <./_static/config_examples/sample-rbac-cc-deployment.yaml>`_
 
 
 .. [#objectpartition]  The |kctlr-long| creates and manages objects in the BIG-IP partition defined in the `F5 resource </containers/v1/kubernetes/index.html#f5-resource-properties>`_ ConfigMap.

--- a/docs/_static/config_examples/sample-rbac-cc-deployment.yaml
+++ b/docs/_static/config_examples/sample-rbac-cc-deployment.yaml
@@ -1,0 +1,37 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: k8s-bigip-ctlr-deployment
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: k8s-bigip-ctlr
+      labels:
+        app: k8s-bigip-ctlr
+    spec:
+      # the serviceAccountName is used only in rbac clusters
+      serviceAccountName: bigip-ctlr-serviceaccount
+      containers:
+        - name: k8s-bigip-ctlr
+          # replace the version as needed
+          image: "f5networks/k8s-bigip-ctlr:1.1.0"
+          env:
+            - name: BIGIP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: bigip-login
+                  key: username
+            - name: BIGIP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: bigip-login
+                  key: password
+          command: ["/app/bin/k8s-bigip-ctlr"]
+          args: [
+            "--bigip-username=$(BIGIP_USERNAME)",
+            "--bigip-password=$(BIGIP_PASSWORD)",
+            "--bigip-url=10.190.24.27",
+            "--bigip-partition=kubernetes"
+            ]

--- a/docs/_static/config_examples/sample-rbac-clusterrole.yaml
+++ b/docs/_static/config_examples/sample-rbac-clusterrole.yaml
@@ -1,0 +1,47 @@
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: bigip-ctlr-clusterrole
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions
+  resources:
+  - ingresses
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - events
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+  - patch
+- apiGroups:
+  - "extensions"
+  resources:
+  - ingresses/status
+  verbs:
+  - get
+  - list
+  - watch
+  - update
+  - create
+  - patch

--- a/docs/_static/config_examples/sample-rbac-clusterrolebinding.yaml
+++ b/docs/_static/config_examples/sample-rbac-clusterrolebinding.yaml
@@ -1,0 +1,13 @@
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: bigip-ctlr-clusterrole-binding
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: bigip-ctlr-clusterrole
+subjects:
+- kind: ServiceAccount
+  name: bigip-ctlr-serviceaccount
+  namespace: kube-system

--- a/docs/_static/config_examples/sample-rbac-serviceaccount.yaml
+++ b/docs/_static/config_examples/sample-rbac-serviceaccount.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bigip-ctlr-serviceaccount
+  namespace: kube-system


### PR DESCRIPTION
Problem:
Sample configs for using k8s-bigip-ctlr with rbac (k8s >= 1.6) were not included.

Solution:
Added sample configs.

Testing:
Tested existing document examples in a k8s 1.6 kubeadm deployment.