### PR TITLE
Additional Dockerfile steps for RHEL based image

### DIFF
--- a/build-tools/Dockerfile.rhel7.runtime
+++ b/build-tools/Dockerfile.rhel7.runtime
@@ -5,6 +5,7 @@ LABEL name="f5networks/k8s-bigip-ctlr" \
       # version - should be passed in via docker build
       url="http://clouddocs.f5.com/products/connectors/k8s-bigip-ctlr/latest/" \
       summary="F5 BIG-IP Controller for Kubernetes" \
+      description="Manages F5 BIG-IP from Kubernetes" \
       run='docker run --name ${NAME} ${IMAGE} /app/bin/k8s-bigip-ctlr' \
       io.k8s.description="Manages F5 BIG-IP from Kubernetes" \
       io.k8s.display-name="F5 BIG-IP Controller for Kubernetes" \
@@ -18,15 +19,19 @@ RUN mkdir -p "$APPPATH/bin" \
 
 WORKDIR $APPPATH
 
+COPY help.md /tmp/
+COPY LICENSE /licenses/
 COPY k8s-runtime-requirements.txt /tmp/k8s-runtime-requirements.txt
 
 RUN microdnf --enablerepo=rhel-7-server-rpms --enablerepo=rhel-7-server-optional-rpms \
-      --enablerepo=rhel-server-rhscl-7-rpms install --nodocs python27-python-pip git && \
+      --enablerepo=rhel-server-rhscl-7-rpms install --nodocs \
+      golang-github-cpuguy83-go-md2man python27-python-pip git && \
+    go-md2man -in /tmp/help.md -out /help.1 && rm -f /tmp/help.md && \
     source scl_source enable python27 && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r /tmp/k8s-runtime-requirements.txt && \
     python -m pip uninstall -y pip setuptools && \
-    microdnf remove git fipscheck fipscheck-lib groff-base \
+    microdnf remove golang-github-cpuguy83-go-md2man git fipscheck fipscheck-lib groff-base \
       less libedit libgnome-keyring openssh openssh-clients perl perl-Carp perl-Encode \
       perl-Error perl-Exporter perl-File-Path perl-File-Temp perl-Filter perl-Getopt-Long \
       perl-Git perl-HTTP-Tiny perl-PathTools perl-Pod-Escapes perl-Pod-Perldoc perl-Pod-Simple \

--- a/build-tools/build-release-images.sh
+++ b/build-tools/build-release-images.sh
@@ -20,6 +20,8 @@ mkdir -p $WKDIR/python
 cp python/*.py $WKDIR/python/
 cp python/k8s-runtime-requirements.txt $WKDIR/
 cp schemas/bigip-virtual-server_v*.json $WKDIR/
+cp LICENSE $WKDIR/
+cp $CURDIR/help.md $WKDIR/help.md
 
 echo "Docker build context:"
 ls -la $WKDIR

--- a/build-tools/help.md
+++ b/build-tools/help.md
@@ -1,0 +1,5 @@
+For detailed information on running the F5 BIG-IP Controller for Kubernetes, see the official
+documents located at:
+http://clouddocs.f5.com/containers/v1/kubernetes/
+and
+http://clouddocs.f5.com/containers/v1/openshift/


### PR DESCRIPTION
Problem: There are a few additional pieces for the RHEL based image
to meet expectations, including the license and help.md files.

Solution: Add the license, help.md, and an additional description label
to the built release image.