### PR TITLE
Fixed scaletest logging.

### DIFF
--- a/python/bigipconfigdriver.py
+++ b/python/bigipconfigdriver.py
@@ -720,12 +720,13 @@ class ConfigHandler():
                     test_data = {}
                     app_count = 0
                     backend_count = 0
-                    for service in config['resources']['virtualServers']:
+                    for service in config['resources']['test'][
+                            'virtualServers']:
                         app_count += 1
                         backends = 0
-                        for pool in config['resources']['pools']:
+                        for pool in config['resources']['test']['pools']:
                             if pool['name'] == service['name']:
-                                backends = len(pool['poolMemberAddrs'])
+                                backends = len(pool['members'])
                                 break
                         test_data[service['name']] = backends
                         backend_count += backends


### PR DESCRIPTION
Problem:
 k8s-bigip-ctlr scaletests were failing due to object renaming when the
 uplift to CCCL was made.

Solution:
 Update the logging code in the controller for the scaletests to reflect
 the name changes.