### PR TITLE
openshift feature parity docs 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -100,6 +100,9 @@ doc-preview:
 _docs: docs/_static/ATTRIBUTIONS.md always-build
 	./build-tools/docker-docs.sh ./build-tools/make-docs.sh
 
+docker-test:
+	rm -rf docs/_build
+	./build-tools/docker-docs.sh ./build-tools/make-docs.sh
 
 #
 # Attributions Generation

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -8,7 +8,7 @@ F5 BIG-IP Controller for Kubernetes
     RELEASE-NOTES
     /_static/ATTRIBUTIONS
 
-The |kctlr-long| manages F5 BIG-IP `Local Traffic Manager <https://f5.com/products/big-ip/local-traffic-manager-ltm>`_ (LTM) objects from `Kubernetes`_.
+The |kctlr-long| lets you manage your F5 BIG-IP device from `Kubernetes`_ or `OpenShift`_ using either environment's native CLI/API.
 
 |release-notes|
 
@@ -19,45 +19,50 @@ The |kctlr-long| manages F5 BIG-IP `Local Traffic Manager <https://f5.com/produc
 Features
 --------
 - Dynamically creates, manages, and destroys BIG-IP objects.
-- Forwards traffic from BIG-IP to `Kubernetes clusters`_ via `NodePorts`_ or `ClusterIPs`_.
+- Forwards traffic from the BIG-IP device to `Kubernetes clusters`_ via `NodePorts`_ or `ClusterIPs`_.
 - Support for F5 `iApps`_.
 - Handles F5-specific VirtualServer objects created in Kubernetes.
-- Handles standard Ingress objects created in Kubernetes (with some F5-specific extensions).
+- Handles standard `Kubernetes Ingress`_ objects using F5-specific extensions.
+- Handles route configuration on the BIG-IP system (**OpenShift only**).
 
 Guides
 ------
-
-See the `F5 Container Connector for Kubernetes user documentation </containers/v1/kubernetes/>`_.
+See the |kctlr-long| `user documentation </containers/latest/kubernetes/>`_.
 
 Overview
 --------
-
 The |kctlr-long| is a Docker container that runs in a `Kubernetes`_ Pod.
-It uses an F5 Resource to determine:
+It uses `F5 Resource`_ s to determine:
 
-- what objects to configure on your BIG-IP, and
-- to which `Kubernetes Service`_ the BIG-IP objects belong.
+- what objects to configure on your BIG-IP system, and
+- to which `Kubernetes Service`_ those objects belong.
 
-The |kctlr-long| watches the Kubernetes API for the creation, modification or deletion of Kubernetes objects.  For some objects, it responds to these events by creating, modifying or deleting objects in the configuration of a BIG-IP. It handles these objects:
-- A *ConfigMap that is the F5-specific VirtualServer* type, used to create per-service virtual servers and/or pools on BIG-IP.
-- The standard Kubernetes *Ingress* object, used to create a single virtual server on BIG-IP with L7 policies to route to individual services. This object can have some F5-specific annotations documented below to control F5-specific behavior.
+The |kctlr| watches the Kubernetes API for the creation, modification, or deletion of Kubernetes objects.
+For some Kubernetes objects, the Controller responds by creating, modifying, or deleting objects in the BIG-IP system.
+The |kctlr| handles the following Kubernetes objects:
 
-One controller can handle a mix of these objects simultaneously. See below for the specifics regarding the handling of these objects.
+- :ref:`F5 Resource ConfigMap <f5 resource configmap properties>` -- creates Service-specific frontend virtual servers and/or pools on the BIG-IP system.
+- `Kubernetes Ingress`_  -- creates a single front-end virtual server on the BIG-IP system that uses L7 policies to route to individual Services.
+- `OpenShift Route`_ -- enables route-handling (specific to OpenShift).
 
+One Controller can handle a mix of these objects simultaneously. See below for specifics regarding the handling of these objects.
 
-For example:
+For example, when run in `NodePort mode`_, the |kctlr| does the following:
 
-#. |kctlr-long| discovers a new F5 ``virtualServer`` resource.
-#. |kctlr-long| creates a new virtual server object on the BIG-IP. [#objectpartition]_
-#. |kctlr-long| creates a pool member on the virtual server for each node in the cluster. [#nodeport]_
-#. |kctlr-long| monitors F5 resources, and linked Kubernetes resources, for changes.
-#. |kctlr-long| reconfigures the BIG-IP when it discovers changes.
+#. Discovers a new F5 ``virtualServer`` resource.
+#. Creates a new virtual server object in the specified partition on the BIG-IP system. [#objectpartition]_
+#. Creates a pool member on the virtual server for each node in the cluster. [#nodeport]_
+#. Monitors F5 resources, and linked Kubernetes resources, for changes.
+#. Reconfigures the BIG-IP system when it discovers changes.
 
-The BIG-IP handles traffic for the Service the specified virtual address and load-balances to all nodes in the cluster. Within the cluster, the allocated NodePort load balances traffic to all pods.
+The BIG-IP system handles traffic for the Service at the specified virtual address and load balances to all nodes in the cluster.
+Within the cluster, the allocated NodePort load balances traffic to all pods.
+
+.. _configuration parameters:
 
 Controller Configuration Parameters
 -----------------------------------
-These configuration parameters are global to the controller.
+The configuration parameters below are global to the |kctlr|.
 
 +--------------------+---------+----------+-------------+-----------------------------------------+----------------+
 | Parameter          | Type    | Required | Default     | Description                             | Allowed Values |
@@ -72,8 +77,10 @@ These configuration parameters are global to the controller.
 | bigip-partition    | string  | Required | n/a         | The BIG-IP partition in which           |                |
 |                    |         |          |             | to configure objects.                   |                |
 +--------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| namespace          | string  | Optional | All         | Kubernetes namespace(s) to watch, if not|                |
-|                    |         |          |             | provided will watch all namespaces      |                |
+| namespace          | string  | Optional | All         | Kubernetes namespace(s) to watch        |                |
+|                    |         |          |             |                                         |                |
+|                    |         |          |             | - may be a comma-separated list         |                |
+|                    |         |          |             | - watches all namespaces by default     |                |
 +--------------------+---------+----------+-------------+-----------------------------------------+----------------+
 | namespace-label    | string  | Optional | n/a         | Tells the ``k8s-bigip-ctlr`` to watch   |                |
 |                    |         |          |             | any namespace with this label           |                |
@@ -104,67 +111,71 @@ These configuration parameters are global to the controller.
 |                    |         |          |             |                                         | WARNING,       |
 |                    |         |          |             |                                         | ERROR          |
 +--------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| pool-member-type   | string  | Optional | nodeport    | Create this type of BIG-IP pool members | cluster,       |
-|                    |         |          |             |                                         | nodeport       |
+| pool-member-type   | string  | Optional | nodeport    | The type of BIG-IP pool members you want| cluster,       |
+|                    |         |          |             | to create.                              | nodeport       |
+|                    |         |          |             |                                         |                |
 |                    |         |          |             | Use ``cluster`` to create pool members  |                |
 |                    |         |          |             | for each of the endpoints for the       |                |
-|                    |         |          |             | service. e.g. the pod's ip              |                |
+|                    |         |          |             | Service (the pod's InternalIP)          |                |
 |                    |         |          |             |                                         |                |
 |                    |         |          |             | Use ``nodeport`` to create pool members |                |
 |                    |         |          |             | for each schedulable node using the     |                |
-|                    |         |          |             | service's NodePort                      |                |
+|                    |         |          |             | Service's NodePort.                     |                |
 +--------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| openshift-sdn-name | string  | Optional | n/a         | BigIP configured VxLAN name             |                |
-|                    |         |          |             | for access into the Openshift           |                |
-|                    |         |          |             | SDN and Pod network                     |                |
+| openshift-sdn-name | string  | Optional | n/a         | Name of the VXLAN set up on the BIG-IP  |                |
+|                    |         |          |             | system that corresponds to an Openshift |                |
+|                    |         |          |             | SDN HostSubnet.                         |                |
 +--------------------+---------+----------+-------------+-----------------------------------------+----------------+
 | manage-routes      | boolean | Optional | false       | Indicates if ``k8s-bigip-ctlr`` should  | true, false    |
 |                    |         |          |             | handle OpenShift Route objects.         |                |
 |                    |         |          |             |                                         |                |
-|                    |         |          |             | Only applicable in the OpenShift        |                |
-|                    |         |          |             | environment.                            |                |
+|                    |         |          |             | **Only applicable in OpenShift.**       |                |
 +--------------------+---------+----------+-------------+-----------------------------------------+----------------+
 | route-vserver-addr | string  | Optional | n/a         | Bind address for virtual server for     |                |
 |                    |         |          |             | OpenShift Route objects.                |                |
 |                    |         |          |             |                                         |                |
-|                    |         |          |             | Only applicable in the OpenShift        |                |
-|                    |         |          |             | environment.                            |                |
+|                    |         |          |             | **Only applicable in OpenShift.**       |                |
 +--------------------+---------+----------+-------------+-----------------------------------------+----------------+
 | route-label        | string  | Optional | n/a         | Tells the ``k8s-bigip-ctlr`` to only    |                |
 |                    |         |          |             | watch for OpenShift Route objects with  |                |
-|                    |         |          |             | a label named 'f5type' set to the       |                |
-|                    |         |          |             | specified value.                        |                |
+|                    |         |          |             | the ``f5type`` label set to this value. |                |
 |                    |         |          |             |                                         |                |
-|                    |         |          |             | Only applicable in the OpenShift        |                |
-|                    |         |          |             | environment.                            |                |
+|                    |         |          |             | **Only applicable in OpenShift.**       |                |
 +--------------------+---------+----------+-------------+-----------------------------------------+----------------+
 
 
-VirtualServer ConfigMap Properties
-----------------------------------
-The |kctlr-long| supports VirtualServer ConfigMap objects.
+.. _f5 resource configmap properties:
+
+F5 Resource ConfigMap Properties
+--------------------------------
+F5 Resource ConfigMap objects tell the |kctlr| how to configure the BIG-IP system.
+See the `Integration Overview </containers/latest/kubernetes/>`_ for more information about F5 resources.
 
 +---------------+---------------------------------------------------+-----------------------------------------------+
 | Property      | Description                                       | Allowed Values                                |
 +===============+===================================================+===============================================+
-| f5type        | Defines the type of object                        | virtual-server                                |
-|               | ``k8s-bigip-ctlr`` creates on the BIG-IP          |                                               |
+| f5type        | Tells ``k8s-bigip-ctlr`` about resources it       |                                               |
+|               | should watch                                      |                                               |
 +---------------+---------------------------------------------------+-----------------------------------------------+
 | schema        | Verifies the ``data`` blob                        | f5schemadb://bigip-virtual-server_v0.1.3.json |
 +---------------+---------------------------------------------------+-----------------------------------------------+
 | data          | Defines the F5 resource                           |                                               |
 +---------------+---------------------------------------------------+-----------------------------------------------+
-| frontend      | Defines object(s) created on the BIG-IP           | See `frontend <#frontend>`_                   |
+| frontend      | Defines object(s) created on the BIG-IP           | See :ref:`frontend`                           |
 +---------------+---------------------------------------------------+-----------------------------------------------+
