### PR TITLE
Various OpenShift Route namespace bug fixes

### DIFF
--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -292,6 +292,21 @@ func formatRouteRuleName(route *routeapi.Route) string {
 		route.ObjectMeta.Name)
 }
 
+// format the client ssl profile name for a Route
+func formatRouteClientSSLName(partition, namespace, name string) string {
+	if partition == "" {
+		return fmt.Sprintf("openshift_route_%s_%s-client-ssl",
+			namespace, name)
+	}
+	return fmt.Sprintf("%s/openshift_route_%s_%s-client-ssl",
+		partition, namespace, name)
+}
+
+// format the server ssl profile name for a Route
+func formatRouteServerSSLName(namespace, name string) string {
+	return fmt.Sprintf("openshift_route_%s_%s-server-ssl", namespace, name)
+}
+
 func formatIngressSslProfileName(secret string) string {
 	profName := strings.TrimSpace(strings.TrimPrefix(secret, "/"))
 	parts := strings.Split(profName, "/")


### PR DESCRIPTION
Problem: When services or routes with the same names were created in different namespaces,
this created a myriad of problems.
  1. The client ssl certs would clobber each other due to the
     naming.
  2. Pool members would not be populated for a second service if the service name
     was the same as another.
  3. Internal data groups were not deleted

Solution:
  1. Change the name of client ssl certs to be namespace and route specific.
  2. Make more namespace adjustments to handle services with the same names.
  3. Remove internal data groups when the associated routes are deleted.
  4. Handle data groups for different namespaces.

Fixes #335, #336 