### PR TITLE
Fix port update for Routes

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1128,7 +1128,11 @@ func (appMgr *Manager) syncRoutes(
 			for i, cfg := range cfgs {
 				if cfg.Virtual.Partition == rsCfg.Virtual.Partition &&
 					!reflect.DeepEqual(cfg, rsCfg) {
+					mdActive := cfg.MetaData.Active
 					cfg = &rsCfg
+					// If the current rsCfg is inactive, we shouldn't deactivate
+					// other configs for other pools. Only this pool (rsCfg) will be disabled.
+					cfg.MetaData.Active = mdActive
 					appMgr.resources.Assign(keys[i], cfg.Virtual.VirtualServerName, cfg)
 				}
 			}

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -2873,6 +2873,9 @@ var _ = Describe("AppManager Tests", func() {
 					spec := routeapi.RouteSpec{
 						Host: "foobar.com",
 						Path: "/foo",
+						Port: &routeapi.RoutePort{
+							TargetPort: intstr.IntOrString{IntVal: 80},
+						},
 						To: routeapi.RouteTargetReference{
 							Kind: "Service",
 							Name: "foo",
@@ -2949,6 +2952,16 @@ var _ = Describe("AppManager Tests", func() {
 						serviceKey{"foo", 80, "default"}, "https-ose-vserver")
 					Expect(len(rs.Policies[0].Rules)).To(Equal(1))
 					Expect(len(customProfiles)).To(Equal(2))
+
+					// Update Route1 port
+					route.Spec.Port.TargetPort = intstr.IntOrString{IntVal: 443}
+					mockMgr.updateRoute(route)
+					Expect(r).To(BeTrue(), "Route resource should be processed.")
+					rs, ok = resources.Get(
+						serviceKey{"foo", 443, "default"}, "https-ose-vserver")
+					Expect(ok).To(BeTrue(), "Route should be accessible.")
+					Expect(rs).ToNot(BeNil(), "Route should be object.")
+					Expect(rs.Pools[0].ServicePort).To(Equal(int32(443)))
 				})
 
 				It("configures passthrough routes", func() {

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -744,8 +744,12 @@ func createRSConfigFromRoute(
 
 		// If this pool doesn't already exist, add it
 		var found bool
-		for _, pl := range rsCfg.Pools {
+		for i, pl := range rsCfg.Pools {
 			if pl.Name == pool.Name {
+				// If port has changed, update it
+				if pl.ServicePort != pool.ServicePort {
+					rsCfg.Pools[i].ServicePort = pool.ServicePort
+				}
 				found = true
 			}
 		}


### PR DESCRIPTION
Problem: If a port was updated on a Route object, the controller would not update the corresponding
Pool with the new port. There was also an issue that if one Route had an inactive pool, the controller
would deactivate all stored configs when attempting to equalize them.

Solution: Update an existing pool if the port changes. Also, if a pool becomes inactive, don't deactivate
all other stored configs for the Route virtual servers. Simply keep the active state for all other configs.

Fixes #346