### PR TITLE
Add Kubernetes 1.6 and 1.7 support to release notes.

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -7,6 +7,7 @@ Release Notes for BIG-IP Controller for Kubernetes
 Added Functionality
 ```````````````````
 
+* Introduced support for Kubernetes 1.6 and 1.7.
 * Watch all nodes by default; watch a subset of nodes with a user-specified label.
 * Create BIG-IP SSL Profiles from Kubernetes Secrets via Ingress TLS.
 * Create BIG-IP objects from OpenShift Route resources.


### PR DESCRIPTION
Problem: The 1.2.0 release added support for Kubernetes 1.7 but it isn't
noted in the relnotes (it is noted in the docs version compatiblity
matrix)

Solution: Add a bullet to the relnotes.

affects-branches: 1.2-stable