### PR TITLE
Fix rhel7 devel permissions; keep setuptools

### DIFF
--- a/build-tools/Dockerfile.rhel7.runtime
+++ b/build-tools/Dockerfile.rhel7.runtime
@@ -30,7 +30,7 @@ RUN microdnf --enablerepo=rhel-7-server-rpms --enablerepo=rhel-7-server-optional
     source scl_source enable python27 && \
     pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir -r /tmp/k8s-runtime-requirements.txt && \
-    python -m pip uninstall -y pip setuptools && \
+    python -m pip uninstall -y pip && \
     microdnf remove golang-github-cpuguy83-go-md2man git fipscheck fipscheck-lib groff-base \
       less libedit libgnome-keyring openssh openssh-clients perl perl-Carp perl-Encode \
       perl-Error perl-Exporter perl-File-Path perl-File-Temp perl-Filter perl-Getopt-Long \

--- a/build-tools/run-in-docker.sh
+++ b/build-tools/run-in-docker.sh
@@ -22,8 +22,8 @@ mkdir -p $wkspace/$srcdir
 
 RUN_ARGS=( \
   --rm
-  -v $wkspace:/build
-  -v $PWD:/build/$srcdir:ro
+  -v $wkspace:/build:Z
+  -v $PWD:/build/$srcdir:ro,Z
   --workdir  /build/$srcdir
   -e GOPATH=/build
   -e CLEAN_BUILD="${CLEAN_BUILD}"


### PR DESCRIPTION
Problem: The devel image in rhel7 did not have permission to
access the filesystem. The release image in rhel7 was removing
setuptools, which is needed in CCCL.

Solution: Add the 'Z' flag to the Docker run volume mount. Keep setuptools
in the release image for CCCL to use.