-| backend       | Identifes the Kubernets Service acting as the     | See `backend <#backend>`_                     |
+| backend       | Identifes the Kubernets Service acting as the     | See :ref:`backend`                            |
 |               | server pool                                       |                                               |
 +---------------+---------------------------------------------------+-----------------------------------------------+
 
+.. _frontend:
+
 Frontend
 ````````
+.. _virtual server f5 resource:
 
 virtualServer
 ~~~~~~~~~~~~~
+The ``frontend.virtualServer`` properties define BIG-IP virtual server, pool, and pool member objects.
 
 ==================== ================= ============== =========== ===================================================== ======================
 Property             Type              Required       Default     Description                                           Allowed Values
@@ -180,7 +191,7 @@ mode                 string            Optional       tcp         Set the proxy 
 
 balance              string            Optional       round-robin Set the load balancing mode                           round-robin
 
-sslProfile           JSON object       Optional                   BIG-IP SSL profile to apply to the virtual server.
+sslProfile [#ssl]_   JSON object       Optional                   BIG-IP SSL profile to apply to the virtual server.
 
 - f5ProfileName      string            Optional                   Name of the BIG-IP SSL profile you want to use.
 
@@ -199,69 +210,90 @@ sslProfile           JSON object       Optional                   BIG-IP SSL pro
                                                                       'Common/testcert1',
                                                                       'Common/testcert2'
                                                                     ]
