### PR TITLE
Fix SIGSEV on non-"f5" valued class annotation

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -4,6 +4,13 @@ Release Notes for BIG-IP Controller for Kubernetes
 |release|
 ---------
 
+Bug Fixes
+`````````
+* - Fix SIGSEV on non-"f5" valued class annotation `[#311] <https://github.com/F5Networks/k8s-bigip-ctlr/issues/311>`_
+
+v1.1.0
+------
+
 Added Functionality
 ```````````````````
 

--- a/pkg/appmanager/validateResources.go
+++ b/pkg/appmanager/validateResources.go
@@ -108,7 +108,7 @@ func (appMgr *Manager) checkValidIngress(
 		var keyList []*serviceQueueKey
 		rsCfg := createRSConfigFromIngress(ing, namespace,
 			appInf.svcInformer.GetIndexer(), portStruct)
-		rsName := rsCfg.Virtual.VirtualServerName
+		rsName := formatIngressVSName(ing, portStruct.protocol)
 		if rsCfg == nil {
 			if nil == ing.Spec.Rules { //single-service
 				serviceName := ing.Spec.Backend.ServiceName
@@ -116,14 +116,15 @@ func (appMgr *Manager) checkValidIngress(
 				sKey := serviceKey{serviceName, servicePort, ing.ObjectMeta.Namespace}
 				if _, ok := appMgr.resources.Get(sKey, rsName); ok {
 					appMgr.resources.Delete(sKey, rsName)
+					appMgr.outputConfigLocked()
 				}
 			} else { //multi-service
 				_, keys := appMgr.resources.GetAllWithName(rsName)
 				for _, key := range keys {
 					appMgr.resources.Delete(key, rsName)
+					appMgr.outputConfigLocked()
 				}
 			}
-			appMgr.outputConfig()
 			return false, nil
 		}
 


### PR DESCRIPTION
Problem: When using a kubernetes ingress class other than "f5", the controller
hit a segfault, due to trying to access a field in a nil struct.

Solution: Change the way the required value is grabbed, and use outputConfigLocked instead of
outputConfig, since the calling function is already locked.

Fixes #311