### PR TITLE
Support Routes in multiple namespaces

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -91,6 +91,8 @@ var (
 
 	routeVserverAddr *string
 	routeLabel       *string
+	routeHttpVs      *string
+	routeHttpsVs     *string
 
 	// package variables
 	isNodePort         bool
@@ -178,6 +180,10 @@ func _init() {
 		"Optional, bind address for virtual server for Route objects.")
 	routeLabel = osRouteFlags.String("route-label", "",
 		"Optional, label for which Route objects to watch.")
+	routeHttpVs = osRouteFlags.String("route-http-vserver", "ose-vserver",
+		"Optional, the name to be used for the OpenShift Route http vserver")
+	routeHttpsVs = osRouteFlags.String("route-https-vserver", "https-ose-vserver",
+		"Optional, the name to be used for the OpenShift Route https vserver")
 
 	osRouteFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  Openshift Routes:\n%s\n", osRouteFlags.FlagUsages())
@@ -395,6 +401,8 @@ func main() {
 	var routeConfig = appmanager.RouteConfig{
 		RouteVSAddr: *routeVserverAddr,
 		RouteLabel:  *routeLabel,
+		HttpVs:      *routeHttpVs,
+		HttpsVs:     *routeHttpsVs,
 	}
 
 	var appMgrParms = appmanager.Params{

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -64,87 +64,97 @@ Controller Configuration Parameters
 -----------------------------------
 The configuration parameters below are global to the |kctlr|.
 
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| Parameter           | Type    | Required | Default     | Description                             | Allowed Values |
-+=====================+=========+==========+=============+=========================================+================+
-| bigip-username      | string  | Required | n/a         | BIG-IP iControl REST username           |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| bigip-password      | string  | Required | n/a         | BIG-IP iControl REST password           |                |
-|                     |         |          |             | [#secrets]_                             |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| bigip-url           | string  | Required | n/a         | BIG-IP admin IP address                 |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| bigip-partition     | string  | Required | n/a         | The BIG-IP partition in which           |                |
-|                     |         |          |             | to configure objects.                   |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| namespace           | string  | Optional | All         | Kubernetes namespace(s) to watch        |                |
-|                     |         |          |             |                                         |                |
-|                     |         |          |             | - may be a comma-separated list         |                |
-|                     |         |          |             | - watches all namespaces by default     |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| namespace-label     | string  | Optional | n/a         | Tells the ``k8s-bigip-ctlr`` to watch   |                |
-|                     |         |          |             | any namespace with this label           |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| kubeconfig          | string  | Optional | ./config    | Path to the *kubeconfig* file           |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| python-basedir      | string  | Optional | /app/python | Path to python utilities                |                |
-|                     |         |          |             | directory                               |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| running-in-cluster  | boolean | Optional | true        | Indicates whether or not a              | true, false    |
-|                     |         |          |             | kubernetes cluster started              |                |
-|                     |         |          |             | ``k8s-bigip-ctlr``                      |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| use-node-internal   | boolean | Optional | true        | filter Kubernetes InternalIP            | true, false    |
-|                     |         |          |             | addresses for pool members              |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| verify-interval     | integer | Optional | 30          | In seconds, interval at which           |                |
-|                     |         |          |             | to verify the BIG-IP                    |                |
-|                     |         |          |             | configuration.                          |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| node-poll-interval  | integer | Optional | 30          | In seconds, interval at which           |                |
-|                     |         |          |             | to poll the cluster for its             |                |
-|                     |         |          |             | node members.                           |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| node-label-selector | string  | Optional | n/a         | Tells the ``k8s-bigip-ctlr`` to watch   |                |
-|                     |         |          |             | only nodes with this label              |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| log-level           | string  | Optional | INFO        | Log level                               | INFO,          |
-|                     |         |          |             |                                         | DEBUG,         |
-|                     |         |          |             |                                         | CRITICAL,      |
-|                     |         |          |             |                                         | WARNING,       |
-|                     |         |          |             |                                         | ERROR          |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| pool-member-type    | string  | Optional | nodeport    | The type of BIG-IP pool members you want| cluster,       |
-|                     |         |          |             | to create.                              | nodeport       |
-|                     |         |          |             |                                         |                |
-|                     |         |          |             | Use ``cluster`` to create pool members  |                |
-|                     |         |          |             | for each of the endpoints for the       |                |
-|                     |         |          |             | Service (the pod's InternalIP)          |                |
-|                     |         |          |             |                                         |                |
-|                     |         |          |             | Use ``nodeport`` to create pool members |                |
-|                     |         |          |             | for each schedulable node using the     |                |
-|                     |         |          |             | Service's NodePort.                     |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| openshift-sdn-name  | string  | Optional | n/a         | Name of the VXLAN set up on the BIG-IP  |                |
-|                     |         |          |             | system that corresponds to an Openshift |                |
-|                     |         |          |             | SDN HostSubnet.                         |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| manage-routes       | boolean | Optional | false       | Indicates if ``k8s-bigip-ctlr`` should  | true, false    |
-|                     |         |          |             | handle OpenShift Route objects.         |                |
-|                     |         |          |             |                                         |                |
-|                     |         |          |             | **Only applicable in OpenShift.**       |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| route-vserver-addr  | string  | Optional | n/a         | Bind address for virtual server for     |                |
-|                     |         |          |             | OpenShift Route objects.                |                |
-|                     |         |          |             |                                         |                |
-|                     |         |          |             | **Only applicable in OpenShift.**       |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
-| route-label         | string  | Optional | n/a         | Tells the ``k8s-bigip-ctlr`` to only    |                |
-|                     |         |          |             | watch for OpenShift Route objects with  |                |
-|                     |         |          |             | the ``f5type`` label set to this value. |                |
-|                     |         |          |             |                                         |                |
-|                     |         |          |             | **Only applicable in OpenShift.**       |                |
-+---------------------+---------+----------+-------------+-----------------------------------------+----------------+
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| Parameter           | Type    | Required | Default           | Description                             | Allowed Values |
++=====================+=========+==========+===================+=========================================+================+
+| bigip-username      | string  | Required | n/a               | BIG-IP iControl REST username           |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| bigip-password      | string  | Required | n/a               | BIG-IP iControl REST password           |                |
+|                     |         |          |                   | [#secrets]_                             |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| bigip-url           | string  | Required | n/a               | BIG-IP admin IP address                 |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| bigip-partition     | string  | Required | n/a               | The BIG-IP partition in which           |                |
+|                     |         |          |                   | to configure objects.                   |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| namespace           | string  | Optional | All               | Kubernetes namespace(s) to watch        |                |
+|                     |         |          |                   |                                         |                |
+|                     |         |          |                   | - may be a comma-separated list         |                |
+|                     |         |          |                   | - watches all namespaces by default     |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| namespace-label     | string  | Optional | n/a               | Tells the ``k8s-bigip-ctlr`` to watch   |                |
+|                     |         |          |                   | any namespace with this label           |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| kubeconfig          | string  | Optional | ./config          | Path to the *kubeconfig* file           |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| python-basedir      | string  | Optional | /app/python       | Path to python utilities                |                |
+|                     |         |          |                   | directory                               |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| running-in-cluster  | boolean | Optional | true              | Indicates whether or not a              | true, false    |
+|                     |         |          |                   | kubernetes cluster started              |                |
+|                     |         |          |                   | ``k8s-bigip-ctlr``                      |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| use-node-internal   | boolean | Optional | true              | filter Kubernetes InternalIP            | true, false    |
+|                     |         |          |                   | addresses for pool members              |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| verify-interval     | integer | Optional | 30                | In seconds, interval at which           |                |
+|                     |         |          |                   | to verify the BIG-IP                    |                |
+|                     |         |          |                   | configuration.                          |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| node-poll-interval  | integer | Optional | 30                | In seconds, interval at which           |                |
+|                     |         |          |                   | to poll the cluster for its             |                |
+|                     |         |          |                   | node members.                           |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| node-label-selector | string  | Optional | n/a               | Tells the ``k8s-bigip-ctlr`` to watch   |                |
+|                     |         |          |                   | only nodes with this label              |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| log-level           | string  | Optional | INFO              | Log level                               | INFO,          |
+|                     |         |          |                   |                                         | DEBUG,         |
+|                     |         |          |                   |                                         | CRITICAL,      |
+|                     |         |          |                   |                                         | WARNING,       |
+|                     |         |          |                   |                                         | ERROR          |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| pool-member-type    | string  | Optional | nodeport          | The type of BIG-IP pool members you want| cluster,       |
+|                     |         |          |                   | to create.                              | nodeport       |
+|                     |         |          |                   |                                         |                |
+|                     |         |          |                   | Use ``cluster`` to create pool members  |                |
+|                     |         |          |                   | for each of the endpoints for the       |                |
+|                     |         |          |                   | Service (the pod's InternalIP)          |                |
+|                     |         |          |                   |                                         |                |
+|                     |         |          |                   | Use ``nodeport`` to create pool members |                |
+|                     |         |          |                   | for each schedulable node using the     |                |
+|                     |         |          |                   | Service's NodePort.                     |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| openshift-sdn-name  | string  | Optional | n/a               | Name of the VXLAN set up on the BIG-IP  |                |
+|                     |         |          |                   | system that corresponds to an Openshift |                |
+|                     |         |          |                   | SDN HostSubnet.                         |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| manage-routes       | boolean | Optional | false             | Indicates if ``k8s-bigip-ctlr`` should  | true, false    |
+|                     |         |          |                   | handle OpenShift Route objects.         |                |
+|                     |         |          |                   |                                         |                |
+|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| route-vserver-addr  | string  | Optional | n/a               | Bind address for virtual server for     |                |
+|                     |         |          |                   | OpenShift Route objects.                |                |
+|                     |         |          |                   |                                         |                |
+|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| route-label         | string  | Optional | n/a               | Tells the ``k8s-bigip-ctlr`` to only    |                |
+|                     |         |          |                   | watch for OpenShift Route objects with  |                |
+|                     |         |          |                   | the ``f5type`` label set to this value. |                |
+|                     |         |          |                   |                                         |                |
+|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| route-http-vserver  | string  | Optional | ose-vserver       | The name of the http virtual server for |                |
+|                     |         |          |                   | OpenShift Routes.                       |                |
+|                     |         |          |                   |                                         |                |
+|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| route-https-vserver | string  | Optional | https-ose-vserver | The name of the https virtual server    |                |
+|                     |         |          |                   | for OpenShift Routes.                   |                |
+|                     |         |          |                   |                                         |                |
+|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
 
 .. note::
 

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -280,12 +280,6 @@ func formatIngressVSName(ing *v1beta1.Ingress, protocol string) string {
 		ing.ObjectMeta.Namespace, ing.ObjectMeta.Name, protocol)
 }
 
-// format the namespace and name for use in the frontend definition
-func formatRouteVSName(route *routeapi.Route, protocol string) string {
-	return fmt.Sprintf("openshift_%s_%s",
-		route.ObjectMeta.Namespace, protocol)
-}
-
 // format the namespace and name for use in the backend definition
 func formatRoutePoolName(route *routeapi.Route) string {
 	return fmt.Sprintf("openshift_%s_%s",
@@ -704,10 +698,10 @@ func createRSConfigFromRoute(
 
 	if pStruct.protocol == "http" {
 		policyName = "openshift_insecure_routes"
-		rsName = formatRouteVSName(route, "http")
+		rsName = routeConfig.HttpVs
 	} else {
 		policyName = "openshift_secure_routes"
-		rsName = formatRouteVSName(route, "https")
+		rsName = routeConfig.HttpsVs
 	}
 	tls := route.Spec.TLS
 

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -486,8 +486,12 @@ var _ = Describe("Resource Config Tests", func() {
 				protocol: "https",
 				port:     443,
 			}
-			cfg, _ := createRSConfigFromRoute(route, Resources{}, RouteConfig{}, ps)
-			Expect(cfg.Virtual.VirtualServerName).To(Equal("openshift_default_https"))
+			rc := RouteConfig{
+				HttpVs:  "ose-vserver",
+				HttpsVs: "https-ose-vserver",
+			}
+			cfg, _ := createRSConfigFromRoute(route, Resources{}, rc, ps)
+			Expect(cfg.Virtual.VirtualServerName).To(Equal("https-ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_foo"))
 			Expect(cfg.Pools[0].ServiceName).To(Equal("foo"))
 			Expect(cfg.Pools[0].ServicePort).To(Equal(int32(80)))
@@ -507,8 +511,8 @@ var _ = Describe("Resource Config Tests", func() {
 				protocol: "http",
 				port:     80,
 			}
-			cfg, _ = createRSConfigFromRoute(route2, Resources{}, RouteConfig{}, ps)
-			Expect(cfg.Virtual.VirtualServerName).To(Equal("openshift_default_http"))
+			cfg, _ = createRSConfigFromRoute(route2, Resources{}, rc, ps)
+			Expect(cfg.Virtual.VirtualServerName).To(Equal("ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_bar"))
 			Expect(cfg.Pools[0].ServiceName).To(Equal("bar"))
 			Expect(cfg.Pools[0].ServicePort).To(Equal(int32(80)))


### PR DESCRIPTION
Problem: Routes in multiple namespaces were not supported, since a single IP address is supplied
to the controller, and therefore would cause conflicts when attempting to create a new set of virtuals
for a new namespace.

Solution: Rename the virtuals for OpenShift Routes, and only create 2 vservers for all routes in all namespaces.

Fixes #331 