+
 ==================== ================= ============== =========== ===================================================== ======================
 
+\
 
-If ``bindAddr`` is not provided in the Frontend configuration, then you must supply it via a `Kubernetes Annotation`_ for the ConfigMap. The controller watches for the annotation key ``virtual-server.f5.com/ip``.
-This annotation must contain the IP address that the virtual server will use. You can configure an IPAM system to write out this annotation containing the IP address that it chose.
+If you don't define ``bindAddr`` in the Frontend configuration, you must include it in a `Kubernetes Annotation`_ to the ConfigMap.
+The Controller watches for the annotation key ``virtual-server.f5.com/ip``.
+This annotation must contain the IP address you want to assign to the virtual server.
 
-A user of the Kubernetes API can check the ``status.virtual-server.f5.com/ip`` annotation, set by the controller, to see the ``bindAddr`` that the virtual server is using.
+- You can `configure an IPAM system </containers/latest/kubernetes/ktclr-manage-bigip-objects.html#use-ipam-to-assign-ip-addresses-to-big-ip-LTM-virtual-servers>`_ to write out an annotation containing the selected IP address.
+-  You can check the ``status.virtual-server.f5.com/ip`` annotation set by the Controller via the Kubernetes API.
+   This allows you to see the ``bindAddr`` assigned to the virtual server.
 
-If ``virtualAddress`` or ``bindAddr`` are not provided in the Frontend configuration, then the controller will configure and manage pools, pool members, and healthchecks for the service without a virtual server on the BIG-IP.
-Instead you should already have a BIG-IP virtual server that handles client connections and has an irule or traffic policy to forward the request to the correct pool. The stable name of the pool will be the namespace
-of the Kubernetes service followed by an underscore followed by the name of the service ConfigMap.
+If you don't define ``virtualAddress`` or ``bindAddr`` in the Frontend configuration, the Controller configures and manages pools, pool members, and healthchecks for the Service without a BIG-IP virtual server.
+In such cases, **you should already have a BIG-IP virtual server** that handles client connections configured with an iRule or local traffic policy that can forward the request to the correct pool.
+The stable name of the pool will be the Kubernetes namespace the Service runs in, followed by an underscore, followed by the name of the Service's ConfigMap.
+For example: :code:`default_myService`.
 
