### PR TITLE
Port specifications for Route Types added to docs

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -397,6 +397,15 @@ Supported Route Configurations
 |                         |                   |                   |         |                 | SNI and forward the re-encrypted traffic.                               |
 +-------------------------+-------------------+-------------------+---------+-----------------+-------------------------------------------------------------------------+
 
+.. note::
+
+   By default, the controller configures any pool members for Passthrough or Re-encrypt Routes on port 443. The controller expects
+   a service running on 443 for these types of Routes.
+
+   For Edge and Unsecured Route types, the default port used for the backend is 80.
+
+   Services exposed on different ports than these defaults require you to specify the port in the Route config's "Port" 
+   field.
 
 Please see the example configuration files for more details.
 


### PR DESCRIPTION
Problem: Need to inform users what the expectations for backend exposed ports
are for the different Route types.

Solution: Clarify the use of port 443 for Passthrough and Re-encrypt Routes and port 80
for all others. Also mention that custom ports should be specified in the Route config.