### PR TITLE
Fix copy by reference bug

### DIFF
--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -2945,6 +2945,8 @@ var _ = Describe("AppManager Tests", func() {
 					r = mockMgr.deleteRoute(route2)
 					Expect(r).To(BeTrue(), "Route resource should be processed.")
 					Expect(resources.Count()).To(Equal(2))
+					rs, ok = resources.Get(
+						serviceKey{"foo", 80, "default"}, "https-ose-vserver")
 					Expect(len(rs.Policies[0].Rules)).To(Equal(1))
 					Expect(len(customProfiles)).To(Equal(2))
 				})

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -740,7 +740,8 @@ func createRSConfigFromRoute(
 	cfgs, _ := resources.GetAllWithName(rsName)
 	if len(cfgs) > 0 {
 		// If we do, use an existing config
-		rsCfg = *cfgs[0]
+		rsCfg.copyConfig(cfgs[0])
+
 		// If this pool doesn't already exist, add it
 		var found bool
 		for _, pl := range rsCfg.Pools {
@@ -780,6 +781,18 @@ func createRSConfigFromRoute(
 	}
 
 	return rsCfg, nil
+}
+
+// Copies from an existing config into our new config
+func (rc *ResourceConfig) copyConfig(cfg *ResourceConfig) {
+	rc.MetaData = cfg.MetaData
+	rc.Virtual = cfg.Virtual
+	rc.Pools = make(Pools, len(cfg.Pools))
+	copy(rc.Pools, cfg.Pools)
+	rc.Monitors = make(Monitors, len(cfg.Monitors))
+	copy(rc.Monitors, cfg.Monitors)
+	rc.Policies = make([]Policy, len(cfg.Policies))
+	copy(rc.Policies, cfg.Policies)
 }
 
 func (rc *ResourceConfig) HandleRouteTls(

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -399,13 +399,17 @@ func (appMgr *Manager) updateRouteDataGroups(
 	defer appMgr.intDgMutex.Unlock()
 
 	// If dgMap is empty, delete all records in our internal map for this namespace
+	var toRemove InternalDataGroupRecords
 	if len(dgMap) == 0 {
 		for _, dg := range appMgr.intDgMap {
 			for _, rec := range dg.Records {
 				ns := strings.Split(rec.Data, "_")[1]
 				if ns == namespace {
-					dg.RemoveRecord(rec.Name)
+					toRemove = append(toRemove, rec)
 				}
+			}
+			for _, rec := range toRemove {
+				dg.RemoveRecord(rec.Name)
 			}
 		}
 	}


### PR DESCRIPTION
Problem: When using a pre-existing config as a base for a newly processed config,
the controller would copy by reference instead of value. This resulted in the config from
the cache being updated whenever the newly processed config was updated, keeping both configs
in the same state. This prevented updates from happening.

Solution: Use golang's builtin copy method to copy by value instead of reference.

Fixes #339