-**To configure multiple SSL profiles**, use ``f5ProfileNames``, not ``f5ProfileName``. ``f5ProfileName`` and ``f5ProfileNames`` are mutually exclusive.
+.. seealso::
+
+   See `Manage pools without virtual servers </containers/latest/kubernetes/kctlr-manage-bigip-objects.html#manage-pools-without-virtual-servers>`_ for more information.
+
+.. [#ssl] If you want to configure multiple SSL profiles, use ``f5ProfileNames`` instead of ``f5ProfileName``. The two parameters are mutually exclusive.
+
+.. _iapp f5 resource:
 
 iApps
 ~~~~~
 
-+---------------------+-----------+-----------+-----------+-------------------------------------------------------+---------------------------+
-| Property            | Type      | Required  | Default   | Description                                           | Allowed Values            |
-+=====================+===========+===========+===========+=======================================================+===========================+
-| partition           | string    | Required  |           | Define the BIG-IP partition                           |                           |
-|                     |           |           |           | to manage.                                            |                           |
-+---------------------+-----------+-----------+-----------+-------------------------------------------------------+---------------------------+
-| iapp                | string    | Required  |           | BIG-IP iApp template to use                           | Any iApp template already |
-|                     |           |           |           | to create the application                             | configured on the BIG-IP. |
-|                     |           |           |           | service.                                              |                           |
-+---------------------+-----------+-----------+-----------+-------------------------------------------------------+---------------------------+
-| iappPoolMemberTable | JSON      | Required  |           | Define the name and layout of the pool-member table   |                           |
-|                     | object    |           |           | in the iApp.                                          |                           |
-|                     |           |           |           | See the iApp Pool Member Table section below.         |                           |
-+---------------------+-----------+-----------+-----------+-------------------------------------------------------+---------------------------+
-| iappTables          | JSON      | Optional  |           | Define iApp tables to apply to                        |                           |
-|                     | object    |           |           | the Application Service                               |                           |
-|                     | array     |           |           |                                                       |                           |
-|                     |           |           |           | Example:                                              |                           |
-|                     |           |           |           | ``"iappTables": {``                                   |                           |
-|                     |           |           |           | ``"monitor__Monitors":``                              |                           |
-|                     |           |           |           | ``{"columns": ["Index", "Name", "Type", "Options"],`` |                           |
-|                     |           |           |           | ``"rows": [[0, "mon1", "tcp", "" ],``                 |                           |
-|                     |           |           |           | ``[1, "mon2", "http", ""]]}}"``                       |                           |
-+---------------------+-----------+-----------+-----------+-------------------------------------------------------+---------------------------+
-| iappOptions         | key-value | Required  |           | Define the App configurations                         | See configuration         |
-|                     | object    |           |           |                                                       | parameters above.         |
-+---------------------+-----------+-----------+-----------+-------------------------------------------------------+---------------------------+
-| iappVariables       | key-value | Required  |           | Define the iApp variables                             |                           |
-|                     | object    |           |           | needed for service creation.                          |                           |
-+---------------------+-----------+-----------+-----------+-------------------------------------------------------+---------------------------+
+The ``frontend.virtualServer`` properties provide the information required to deploy an iApp on the BIG-IP system.
+
+.. tip::
+
+   The ``iappOptions`` represent information that the user would provide if deploying the iApp via the BIG-IP configuration utility.
+
+\
+
+==================== ================= ============== ======================================================= ====================================
+Property             Type              Required       Description                                             Allowed Values
+==================== ================= ============== ======================================================= ====================================
+partition            string            Required       The BIG-IP partition you want the |kctlr| to manage.                                            
+-------------------- ----------------- -------------- ------------------------------------------------------- ------------------------------------
+iapp                 string            Required       BIG-IP iApp template to use to create the               Any iApp template that already 
+                                                      application  Service.                                   exists on the BIG-IP system. 
+-------------------- ----------------- -------------- ------------------------------------------------------- ------------------------------------
+iappPoolMemberTable  JSON object       Required       Define the name and layout of the pool member table   
+                                                      in the iApp.                                          
+                                    
+                                                      **See** :ref:`iApp Pool Member Table`.         
+-------------------- ----------------- -------------- ------------------------------------------------------- ------------------------------------
+iappTables           JSON object       Optional       Define iApp tables to apply to the Application Service
+                     array
+                                                      Example: ::
+                                                      
+                                                        "iappTables": {
+                                                          "monitor__Monitors":
+                                                            {"columns": ["Index", "Name", "Type", "Options"],
+                                                             "rows": [[0, "mon1", "tcp", "" ],
+                                                                      [1, "mon2", "http", ""]]}}"
+
+-------------------- ----------------- -------------- ------------------------------------------------------- ------------------------------------
+iappOptions          key-value object  Required       Define the App configurations                           See :ref:`configuration parameters`.        
+-------------------- ----------------- -------------- ------------------------------------------------------- ------------------------------------
+iappVariables        key-value object  Required       Define the iApp variables needed for Service creation.
+                              
+==================== ================= ============== ======================================================= ====================================
+
+.. _iapp pool member table:
 
 iApp Pool Member Table
-``````````````````````
+^^^^^^^^^^^^^^^^^^^^^^
 
-You can use the ``iappPoolMemberTable`` option to describe the layout of the pool-member table that the controller should configure.  It is a JSON object with these properties:
+You can use the ``iappPoolMemberTable`` option to describe the layout of the pool-member table that the Controller should configure.  It is a JSON object with these properties:
 
 - ``name`` (required): A string that specifies the name of the table that contains the pool members.
-- ``columns`` (required): An array that specifies the columns that the controller will configure in the pool-member table, in order.
+- ``columns`` (required): An array that specifies the columns that the Controller will configure in the pool-member table, in order.
 
 Each entry in ``columns`` is an object that has a ``name`` property and either a ``kind`` or ``value`` property:
 
 - ``name`` (required): A string that specifies the column name.
-- ``kind``: A string that tells the controller what property from the node to substitute.  The controller supports ``"IPAddress"`` and ``"Port"``.
-- ``value``: A string that specifies a value.  The controller will not perform any substitution, it uses the value as specified.
+- ``kind``: A string that tells the Controller what property from the node to substitute.  The Controller supports ``"IPAddress"`` and ``"Port"``.
+- ``value``: A string that specifies a value.  The Controller will not perform any substitution, it uses the value as specified.
 
-For instance, if you configure an application with two pods at 1.2.3.4:20123 and 1.2.3.5:20321, and you specify::
+For example: If you configure an application with two pods at 1.2.3.4:20123 and 1.2.3.5:20321 and you specify the following JSON::
 
     "iappPoolMemberTable" = {
       "name": "pool__members",
@@ -272,7 +304,7 @@ For instance, if you configure an application with two pods at 1.2.3.4:20123 and
       ]
     }
 
