### PR TITLE
Create default client and server profiles for SNI

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -93,6 +93,8 @@ var (
 	routeLabel       *string
 	routeHttpVs      *string
 	routeHttpsVs     *string
+	clientSSL        *string
+	serverSSL        *string
 
 	// package variables
 	isNodePort         bool
@@ -184,6 +186,12 @@ func _init() {
 		"Optional, the name to be used for the OpenShift Route http vserver")
 	routeHttpsVs = osRouteFlags.String("route-https-vserver", "https-ose-vserver",
 		"Optional, the name to be used for the OpenShift Route https vserver")
+	clientSSL = osRouteFlags.String("default-client-ssl", "",
+		"Optional, specify a user-created client ssl profile to be used as"+
+			" default for SNI for Route virtual servers")
+	serverSSL = osRouteFlags.String("default-server-ssl", "",
+		"Optional, specify a user-created server ssl profile to be used as"+
+			" default for SNI for Route virtual servers")
 
 	osRouteFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  Openshift Routes:\n%s\n", osRouteFlags.FlagUsages())
@@ -403,6 +411,8 @@ func main() {
 		RouteLabel:  *routeLabel,
 		HttpVs:      *routeHttpVs,
 		HttpsVs:     *routeHttpsVs,
+		ClientSSL:   *clientSSL,
+		ServerSSL:   *serverSSL,
 	}
 
 	var appMgrParms = appmanager.Params{

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -155,12 +155,36 @@ The configuration parameters below are global to the |kctlr|.
 |                     |         |          |                   |                                         |                |
 |                     |         |          |                   | **Only applicable in OpenShift.**       |                |
 +---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| default-client-ssl  | string  | Optional | n/a               | Specify the name of a user created      |                |
+|                     |         |          |                   | client ssl profile that will be         |                |
+|                     |         |          |                   | attached to the route https vserver and |                |
+|                     |         |          |                   | used as default for SNI. This profile   |                |
+|                     |         |          |                   | must have the Default for SNI field     |                |
+|                     |         |          |                   | enabled.                                |                |
+|                     |         |          |                   |                                         |                |
+|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| default-server-ssl  | string  | Optional | n/a               | Specify the name of a user created      |                |
+|                     |         |          |                   | server ssl profile that will be         |                |
+|                     |         |          |                   | attached to the route https vserver and |                |
+|                     |         |          |                   | used as default for SNI. This profile   |                |
+|                     |         |          |                   | must have the Default for SNI field     |                |
+|                     |         |          |                   | enabled.                                |                |
+|                     |         |          |                   |                                         |                |
+|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
++---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
 
 .. note::
 
   Use the ``node-label-selector`` parameter if you only want the controller to manage specific nodes from the cluster.
   For example, the BIG-IP device may not be able to reach certain nodes, or the BIG-IP device already manages certain
   nodes. Therefore, the controller should only watch the nodes that match the environmental constraints (by using a label).
+  
+.. note::
+
+   If the ``default-client-ssl`` or ``default-server-ssl`` parameters are not provided, then the controller creates default
+   clientssl and serverssl profiles for the OpenShift Route HTTPS virtual server. The controller sets these profiles as
+   Default for SNI. 
 
 .. _f5 resource configmap properties:
 

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -2903,7 +2903,8 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(len(rs.Policies[0].Rules)).To(Equal(1))
 
 					customProfiles := mockMgr.customProfiles()
-					Expect(len(customProfiles)).To(Equal(1))
+					// Should be 1 profile from Spec, and 1 default clientssl
+					Expect(len(customProfiles)).To(Equal(2))
 
 					spec = routeapi.RouteSpec{
 						Host: "barfoo.com",
@@ -2937,14 +2938,15 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(len(rs.Policies[0].Rules)).To(Equal(2))
 
 					customProfiles = mockMgr.customProfiles()
-					Expect(len(customProfiles)).To(Equal(2))
+					// Should be 2 profile from Spec, and 1 default clientssl
+					Expect(len(customProfiles)).To(Equal(3))
 
 					// Delete a Route resource
 					r = mockMgr.deleteRoute(route2)
 					Expect(r).To(BeTrue(), "Route resource should be processed.")
 					Expect(resources.Count()).To(Equal(2))
 					Expect(len(rs.Policies[0].Rules)).To(Equal(1))
-					Expect(len(customProfiles)).To(Equal(1))
+					Expect(len(customProfiles)).To(Equal(2))
 				})
 
 				It("configures passthrough routes", func() {
@@ -3089,7 +3091,9 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(hostDg.Records[0].Data).To(Equal(formatRoutePoolName(route)))
 
 					customProfiles := mockMgr.customProfiles()
-					Expect(len(customProfiles)).To(Equal(2))
+					// Should be 2 profiles from Spec, 2 defaults (clientssl and serverssl)
+					Expect(len(customProfiles)).To(Equal(4))
+					// should have 2 client ssl custom profile and 2 server ssl custom profile
 					// should have 1 client ssl custom profile and 1 server ssl custom profile
 					haveClientSslProfile := false
 					haveServerSslProfile := false
@@ -3105,8 +3109,8 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(haveServerSslProfile).To(BeTrue())
 
 					// and both should be referenced by the virtual
-					Expect(rs.Virtual.GetProfileCountByContext(customProfileClient)).To(Equal(1))
-					Expect(rs.Virtual.GetProfileCountByContext(customProfileServer)).To(Equal(1))
+					Expect(rs.Virtual.GetProfileCountByContext(customProfileClient)).To(Equal(2))
+					Expect(rs.Virtual.GetProfileCountByContext(customProfileServer)).To(Equal(2))
 				})
 			})
 		})

