### PR TITLE
Remove default pool for Ingress and Routes

### DIFF
--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -569,9 +569,6 @@ func createRSConfigFromIngress(ing *v1beta1.Ingress,
 		rules := processIngressRules(&ing.Spec, cfg.Pools, cfg.Virtual.Partition)
 		plcy := createPolicy(*rules, cfg.Virtual.VirtualServerName, cfg.Virtual.Partition)
 		cfg.SetPolicy(*plcy)
-		if nil != cfg.Pools {
-			cfg.Virtual.PoolName = fmt.Sprintf("/%s/%s", cfg.Virtual.Partition, cfg.Pools[0].Name)
-		}
 	} else { // single-service
 		pool := Pool{
 			Name:        cfg.Virtual.VirtualServerName,
@@ -698,7 +695,6 @@ func createRSConfigFromRoute(
 			rsCfg.Virtual.VirtualAddress.BindAddr = routeConfig.RouteVSAddr
 		}
 		rsCfg.Pools = append(rsCfg.Pools, pool)
-		rsCfg.Virtual.PoolName = fmt.Sprintf("/%s/%s", rsCfg.Virtual.Partition, pool.Name)
 
 		if pStruct.protocol == "http" {
 			if nil == tls || len(tls.Termination) == 0 {

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -47,7 +47,7 @@ type (
 	// Virtual server config
 	Virtual struct {
 		VirtualServerName string `json:"name"`
-		PoolName          string `json:"pool"`
+		PoolName          string `json:"pool,omitempty"`
 		// Mutual parameter, partition
 		Partition string `json:"partition"`
 

--- a/python/bigipconfigdriver.py
+++ b/python/bigipconfigdriver.py
@@ -507,8 +507,6 @@ def create_ltm_config_kubernetes(partition, config):
 
             configuration['iapps'].append(iapp)
         else:
-            f5_service['pool'] = {}
-
             # Parse the SSL profile into partition and name
             if 'sslProfile' in svc:
                 # The sslProfile item can be empty or have either
@@ -550,11 +548,12 @@ def create_ltm_config_kubernetes(partition, config):
                     'enabled': True,
                     'ipProtocol': get_protocol(svc['mode']),
                     'destination': destination,
-                    'pool': "%s" % (svc['pool']),
                     'sourceAddressTranslation': {'type': 'automap'},
                     'profiles': profiles,
                     'policies': policies
                 })
+                if 'pool' in svc:
+                    f5_service['pool'] = str(svc['pool'])
             f5_services.update({vs_name: f5_service})
 
             if f5_service.get('destination', None) is not None:


### PR DESCRIPTION
Problem: Default pools were being set on virtual servers for Ingress
and Route configuration. This would mean that if traffic for a specific host/path
didn't match any rules, it would still be forwarded to the default pool. This is
incorrect behavior. If traffic doesn't match a rule, then it shouldn't go to any pool.

Solution: Remove the default pool in the case of multi-service Ingress and Routes.

Fixes #288