### PR TITLE
Add route label watcher; set backend port properly

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -88,9 +88,8 @@ var (
 	openshiftSDNMode string
 	openshiftSDNName *string
 
-	routeVserverAddr       *string
-	routeDefaultServerCert *string
-	routeLabel             *string
+	routeVserverAddr *string
+	routeLabel       *string
 
 	// package variables
 	isNodePort         bool
@@ -175,12 +174,9 @@ func _init() {
 	// OpenShift Route flags
 	routeVserverAddr = osRouteFlags.String("route-vserver-addr", "",
 		"Optional, bind address for virtual server for Route objects.")
-	routeDefaultServerCert = osRouteFlags.String("route-default-server-cert", "",
-		"Optional, default server cert for Route objects.")
 	routeLabel = osRouteFlags.String("route-label", "",
 		"Optional, label for which Route objects to watch.")
 	osRouteFlags.MarkHidden("route-vserver-addr")
-	osRouteFlags.MarkHidden("route-default-server-cert")
 	osRouteFlags.MarkHidden("route-label")
 
 	osRouteFlags.Usage = func() {
@@ -392,10 +388,13 @@ func main() {
 		log.Fatalf("Failed creating ConfigWriter tool: %v", err)
 	}
 	defer configWriter.Stop()
+
+	if len(*routeLabel) > 0 {
+		*routeLabel = fmt.Sprintf("f5type in (%s)", *routeLabel)
+	}
 	var routeConfig = appmanager.RouteConfig{
-		RouteVSAddr:     *routeVserverAddr,
-		RouteServerCert: *routeDefaultServerCert,
-		RouteLabel:      *routeLabel,
+		RouteVSAddr: *routeVserverAddr,
+		RouteLabel:  *routeLabel,
 	}
 
 	var appMgrParms = appmanager.Params{

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -3605,13 +3605,13 @@ func TestVirtualServerForRoute(t *testing.T) {
 	resources := appMgr.resources()
 	// Associate a service
 	fooSvc := test.NewService("foo", "1", namespace, "NodePort",
-		[]v1.ServicePort{{Port: 443, NodePort: 37001}})
+		[]v1.ServicePort{{Port: 80, NodePort: 37001}})
 	r = appMgr.addService(fooSvc)
 	assert.True(r, "Service should be processed")
 	require.Equal(2, resources.Count())
 
 	rs, ok := resources.Get(
-		serviceKey{"foo", 443, "default"}, "openshift_default_https")
+		serviceKey{"foo", 80, "default"}, "openshift_default_https")
 	require.True(ok, "Route should be accessible")
 	require.NotNil(rs, "Route should be object")
 	assert.True(rs.MetaData.Active)
@@ -3728,7 +3728,7 @@ func TestPassthroughRoute(t *testing.T) {
 	require.True(r, "Route resource should be processed")
 	resources = appMgr.resources()
 	barSvc := test.NewService(svcName2, "1", namespace, "NodePort",
-		[]v1.ServicePort{{Port: 80, NodePort: 37001}})
+		[]v1.ServicePort{{Port: 443, NodePort: 37001}})
 	appMgr.addService(barSvc)
 	r = assert.True(r, "Service should be processed")
 	assert.Equal(4, resources.Count())
@@ -3757,7 +3757,7 @@ func TestPassthroughRoute(t *testing.T) {
 	assert.Equal(formatRoutePoolName(route2), hostDg.Records[0].Data)
 
 	rs, ok = resources.Get(
-		serviceKey{svcName2, 80, namespace}, "openshift_default_http")
+		serviceKey{svcName2, 443, namespace}, "openshift_default_http")
 	require.True(ok, "Route should be accessible")
 	require.NotNil(rs, "Route should be object")
 	assert.True(rs.MetaData.Active)

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -504,12 +504,12 @@ func TestRouteConfiguration(t *testing.T) {
 		protocol: "https",
 		port:     443,
 	}
-	cfg, _ := createRSConfigFromRoute(route, Resources{}, RouteConfig{}, ps, 443)
+	cfg, _ := createRSConfigFromRoute(route, Resources{}, RouteConfig{}, ps)
 
 	require.Equal("openshift_default_https", cfg.Virtual.VirtualServerName)
 	require.Equal("openshift_default_foo", cfg.Pools[0].Name)
 	require.Equal("foo", cfg.Pools[0].ServiceName)
-	require.Equal(int32(443), cfg.Pools[0].ServicePort)
+	require.Equal(int32(80), cfg.Pools[0].ServicePort)
 	require.Equal("openshift_secure_routes", cfg.Policies[0].Name)
 	require.Equal("openshift_route_default_route", cfg.Policies[0].Rules[0].Name)
 
@@ -526,7 +526,7 @@ func TestRouteConfiguration(t *testing.T) {
 		protocol: "http",
 		port:     80,
 	}
-	cfg, _ = createRSConfigFromRoute(route2, Resources{}, RouteConfig{}, ps, 80)
+	cfg, _ = createRSConfigFromRoute(route2, Resources{}, RouteConfig{}, ps)
 
 	require.Equal("openshift_default_http", cfg.Virtual.VirtualServerName)
 	require.Equal("openshift_default_bar", cfg.Pools[0].Name)


### PR DESCRIPTION
Problem:
1. Need to add functionality for the route-label cli argument.
2. There is a bug when configuring routes using the first service port we see,
as all route configuratiosn end up using this port, which is wrong.

Solution:
1. Add a watcher for route labels if they are provided. The label on the Route config
should be of the format 'f5type: label', where label is provided in the --route-label cli
argument. Default is to watch all routes.
 - Also removed the route-default-server-cert argument, as it is not needed.

2. Set specific expectations around configuring the backend service port, rather than just
grabbing the first we see. The expectations are:
   - If a port is provided in the Route config, use it.
   - Else if the Route is of type passthrough or reencrypt, port is set to 443
   - Else port is set to 80
This allows for explicit port configuration for every Route, rather than the ambiguous behavior
of grabbing the first port we see.