### PR TITLE
Add OpenShift Route resources to product documentation.

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -151,7 +151,6 @@ func _init() {
 		"Optional, used to watch for namespaces with this label")
 	manageRoutes = kubeFlags.Bool("manage-routes", false,
 		"Optional, specify whether or not to manage Route resources")
-	kubeFlags.MarkHidden("manage-routes")
 
 	kubeFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  Kubernetes:\n%s\n", kubeFlags.FlagUsages())
@@ -176,8 +175,6 @@ func _init() {
 		"Optional, bind address for virtual server for Route objects.")
 	routeLabel = osRouteFlags.String("route-label", "",
 		"Optional, label for which Route objects to watch.")
-	osRouteFlags.MarkHidden("route-vserver-addr")
-	osRouteFlags.MarkHidden("route-label")
 
 	osRouteFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  Openshift Routes:\n%s\n", osRouteFlags.FlagUsages())

--- a/docs/_static/config_examples/sample-edge-route.yaml
+++ b/docs/_static/config_examples/sample-edge-route.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Route
+metadata:
+  labels:
+    name: svc1
+  name: svc1-route-edge
+  namespace: default
+spec:
+  host: svc1-route.local
+  path: "/test"
+  port:
+    targetPort: 443
+  tls:
+    certificate: |
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE-----
+    key: |
+      -----BEGIN PRIVATE KEY-----
+      -----END PRIVATE KEY-----
+    termination: edge
+    insecureEdgeTerminationPolicy: Allow
+  to:
+    kind: Service
+    name: svc1

--- a/docs/_static/config_examples/sample-passthrough-route.yaml
+++ b/docs/_static/config_examples/sample-passthrough-route.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Route
+metadata:
+  labels:
+    name: svc1
+  name: svc1-route-passthrough
+  namespace: default
+spec:
+  host: svc1-route.local
+  port:
+    targetPort: 443
+  tls:
+    termination: passthrough
+  to:
+    kind: Service
+    name: svc1

--- a/docs/_static/config_examples/sample-reencrypt-route.yaml
+++ b/docs/_static/config_examples/sample-reencrypt-route.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Route
+metadata:
+  labels:
+    name: svc1
+  name: svc1-route-reencrypt
+  namespace: default
+spec:
+  host: svc1-route.local
+  path: "/test"
+  port:
+    targetPort: https
+  tls:
+    certificate: |
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE-----
+    key: |
+      -----BEGIN PRIVATE KEY-----
+      -----END PRIVATE KEY-----
+    destinationCACertificate: |
+      -----BEGIN CERTIFICATE-----
+      -----END CERTIFICATE-----
+    termination: reencrypt
+  to:
+    kind: Service
+    name: svc1
+    weight: 100

--- a/docs/_static/config_examples/sample-unsecured-route.yaml
+++ b/docs/_static/config_examples/sample-unsecured-route.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Route
+metadata:
+  labels:
+    name: svc1
+  name: svc1-route-unsecured
+  namespace: default
+spec:
+  host: svc1-route.local
+  path: "/test"
+  port:
+    targetPort: 80
+  to:
+    kind: Service
+    name: svc1


### PR DESCRIPTION
Problem:
The product documention needs to be updated to cover OpenShift Route
resources.

Solution:
Added key information regarding OpenShift Routes to the product
documentation, including examples. Removed hidden attribute from new
controller parameters.

affects-branches: master