### PR TITLE
Add support for re-encryption termination for OpenShift routes.

### DIFF
--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -59,15 +59,14 @@ func (appMgr *Manager) outputConfigLocked() {
 
 	// To allow the ssl passthrough iRule to be associated with a virtual,
 	// it must have at least one client or server SSL profile associated with
-	// it. We currently only support client SSL profiles, so if the virtual
-	// does not have any client SSL profiles AND references the iRule then
-	// we force it to take the BIG-IP's base client SSL profile in the output
-	// config.
+	// it. If the virtual doesn't have any of either type, we force it to take
+	// the BIG-IP's base client SSL profile in the output config.
 	for vKey, virtual := range resources.Virtuals {
 		for _, irule := range virtual.IRules {
 			if strings.Contains(irule, sslPassthroughIRuleName) {
-				clientSslProfiles := virtual.GetFrontendSslProfileNames()
-				if len(clientSslProfiles) == 0 {
+				clientProfCt := virtual.GetProfileCountByContext(customProfileClient)
+				serverProfCt := virtual.GetProfileCountByContext(customProfileServer)
+				if 0 == clientProfCt && 0 == serverProfCt {
 					sslProf := "Common/clientssl"
 					resources.Virtuals[vKey].AddFrontendSslProfileName(sslProf)
 				}

--- a/pkg/appmanager/routing_test.go
+++ b/pkg/appmanager/routing_test.go
@@ -1,0 +1,115 @@
+/*-
+ * Copyright (c) 2017, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package appmanager
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/F5Networks/k8s-bigip-ctlr/pkg/test"
+
+	routeapi "github.com/openshift/origin/pkg/route/api"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestRouteOrdering(t *testing.T) {
+	mw := &test.MockWriter{
+		FailStyle: test.Success,
+		Sections:  make(map[string]interface{}),
+	}
+	require := require.New(t)
+	assert := assert.New(t)
+	fakeClient := fake.NewSimpleClientset()
+	require.NotNil(fakeClient, "Mock client should not be nil")
+
+	appMgr := newMockAppManager(&Params{
+		KubeClient:    fakeClient,
+		ConfigWriter:  mw,
+		restClient:    test.CreateFakeHTTPClient(),
+		RouteClientV1: test.CreateFakeHTTPClient(),
+		IsNodePort:    true,
+	})
+	err := appMgr.startNonLabelMode([]string{"test"})
+	require.Nil(err)
+	defer appMgr.shutdown()
+
+	namespace := "test"
+	type testData struct {
+		serviceName string
+		hostName    string
+		path        string
+	}
+	sortedTestData := []testData{
+		{
+			serviceName: "bar",
+			hostName:    "barfoo.com",
+			path:        "/bar",
+		}, {
+			serviceName: "foo",
+			hostName:    "foobar.com",
+			path:        "/foo",
+		}, {
+			serviceName: "foo",
+			hostName:    "foobar.com",
+			path:        "/foo/bar",
+		}, {
+			serviceName: "foo",
+			hostName:    "foobar.com",
+			path:        "/foo/bar/bay",
+		}, {
+			serviceName: "foo",
+			hostName:    "foobar.com",
+			path:        "/foo/bar/baz",
+		},
+	}
+
+	unsortedTestData := []testData{
+		sortedTestData[4],
+		sortedTestData[1],
+		sortedTestData[0],
+		sortedTestData[3],
+		sortedTestData[2],
+	}
+
+	for i, td := range unsortedTestData {
+		routeName := fmt.Sprintf("route%d", i)
+		spec := routeapi.RouteSpec{
+			Host: td.hostName,
+			Path: td.path,
+			To: routeapi.RouteTargetReference{
+				Kind: "Service",
+				Name: td.serviceName,
+			},
+			TLS: &routeapi.TLSConfig{
+				Termination: routeapi.TLSTerminationEdge,
+			},
+		}
+		ok := appMgr.addRoute(test.NewRoute(routeName, "1", namespace, spec))
+		assert.True(ok, "Route resource should be processed")
+	}
+
+	appInf, _ := appMgr.appMgr.getNamespaceInformer(namespace)
+	routes, err := appInf.getOrderedRoutes(namespace)
+	assert.Nil(err)
+	assert.Equal(len(sortedTestData), len(routes))
+	for i, route := range routes {
+		assert.Equal(sortedTestData[i].hostName, route.Spec.Host)
+		assert.Equal(sortedTestData[i].path, route.Spec.Path)
+	}
+}

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -44,6 +44,14 @@ type (
 		ResourceType string
 	}
 
+	// Reference to pre-existing profiles
+	ProfileRef struct {
+		Name      string `json:"name"`
+		Partition string `json:"partition"`
+		Context   string `json:"context"` // 'clientside', 'serverside', or 'all'
+	}
+	ProfileRefs []ProfileRef
+
 	// Virtual server config
 	Virtual struct {
 		VirtualServerName string `json:"name"`
@@ -58,6 +66,8 @@ type (
 		SslProfile     *sslProfile     `json:"sslProfile,omitempty"`
 		Policies       []nameRef       `json:"policies,omitempty"`
 		IRules         []string        `json:"rules,omitempty"`
+		// FIXME: All profiles should reside in Profiles, just server ssl ones now.
+		Profiles ProfileRefs `json:"profiles,omitempty"`
 
 		// iApp parameters
 		IApp                string                    `json:"iapp,omitempty"`
@@ -182,10 +192,11 @@ type (
 		Rows    [][]string `json:"rows,omitempty"`
 	}
 
-	// Client SSL Profile loaded from Secret
+	// SSL Profile loaded from Secret or Route object
 	CustomProfile struct {
 		Name       string `json:"name"`
 		Partition  string `json:"partition"`
+		Context    string `json:"context"` // 'clientside', 'serverside', or 'all'
 		Cert       string `json:"cert"`
 		Key        string `json:"key"`
 		ServerName string `json:"serverName,omitempty"`

--- a/python/tests/kubernetes_invalid_svcs_expected.json
+++ b/python/tests/kubernetes_invalid_svcs_expected.json
@@ -39,6 +39,7 @@
                 "pool": "invalid_sslProfile0_configmap",
                 "profiles": [
                     {
+                        "context": "all",
                         "name": "tcp",
                         "partition": "Common"
                     }

--- a/python/tests/kubernetes_one_svc_four_nodes_expected.json
+++ b/python/tests/kubernetes_one_svc_four_nodes_expected.json
@@ -43,6 +43,7 @@
                 "pool": "/k8s/default_configmap",
                 "profiles": [
                     {
+                        "context": "all",
                         "name": "http",
                         "partition": "Common"
                     }

--- a/python/tests/kubernetes_one_svc_one_node_expected.json
+++ b/python/tests/kubernetes_one_svc_one_node_expected.json
@@ -28,6 +28,7 @@
                 "pool": "/k8s/default_configmap",
                 "profiles": [
                     {
+                        "context": "all",
                         "name": "http",
                         "partition": "Common"
                     }

--- a/python/tests/kubernetes_one_svc_two_nodes_expected.json
+++ b/python/tests/kubernetes_one_svc_two_nodes_expected.json
@@ -52,14 +52,17 @@
                 "pool": "/k8s/default_configmap",
                 "profiles": [
                     {
+                        "context": "clientside",
                         "name": "clientssl",
                         "partition": "Common"
                     },
                     {
+                        "context": "clientside",
                         "name": "clientssl-secure",
                         "partition": "Common"
                     },
                     {
+                        "context": "all",
                         "name": "http",
                         "partition": "Common"
                     }


### PR DESCRIPTION
Problem:
Add support for OpenShift reencrypt routes

Solution:
The main focus of this fix is the addition of reencrypt route support
in OpenShift, which required several other changes:
1. Added server SSL profile support to bigipconfigdriver.py and
   refactored existing SSL profile related code for reuse.
2. Added support for server SSL profiles in the controller, including
   the ability to attach them to virtual servers.
3. To improve configuration consistency, route objects are now sorted
   before they are processed by syncRoutes(). The sort order is by
   namespace/service/path.
4. Refactored createRSConfigFromRoute() to better handle the
   commonality between create and update modes while adding support for
   reencrypt routes.
5. OutputConfigLocked() now looks at server profiles when satisfying
   the iRule requirement for the passthrough/reencrypt iRule.
6. Corrected the handling of insecureEdgeTerminationPolicy and
   passthrough routes, as the policy only applies to edge terminated
   routes.
7. Added unit tests as appropriate.

affects-branches: master