### PR TITLE
Exclude release notes from docks link checker

### DIFF
--- a/build-tools/docker-docs.sh
+++ b/build-tools/docker-docs.sh
@@ -10,6 +10,7 @@ RUN_ARGS=( \
   --workdir $PWD
   ${DOCKER_RUN_ARGS}
   -e "LOCAL_USER_ID=$(id -u)"
+  -e TRAVIS=$TRAVIS
 )
 
 # Add -it if caller is a terminal

--- a/build-tools/make-docs.sh
+++ b/build-tools/make-docs.sh
@@ -6,6 +6,12 @@ set -e
 echo "Building docs and checking links with Sphinx"
 rm -rf docs/_build
 make -C docs html
+
+# Exclude release notes from linkcheck when running in travis.
+# Note: we've already rendered these - its safe to remove the unneeded source files.
+if [ "$TRAVIS" = true ]; then
+  rm -f docs/RELEASE-NOTES.rst
+fi
 make -C docs linkcheck
 
 echo "Checking grammar and style"


### PR DESCRIPTION
Problem:
linkcheck fails due to links in release notes not
yet live.

Solution:
Remove RELEASE-NOTES.rst file prior to linkcheck. The html file has
already been generated at this point and the source is no longer needed.

Testing:
Tested that the following command passed linkcheck with changes (these
failed previously):
./build-tools/docker-docs.sh build-tools/make-docs.sh

affects-branches: master

Fixes: #337