-This would configure the following table on BIG-IP::
+the |kctlr| creates the table below on the BIG-IP system. ::
 
     {
       "name": "pool__members",
@@ -299,19 +331,23 @@ This would configure the following table on BIG-IP::
       ]
     }
 
-You will need to adjust this for the particular iApp template that you are using.  One way to discover the format is to configure an iApp manually from a template, and then check its configuration using ``tmsh list sys app service <appname>``.
+You will need to adjust this for the particular iApp template that you are using.  
+One way to discover the format is to configure an iApp manually from a template,  then check its configuration using :command:`tmsh list sys app Service <appname>`.
 
+.. _backend:
 
 Backend
 ```````
 
+The ``backend`` section tells the |kctlr| about the Service you want to manage.
+
 +---------------+-----------+-----------+-----------+-------------------------------+---------------------------+
 | Property      | Type      | Required  | Default   | Description                   | Allowed Values            |
 +===============+===========+===========+===========+===============================+===========================+
-| serviceName   | string    | Required  | none      | The `Kubernetes Service`_     |                           |
+| ServiceName   | string    | Required  | none      | The `Kubernetes Service`_     |                           |
 |               |           |           |           | representing the server pool. |                           |
 +---------------+-----------+-----------+-----------+-------------------------------+---------------------------+
-| servicePort   | integer   | Required  | none      | Kubernetes Service port       |                           |
+| ServicePort   | integer   | Required  | none      | Kubernetes Service port       |                           |
 |               |           |           |           | number                        |                           |
 +---------------+-----------+-----------+-----------+-------------------------------+---------------------------+
 | healthMonitors| JSON      | Optional  | none      | Array of TCP or HTTP Health   |                           |
@@ -319,9 +355,14 @@ Backend
 |               | array     |           |           |                               |                           |
 +---------------+-----------+-----------+-----------+-------------------------------+---------------------------+
 
+.. _ingress resources:
+
 Ingress Resources
 -----------------
-The |kctlr-long| supports Kubernetes Ingress resources as an alternative to F5 Resource ConfigMaps and OpenShift Route Resources.
+
+You can use the |kctlr| as a `Kubernetes Ingress`_ Controller to `expose Services to external traffic </containers/latest/kubernetes/kctlr-ingress.html>`_.
+
+.. _ingress annotations:
 
 Supported annotations
 `````````````````````
@@ -329,12 +370,13 @@ Supported annotations
 +------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
 | Annotation                         | Type        | Required  | Description                                                                         | Default     |
 +====================================+=============+===========+=====================================================================================+=============+
-| virtual-server.f5.com/ip           | string      | Required  | Contains the IP address that the virtual server will use.                           |             |
+| virtual-server.f5.com/ip           | string      | Required  | The IP address you want to assign to the virtual server.                            | N/A         |
 +------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
-| virtual-server.f5.com/partition    | string      | Required  | Specifies which partition on the Big-IP the controller should create/update/delete  |             |
-|                                    |             |           | objects in for this Ingress.                                                        |             |
+| virtual-server.f5.com/partition    | string      | Required  | The BIG-IP partition in which the Controller should create/update/delete            | N/A         |
+|                                    |             |           | objects for this Ingress.                                                           |             |
 +------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
-| kubernetes.io/ingress.class        | string      | Optional  | If specified, it must contain the value `f5`.                                       | f5          |
+| kubernetes.io/ingress.class        | string      | Optional  | Tells the Controller it should only manage Ingress resources in the ``f5`` class.   | f5          |
+|                                    |             |           | If defined, the value must be ``f5``.                                               |             |
 +------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
 | virtual-server.f5.com/balance      | string      | Optional  | Specifies the load balancing mode.                                                  | round-robin |
 +------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
@@ -342,108 +384,150 @@ Supported annotations
 +------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
 | virtual-server.f5.com/https-port   | integer     | Optional  | Specifies the HTTPS port.                                                           | 443         |
 +------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
