### PR TITLE
Controller should support Node Taints for k8s 1.6

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -398,10 +398,11 @@ func main() {
 	}
 
 	var appMgrParms = appmanager.Params{
-		ConfigWriter:    configWriter,
-		UseNodeInternal: *useNodeInternal,
-		IsNodePort:      isNodePort,
-		RouteConfig:     routeConfig,
+		ConfigWriter:      configWriter,
+		UseNodeInternal:   *useNodeInternal,
+		IsNodePort:        isNodePort,
+		RouteConfig:       routeConfig,
+		NodeLabelSelector: *nodeLabelSelector,
 	}
 
 	gs := globalSection{

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -165,8 +165,13 @@ func NewRoute(id, rv, namespace string, spec routeapi.RouteSpec) *routeapi.Route
 }
 
 // NewNode returns a new node object
-func NewNode(id, rv string, unsched bool,
-	addresses []v1.NodeAddress) *v1.Node {
+func NewNode(
+	id string,
+	rv string,
+	unsched bool,
+	addresses []v1.NodeAddress,
+	taints []v1.Taint,
+) *v1.Node {
 	return &v1.Node{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Node",
@@ -178,6 +183,7 @@ func NewNode(id, rv string, unsched bool,
 		},
 		Spec: v1.NodeSpec{
 			Unschedulable: unsched,
+			Taints:        taints,
 		},
 		Status: v1.NodeStatus{
 			Addresses: addresses,


### PR DESCRIPTION
Problem:
The controller sometimes wishes to identify Unschedulable nodes in order
to prevent sending traffic to them - traffic that is guaranteed a second
hop.

In 1.6 Taints are beta and fully supported in 1.7. Nodes may no longer
be marked Unschedulable but be tainted as NoSchedule. Creating the same
behavior but failing the controller test of watching the Unschedulable
field.

Solution:
Update controller to look for and prefer the Node.Spec.Taint setting and
then defer to the Node.Spec.Unschedulable setting - if a node selector
label has been configured appManager will ignore taint.

Tests: new unit tests, and test_restore.py / test_e2e.py

Fixes #321 