### PR TITLE
Add node label selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Prerequisites:
 git clone https://github.com/f5networks/k8s-bigip-ctlr.git
 cd  k8s-bigip-ctlr
 
-# Use docker to build the release artifacts, into a local "_docker_workspace" directory, then put into docker iamges
+# Use docker to build the release artifacts, into a local "_docker_workspace" directory, then put into docker images
 # Alpine image
 make prod
 

--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -72,13 +72,14 @@ var (
 	verifyInterval   *int
 	nodePollInterval *int
 
-	namespaces      *[]string
-	useNodeInternal *bool
-	poolMemberType  *string
-	inCluster       *bool
-	kubeConfig      *string
-	namespaceLabel  *string
-	manageRoutes    *bool
+	namespaces        *[]string
+	useNodeInternal   *bool
+	poolMemberType    *string
+	inCluster         *bool
+	kubeConfig        *string
+	namespaceLabel    *string
+	manageRoutes      *bool
+	nodeLabelSelector *string
 
 	bigIPURL        *string
 	bigIPUsername   *string
@@ -151,6 +152,8 @@ func _init() {
 		"Optional, used to watch for namespaces with this label")
 	manageRoutes = kubeFlags.Bool("manage-routes", false,
 		"Optional, specify whether or not to manage Route resources")
+	nodeLabelSelector = kubeFlags.String("node-label-selector", "",
+		"Optional, used to watch only for nodes with this label")
 
 	kubeFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  Kubernetes:\n%s\n", kubeFlags.FlagUsages())
@@ -456,7 +459,7 @@ func main() {
 
 	if isNodePort || 0 != len(openshiftSDNMode) {
 		intervalFactor := time.Duration(*nodePollInterval)
-		np := pollers.NewNodePoller(appMgrParms.KubeClient, intervalFactor*time.Second)
+		np := pollers.NewNodePoller(appMgrParms.KubeClient, intervalFactor*time.Second, *nodeLabelSelector)
 		err := setupNodePolling(appMgr, np)
 		if nil != err {
 			log.Fatalf("Required polling utility for node updates failed setup: %v",


### PR DESCRIPTION
Problem: If you use `nodeport` (which is the default) per default all nodes from the cluster will be added to the pool. In some cases you only want to use a subset of these nodes (e.q. only nodes with the label `node-role.kubernetes.io/node`) because not all nodes are reachable by the F5 or the nodes are already managed by F5 (but nor the Plugin). Currently we use to F5 to load balance traffic to the API servers (HA setup), this means that the Kubernetes master nodes are already present in F5 if you start the bigip-ctlr without a nodeLabelSelector the creation of the node pool for Kubernetes will fail since the bigip-ctlr can't create nodes that are already present.