### PR TITLE
Use iRule to support http redirect in 11.6.1

### DIFF
--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -3417,9 +3417,10 @@ func TestIngressSslProfile(t *testing.T) {
 
 	// No annotations were specified to control http redirect, check that
 	// we are in the default state 2.
-	require.Equal(1, len(httpCfg.Policies))
-	require.Equal(1, len(httpCfg.Policies[0].Rules))
-	assert.Equal(httpRedirectRuleName, httpCfg.Policies[0].Rules[0].Name)
+	require.Equal(1, len(httpCfg.Virtual.IRules))
+	expectedIRuleName := fmt.Sprintf("/%s/%s",
+		DEFAULT_PARTITION, httpRedirectIRuleName)
+	assert.Equal(expectedIRuleName, httpCfg.Virtual.IRules[0])
 
 	// Set the annotations the same as default and recheck
 	fooIng.ObjectMeta.Annotations[ingressSslRedirect] = "true"
@@ -3429,9 +3430,10 @@ func TestIngressSslProfile(t *testing.T) {
 	assert.True(found)
 	require.NotNil(httpCfg)
 	assert.True(r, "Ingress resource should be processed")
-	require.Equal(1, len(httpCfg.Policies))
-	require.Equal(1, len(httpCfg.Policies[0].Rules))
-	assert.Equal(httpRedirectRuleName, httpCfg.Policies[0].Rules[0].Name)
+	require.Equal(1, len(httpCfg.Virtual.IRules))
+	expectedIRuleName = fmt.Sprintf("/%s/%s",
+		DEFAULT_PARTITION, httpRedirectIRuleName)
+	assert.Equal(expectedIRuleName, httpCfg.Virtual.IRules[0])
 
 	// Now test state 1.
 	fooIng.ObjectMeta.Annotations[ingressSslRedirect] = "false"
@@ -3759,9 +3761,10 @@ func TestPassthroughRoute(t *testing.T) {
 	require.True(ok, "Route should be accessible")
 	require.NotNil(rs, "Route should be object")
 	assert.True(rs.MetaData.Active)
-	assert.Equal(1, len(rs.Policies))
-	assert.Equal(1, len(rs.Policies[0].Rules))
-	assert.Equal(httpRedirectRuleName, rs.Policies[0].Rules[0].Name)
+	require.Equal(1, len(rs.Virtual.IRules))
+	expectedIRuleName = fmt.Sprintf("/%s/%s",
+		DEFAULT_PARTITION, httpRedirectIRuleName)
+	assert.Equal(expectedIRuleName, rs.Virtual.IRules[0])
 
 	// Delete a Route resource and make sure the data groups are cleaned up.
 	r = appMgr.deleteRoute(route2)

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -603,6 +603,8 @@ func createRSConfigFromRoute(
 	}
 	passThroughRuleName := fmt.Sprintf("/%s/%s",
 		DEFAULT_PARTITION, sslPassthroughIRuleName)
+	redirectIRuleName := fmt.Sprintf("/%s/%s",
+		DEFAULT_PARTITION, httpRedirectIRuleName)
 
 	// Create the pool
 	pool := Pool{
@@ -661,14 +663,12 @@ func createRSConfigFromRoute(
 							rsCfg.AddRuleToPolicy(policyName, rule)
 						} else if tls.InsecureEdgeTerminationPolicy ==
 							routeapi.InsecureEdgeTerminationPolicyRedirect {
-							rule = newHttpRedirectPolicyRule(DEFAULT_HTTPS_PORT)
-							rsCfg.AddRuleToPolicy(policyName, rule)
+							rsCfg.Virtual.AddIRule(redirectIRuleName)
 						}
 					case routeapi.TLSTerminationPassthrough:
 						if tls.InsecureEdgeTerminationPolicy ==
 							routeapi.InsecureEdgeTerminationPolicyRedirect {
-							rule = newHttpRedirectPolicyRule(DEFAULT_HTTPS_PORT)
-							rsCfg.AddRuleToPolicy(policyName, rule)
+							rsCfg.Virtual.AddIRule(redirectIRuleName)
 						}
 					}
 				}
@@ -707,14 +707,12 @@ func createRSConfigFromRoute(
 						rsCfg.AddRuleToPolicy(policyName, rule)
 					} else if tls.InsecureEdgeTerminationPolicy ==
 						routeapi.InsecureEdgeTerminationPolicyRedirect {
-						rule = newHttpRedirectPolicyRule(DEFAULT_HTTPS_PORT)
-						rsCfg.AddRuleToPolicy(policyName, rule)
+						rsCfg.Virtual.AddIRule(redirectIRuleName)
 					}
 				case routeapi.TLSTerminationPassthrough:
 					if tls.InsecureEdgeTerminationPolicy ==
 						routeapi.InsecureEdgeTerminationPolicyRedirect {
-						rule = newHttpRedirectPolicyRule(DEFAULT_HTTPS_PORT)
-						rsCfg.AddRuleToPolicy(policyName, rule)
+						rsCfg.Virtual.AddIRule(redirectIRuleName)
 					}
 				}
 			}


### PR DESCRIPTION
Problem: The action location parameter for our https redirect rule only
works in BIG-IP version 12.0.0+. Version 11.6.1 has a different format.

Solution: Use a generic iRule instead of a policy rule to set the http
redirect. This works in both BIG-IP versions.