### PR TITLE
Fix SNIDefault for Routes

### DIFF
--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -317,6 +317,7 @@ func reformatCustomProfiles(resources PartitionMap, partition string, wg *sync.W
 	defer wg.Done()
 	for i, _ := range resources[partition].CustomProfiles {
 		resources[partition].CustomProfiles[i].Partition = ""
+		resources[partition].CustomProfiles[i].VSName = ""
 	}
 }
 

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -659,7 +659,13 @@ var _ = Describe("Resource Config Tests", func() {
 				{Partition: "test3", Name: "third", Context: customProfileClient},
 			}
 			for _, prof := range testData {
-				cprof := NewCustomProfile(prof, "")
+				cprof := NewCustomProfile(
+					prof,
+					"crt",
+					"key",
+					"srver",
+					"vs",
+					CustomProfileStore{})
 				refs := virtual.ReferencesProfile(cprof)
 				Expect(refs).To(BeFalse())
 			}
@@ -678,11 +684,24 @@ var _ = Describe("Resource Config Tests", func() {
 			for _, prof := range testData {
 				switch prof.Partition {
 				case "test1", "test3":
-					cprof := NewCustomProfile(prof, "")
+					cprof := NewCustomProfile(
+						prof,
+						"crt",
+						"key",
+						"srver",
+						"vs",
+						CustomProfileStore{},
+					)
 					refs := virtual.ReferencesProfile(cprof)
 					Expect(refs).To(BeTrue())
 				case "test2":
-					cprof := NewCustomProfile(prof, "")
+					cprof := NewCustomProfile(
+						prof,
+						"crt",
+						"key",
+						"srver",
+						"vs",
+						CustomProfileStore{})
 					refs := virtual.ReferencesProfile(cprof)
 					Expect(refs).To(BeFalse())
 				}

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -75,7 +75,7 @@ type (
 		Policies              []nameRef             `json:"policies,omitempty"`
 		IRules                []string              `json:"rules,omitempty"`
 		// FIXME: All profiles should reside in Profiles, just server ssl ones now.
-		Profiles              ProfileRefs           `json:"profiles,omitempty"`
+		Profiles ProfileRefs `json:"profiles,omitempty"`
 
 		// iApp parameters
 		IApp                string                    `json:"iapp,omitempty"`
@@ -235,6 +235,8 @@ type (
 		Cert       string `json:"cert"`
 		Key        string `json:"key"`
 		ServerName string `json:"serverName,omitempty"`
+		SNIDefault bool   `json:"sniDefault,omitempty"`
+		VSName     string `json:"-"` // virtual server that uses this profile
 	}
 
 	// Used to unmarshal ConfigMap data

--- a/python/bigipconfigdriver.py
+++ b/python/bigipconfigdriver.py
@@ -411,11 +411,12 @@ def _create_client_ssl_profile(mgmt, partition, profile):
                   'cert': '/Common/' + cert_name,
                   'key': '/Common/' + key_name}]
         serverName = profile.get('serverName', None)
+        sniDefault = profile.get('sniDefault', False)
         ssl_client_profile.create(name=name,
                                   partition=partition,
                                   certKeyChain=chain,
                                   serverName=serverName,
-                                  sniDefault=False,
+                                  sniDefault=sniDefault,
                                   defaultsFrom=None)
     except Exception as err:
         log.error("Error creating client SSL profile: %s" % err.message)
@@ -442,9 +443,13 @@ def _create_server_ssl_profile(mgmt, partition, profile):
 
     try:
         # create ssl-server profile
+        serverName = profile.get('serverName', None)
+        sniDefault = profile.get('sniDefault', False)
         ssl_server_profile.create(name=name,
                                   partition=partition,
-                                  chain=cert_name)
+                                  chain=cert_name,
+                                  serverName=serverName,
+                                  sniDefault=sniDefault)
     except Exception as err:
         incomplete += 1
         log.error("Error creating server SSL profile: %s" % err.message)


### PR DESCRIPTION
Problem: SNIDefault was not being set for custom profiles when configuring
https Routes. The server name was set, but a default SNI was not.

Solution: Set the default SNI for the first custom profile for a virtual server.
All subsequent profiles for that same virtual server will not be set for default SNI.