-| virtual-server.f5.com/health       | JSON object | Optional  | Health monitor configuration to use for the Ingress resource.                       |             |
+| virtual-server.f5.com/health       | JSON object | Optional  | Defines a health monitor for the Ingress resource.                                  | N/A         |
++----------------------+-------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
+|                      | path        | string      | Required  | The path for the Service specified in the Ingress resource.                         | N/A         |
+|                      |             |             | [#hm1]_   |                                                                                     |             |
++----------------------+-------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
+|                      | send        | string      | Required  | The send string to set in the health monitor. [#hm2]_                               | N/A         |
+|                      |             |             | [#hm1]_   |                                                                                     |             |
++----------------------+-------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
+|                      | interval    | integer     | Required  | The interval at which to check the health of the virtual server.                    | N/A         |
+|                      |             |             | [#hm1]_   |                                                                                     |             |
++----------------------+-------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
+|                      | timeout     | integer     | Required  | Number of seconds before the check times out.                                       | N/A         |
+|                      |             |             | [#hm1]_   |                                                                                     |             |
++----------------------+-------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
+| ingress.kubernetes.io/allow-http   | boolean     | Optional  | Tells the Controller to allow HTTP traffic for HTTPS Ingress resources.             | false       |
 +------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
-| ingress.kubernetes.io/allow-http   | boolean     | Optional  | For HTTPS Ingress resources, specifies to also allow HTTP traffic.                  | false       |
-+------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
-| ingress.kubernetes.io/ssl-redirect | boolean     | Optional  | For HTTPS Ingress resources, specifies to redirect HTTP traffic to the HTTPS port   | true        |
-|                                    |             |           | (see below).                                                                        |             |
+| ingress.kubernetes.io/ssl-redirect | boolean     | Optional  | Tells the Controller to redirect HTTP traffic to the HTTPS port for HTTPS Ingress   | true        |
+|                                    |             |           | resources (see TLS Ingress resources, below).                                       |             |
 +------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
 
-If the Ingress resource contains a `tls` section, the `allow-http` and `ssl-redirect` annotations provide a method of controlling HTTP traffic. In this case, the controller uses the value set in the `allow-http` annotation to enable or disable HTTP traffic. Use the `ssl-redirect` annotation to redirect all HTTP traffic to the HTTPS Virtual Server.
+.. _tls ingress:
 
-One or more SSL profiles may exist in the Ingress resource, and must already exist on the BIG-IP. The SSL profiles referenced in the Ingress resource must use the full path used on the BIG-IP, such as `/Common/clientssl`.
+TLS Ingress resources
+`````````````````````
 
-To configure health monitors on your Ingress resource, you need to use the appropriate annotation with a JSON object containing an array of health monitor JSON object for each path specified in the Ingress resource. Each health monitor JSON object must have the following 4 fields::
+If the Ingress resource contains a `tls` section, the `allow-http` and `ssl-redirect` annotations provide a method of controlling HTTP traffic.
+In this case, the Controller uses the value set in the `allow-http` annotation to enable or disable HTTP traffic.
+Use the `ssl-redirect` annotation to redirect all HTTP traffic to the HTTPS Virtual Server.
 
-    {
-      "path": "serviceName/path",
-      "send": "<send string to set in the health monitor>",
-      "interval": <health check interval>,
-      "timeout": <number of seconds before the check has timed out>
-    }
+You can specify one (1) or more SSL profiles in the Ingress resource.
 
+- Profiles must already exist either in Kubernetes/OpenShift --OR-- on the BIG-IP system;
+
+  - If the controller looks for a Kubernetes Secret with the name(s) provided first;
+  - if it doesn't find a matching Secret, the Controller assumes that the name(s) matches a profile that already exists on the BIG-IP system.
+  - If naming an existing BIG-IP profile, provide the full path to the profile (for example, ``/Common/clientssl``).
+
+To configure health monitors on your Ingress resource, define the ``virtual-server.f5.com/health`` annotation with a JSON object.
+Provide an array for each path specified in the Ingress resource.
+For example ::
+
+   {
+   "path": "ServiceName/path",
+   "send": "<send string to set in the health monitor>",
+   "interval": <health check interval>,
+   "timeout": <number of seconds before the check has timed out>
+   }
+
+
+.. _openshift routes:
 
 OpenShift Route Resources
 -------------------------
-The |kctlr-long| supports OpenShift Route resources as an alternative to F5 Resource ConfigMaps and Kubernetes Ingress Resources.
+
+.. note::
+
+   You can use OpenShift Route resources in an existing deployment once you `replace the OpenShift F5 Router with the BIG-IP Controller`_.
+
+.. _supported-routes:
 
 Supported Route Configurations
 ``````````````````````````````
 
 +-------------------------+-------------------+-------------------+---------+-----------------+-------------------------------------------------------------------------+
-| Type                    | Client Connection | Server Connection | Path    | SSL Termination | Notes                                                                   |
+| Type                    | Client Connection | Server Connection | Path    | SSL Termination | Description                                                             |
 |                         | Encrypted         | Encrypted         | Support | on BIG-IP       |                                                                         |
 +=========================+===================+===================+=========+=================+=========================================================================+
 | Unsecured               | No                | No                | Yes     | No              | The BIG-IP system forwards unsecured traffic from the client to the     |
 |                         |                   |                   |         |                 | endpoint.                                                               |
 +-------------------------+-------------------+-------------------+---------+-----------------+-------------------------------------------------------------------------+
-| Edge Terminated         | Yes               | No                | Yes     | Yes             | The controller maintains a new client SSL profile on the BIG-IP system  |
+| Edge Terminated         | Yes               | No                | Yes     | Yes             | The Controller maintains a new client SSL profile on the BIG-IP system  |
 |                         |                   |                   |         |                 | based on the client certificate and key from the Route resource.        |
-|                         |                   |                   |         |                 | Set 'insecureEdgeTerminationPolicy' in the Route resource to 'Allow'    |
-|                         |                   |                   |         |                 | to enable support for insecure client connections.                      |
-|                         |                   |                   |         |                 | Set 'insecureEdgeTerminationPolicy' in the Route resource to 'Redirect' |
-|                         |                   |                   |         |                 | to redirect HTTP client connections to the HTTPS endpoint               |
+|                         |                   |                   |         |                 |                                                                         |
+|                         |                   |                   |         |                 | - Set `insecureEdgeTerminationPolicy` in the Route resource to `Allow`  |
+|                         |                   |                   |         |                 |   to enable support for insecure client connections.                    |
+|                         |                   |                   |         |                 |                                                                         |
+|                         |                   |                   |         |                 | - Set `insecureEdgeTerminationPolicy` in the Route resource to          |
+|                         |                   |                   |         |                 |   `Redirect` to redirect HTTP client connections to the HTTPS endpoint. |
 +-------------------------+-------------------+-------------------+---------+-----------------+-------------------------------------------------------------------------+
 | Passthrough Terminated  | Yes               | Yes               | No      | No              | The BIG-IP system uses an iRule to select the destination pool based on |
 |                         |                   |                   |         |                 | SNI and forward the re-encrypted traffic.                               |
 +-------------------------+-------------------+-------------------+---------+-----------------+-------------------------------------------------------------------------+
-| Re-encrypt Terminated   | Yes               | Yes               | Yes     | Yes             | The controller maintains a new client SSL profile on the BIG-IP based   |
+| Re-encrypt Terminated   | Yes               | Yes               | Yes     | Yes             | The Controller maintains a new BIG-IP client SSL profile based          |
 |                         |                   |                   |         |                 | on the client certificate and key from the Route resource.              |
-|                         |                   |                   |         |                 | The controller maintains a new server SSL profile on the BIG-IP based   |
+|                         |                   |                   |         |                 |                                                                         |
+|                         |                   |                   |         |                 | The Controller maintains a new BIG-IP server SSL profile based          |
 |                         |                   |                   |         |                 | on the server CA certificate from the Route resource for re-encrypting  |
 |                         |                   |                   |         |                 | the traffic.                                                            |
+|                         |                   |                   |         |                 |                                                                         |
 |                         |                   |                   |         |                 | The BIG-IP system uses an iRule to select the destination pool based on |
 |                         |                   |                   |         |                 | SNI and forward the re-encrypted traffic.                               |
 +-------------------------+-------------------+-------------------+---------+-----------------+-------------------------------------------------------------------------+
 
-.. note::
+.. important::
 
-   By default, the controller configures any pool members for Passthrough or Re-encrypt Routes on port 443. The controller expects
-   a service running on 443 for these types of Routes.
+   - By default, the Controller configures all pool members for Passthrough or Re-encrypt Routes on port 443.
+     The Controller expects a Service running on 443 for these types of Routes.
 
-   For Edge and Unsecured Route types, the default port used for the backend is 80.
+   - For Edge and Unsecured Route types, the default backend port is 80.
 
-   Services exposed on different ports than these defaults require you to specify the port in the Route config's "Port" 
-   field.
+   - To expose a Service on any other ports. **specify the port in the Route config's "Port" field**.
 
 Please see the example configuration files for more details.
 
 Example Configuration Files
-```````````````````````````
-- `sample-k8s-bigip-ctlr-secrets.yaml <./_static/config_examples/sample-k8s-bigip-ctlr-secrets.yaml>`_
-- `sample-bigip-credentials-secret.yaml <./_static/config_examples/sample-bigip-credentials-secret.yaml>`_
-- `example-vs-resource.configmap.yaml <./_static/config_examples/example-vs-resource.configmap.yaml>`_
-- `example-vs-resource.json <./_static/config_examples/example-vs-resource.json>`_
-- `example-vs-resource-iapp.json <./_static/config_examples/example-vs-resource-iapp.json>`_
-- `example-advanced-vs-resource-iapp.json <./_static/config_examples/example-advanced-vs-resource-iapp.json>`_
-- `single-service-ingress.yaml <./_static/config_examples/single-service-ingress.yaml>`_
-- `single-service-tls-ingress.yaml <./_static/config_examples/single-service-tls-ingress.yaml>`_
-- `simple-ingress-fanout.yaml <./_static/config_examples/simple-ingress-fanout.yaml>`_
-- `name-based-ingress.yaml <./_static/config_examples/name-based-ingress.yaml>`_
-- `ingress-with-health-monitors.yaml <./_static/config_examples/ingress-with-health-monitors.yaml>`_
-- `sample-rbac.yaml <./_static/config_examples/sample-rbac.yaml>`_
-- `sample-unsecured-route.yaml <./_static/config_examples/sample-unsecured-route.yaml>`_
-- `sample-edge-route.yaml <./_static/config_examples/sample-edge-route.yaml>`_
-- `sample-passthrough-route.yaml <./_static/config_examples/sample-passthrough-route.yaml>`_
-- `sample-reencrypt-route.yaml <./_static/config_examples/sample-reencrypt-route.yaml>`_
+---------------------------
 
+- :fonticon:`fa fa-download` :download:`sample-k8s-bigip-ctlr-secrets.yaml <./_static/config_examples/sample-k8s-bigip-ctlr-secrets.yaml>`
+- :fonticon:`fa fa-download` :download:`sample-bigip-credentials-secret.yaml <./_static/config_examples/sample-bigip-credentials-secret.yaml>`
+- :fonticon:`fa fa-download` :download:`example-vs-resource.configmap.yaml <./_static/config_examples/example-vs-resource.configmap.yaml>`
+- :fonticon:`fa fa-download` :download:`example-vs-resource.json <./_static/config_examples/example-vs-resource.json>`
+- :fonticon:`fa fa-download` :download:`example-vs-resource-iapp.json <./_static/config_examples/example-vs-resource-iapp.json>`
+- :fonticon:`fa fa-download` :download:`example-advanced-vs-resource-iapp.json <./_static/config_examples/example-advanced-vs-resource-iapp.json>`
+- :fonticon:`fa fa-download` :download:`single-service-ingress.yaml <./_static/config_examples/single-service-ingress.yaml>`
+- :fonticon:`fa fa-download` :download:`single-service-tls-ingress.yaml <./_static/config_examples/single-service-tls-ingress.yaml>`
+- :fonticon:`fa fa-download` :download:`simple-ingress-fanout.yaml <./_static/config_examples/simple-ingress-fanout.yaml>`
+- :fonticon:`fa fa-download` :download:`name-based-ingress.yaml <./_static/config_examples/name-based-ingress.yaml>`
+- :fonticon:`fa fa-download` :download:`ingress-with-health-monitors.yaml <./_static/config_examples/ingress-with-health-monitors.yaml>`
+- :fonticon:`fa fa-download` :download:`sample-rbac.yaml <./_static/config_examples/sample-rbac.yaml>`
+- :fonticon:`fa fa-download` :download:`sample-unsecured-route.yaml <./_static/config_examples/sample-unsecured-route.yaml>`
+- :fonticon:`fa fa-download` :download:`sample-edge-route.yaml <./_static/config_examples/sample-edge-route.yaml>`
+- :fonticon:`fa fa-download` :download:`sample-passthrough-route.yaml <./_static/config_examples/sample-passthrough-route.yaml>`
+- :fonticon:`fa fa-download` :download:`sample-reencrypt-route.yaml <./_static/config_examples/sample-reencrypt-route.yaml>`
 
-.. [#objectpartition]  The |kctlr-long| creates and manages objects in the BIG-IP partition defined in the `F5 resource </containers/v1/kubernetes/index.html#f5-resource-properties>`_ ConfigMap.
-.. [#nodeport]  The |kctlr-long| forwards traffic to the NodePort assigned to the service by Kubernetes; see the Kubernetes `Services <http://kubernetes.io/docs/user-guide/services/>`_ documentation for more information.
-.. [#secrets]  You can store sensitive information as a `Kubernetes Secret <http://kubernetes.io/docs/user-guide/secrets/>`_. See the `user documentation <#>`_ for instructions.
-
-
+.. rubric:: Footnotes
+.. [#objectpartition] The |kctlr| creates and manages objects in the BIG-IP partition defined in the `F5 resource </containers/latest/kubernetes/index.html#f5-resource-properties>`_ ConfigMap. **It cannot manage objects in the** ``/Common`` **partition**.
+.. [#nodeport] The |kctlr| forwards traffic to the NodePort assigned to the Service by Kubernetes. See the Kubernetes `Services <http://kubernetes.io/docs/user-guide/services/>`_ documentation for more information.
+.. [#secrets] You can `secure your BIG-IP credentials </containers/latest/kubernetes/kctlr-secrets.html#secure-your-BIG-IP-credentials>`_ using a Kubernetes Secret.
+.. [#hm1] Required if defining the ``virtual-server.f5.com/health`` Ingress annotation.
+.. [#hm2] See the **HTTP monitor settings** section of the `BIG-IP LTM Monitors Reference Guide <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-local-traffic-manager-monitors-reference-13-0-0/3.html>`_ for more information about defining send strings.
 
 
 .. _Kubernetes: https://kubernetes.io/
 .. _Kubernetes Service: https://kubernetes.io/docs/user-guide/services/
 .. _Kubernetes Annotation: https://kubernetes.io/docs/user-guide/annotations/
 .. _Kubernetes clusters: https://kubernetes.io/docs/admin/
-.. _NodePorts: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
-.. _ClusterIPs: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services---service-types
+.. _NodePorts: https://kubernetes.io/docs/concepts/services-networking/Service/#type-nodeport
+.. _ClusterIPs: https://kubernetes.io/docs/concepts/services-networking/Service/
 .. _iApps: https://devcentral.f5.com/iapps
 .. _Kubernetes pods: https://kubernetes.io/docs/user-guide/pods/
-.. _Kubernetes Ingress resources: https://kubernetes.io/docs/user-guide/ingress/
+.. _Kubernetes Ingress: https://kubernetes.io/docs/concepts/services-networking/ingress/
 .. _iApp table: https://devcentral.f5.com/wiki/iApp.Working-with-Tables.ashx
-.. _Kubernetes Service Type: https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services---service-types
+.. _Kubernetes Service Type: https://kubernetes.io/docs/concepts/services-networking/service/
+.. _OpenShift: https://www.openshift.com/
+.. _replace the OpenShift F5 Router with the BIG-IP Controller: /containers/latest/openshift/replace-f5-router.html
+.. _NodePort mode: /containers/latest/kubernetes/kctlr-modes.html
+.. _OpenShift Route: https://docs.openshift.org/1.4/dev_guide/routes.html

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,6 +96,8 @@ rst_epilog = '''
     <a href="http://clouddocs.f5.com/products/connectors/k8s-bigip-ctlr/%(url_version)s/_static/ATTRIBUTIONS.html">Attributions</a>
 .. |kctlr| replace:: :code:`k8s-bigip-ctlr`
 .. |kctlr-long| replace:: F5 BIG-IP Controller for Kubernetes
+.. F5 Resource: /containers/latest/kubernetes/#f5-resource-properties
+.. Kubernetes Ingress: https://kubernetes.io/docs/concepts/services-networking/ingress/
 ''' % {
     'url_version': version
 }


### PR DESCRIPTION
### Fixes #313

### Problem
We need to document the existing and upcoming functionality the controller provides in OpenShift environments.

### Solution
The documentation has been updated and edited as needed to support the new functionality.
Staged docs are online at staging site (/products/connectors/k8s-bigip-ctlr/elbert/index.html).