--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -317,7 +317,6 @@ func reformatCustomProfiles(resources PartitionMap, partition string, wg *sync.W
 	defer wg.Done()
 	for i, _ := range resources[partition].CustomProfiles {
 		resources[partition].CustomProfiles[i].Partition = ""
-		resources[partition].CustomProfiles[i].VSName = ""
 	}
 }
 

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -323,22 +323,6 @@ func NewCustomProfiles() CustomProfileStore {
 	return cps
 }
 
-// Return whether or not a there is an SNIDefault profile for a specific VS
-func (cps *CustomProfileStore) SNIDefault(
-	vsname,
-	partition,
-	context string,
-) (string, bool) {
-	for _, cp := range cps.profs {
-		if cp.VSName == vsname &&
-			cp.Partition == partition &&
-			cp.Context == context && cp.SNIDefault {
-			return cp.Name, true
-		}
-	}
-	return "", false
-}
-
 type ResourceConfigMap map[string]*ResourceConfig
 
 // Map of Resource configs
@@ -1084,20 +1068,10 @@ func NewCustomProfile(
 	profile ProfileRef,
 	cert,
 	key,
-	serverName,
-	vsName string,
+	serverName string,
+	sni bool,
 	cProfiles CustomProfileStore,
 ) CustomProfile {
-	// Check to see if there is a custom profile set to SNI Default for this VS.
-	// If not, or if a profile with this name already is SNI Default, then set
-	// SNIDefault to true. (the latter is in the case that we are updating an already
-	// existing profile, so we have to keep SNIDefault to the same value)
-	var sni bool
-	name, found := cProfiles.SNIDefault(vsName, profile.Partition, profile.Context)
-	if !found || name == profile.Name {
-		sni = true
-	}
-
 	return CustomProfile{
 		Name:       profile.Name,
 		Partition:  profile.Partition,
@@ -1106,6 +1080,5 @@ func NewCustomProfile(
 		Key:        key,
 		ServerName: serverName,
 		SNIDefault: sni,
-		VSName:     vsName,
 	}
 }

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -668,7 +668,7 @@ var _ = Describe("Resource Config Tests", func() {
 					"crt",
 					"key",
 					"srver",
-					"vs",
+					false,
 					CustomProfileStore{})
 				refs := virtual.ReferencesProfile(cprof)
 				Expect(refs).To(BeFalse())
@@ -693,7 +693,7 @@ var _ = Describe("Resource Config Tests", func() {
 						"crt",
 						"key",
 						"srver",
-						"vs",
+						false,
 						CustomProfileStore{},
 					)
 					refs := virtual.ReferencesProfile(cprof)
@@ -704,7 +704,7 @@ var _ = Describe("Resource Config Tests", func() {
 						"crt",
 						"key",
 						"srver",
-						"vs",
+						false,
 						CustomProfileStore{})
 					refs := virtual.ReferencesProfile(cprof)
 					Expect(refs).To(BeFalse())

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -236,7 +236,6 @@ type (
 		Key        string `json:"key"`
 		ServerName string `json:"serverName,omitempty"`
 		SNIDefault bool   `json:"sniDefault,omitempty"`
-		VSName     string `json:"-"` // virtual server that uses this profile
 	}
 
 	// Used to unmarshal ConfigMap data


### PR DESCRIPTION
Problem: The controller was using the first https route's cert/key
as the default for SNI for the https virtual server. There was a bug
that either caused none of the Routes to be used, or more than one.

Upon further discussion, we concluded that we don't want to use the Routes'
certs/keys as the default SNI profile, and instead a generic or user-specified default.

Solution: Route certs/keys will no longer be used as default SNI profiles for the https
virtual server. Instead, we will allow the user to create client and server ssl profiles and
specify them via CLI. If none are specified, the controller creates a generic profile, inherited
from either the clientssl or serverssl profiles, and use those as default for SNI.