### PR TITLE
Improve travis build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ script:
   - export CLEAN_BUILD=true
   - export BASE_OS=alpine
   - ./build-tools/build-devel-image.sh
-  - ./build-tools/run-in-docker.sh make verify
   - ./build-tools/build-debug-artifacts.sh
   - ./build-tools/build-release-artifacts.sh
   - ./build-tools/build-release-images.sh

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,7 +22,6 @@ pipeline {
           export BUILD_IMG_TAG="${BASE_PUSH_TARGET}-devel:${GIT_COMMIT}-$BASE_OS"
           export CLEAN_BUILD=true
           build-tools/build-devel-image.sh
-          build-tools/run-in-docker.sh make verify
           build-tools/build-debug-artifacts.sh
           build-tools/build-release-artifacts.sh
           build-tools/build-release-images.sh

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,7 @@ pre-build:
 
 prod-build: pre-build
 	@echo "Building with minimal instrumentation..."
+	BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-devel-image.sh
 	BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-release-artifacts.sh
 	BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-release-images.sh
 

--- a/build-tools/_build-lib.sh
+++ b/build-tools/_build-lib.sh
@@ -79,7 +79,7 @@ ginkgo_test_with_coverage () {
   (
     export GOBIN="$BUILDDIR/bin"
     cd "$WKDIR/src/$PKGIMPORT"
-    ginkgo -r -keepGoing -trace -randomizeAllSpecs -progress --nodes 4 -cover
+    ginkgo -r -compilers 1 -keepGoing -trace -randomizeAllSpecs -progress --nodes 4 -cover
     echo "Gathering unit test code coverage for 'release' build..."
     gather_coverage $WKDIR
     rm -rf $WKDIR
@@ -95,7 +95,7 @@ ginkgo_test_with_profile () {
   (
     export GOBIN="$BUILDDIR/bin"
     cd "$WKDIR/src/$PKGIMPORT"
-    ginkgo -r -keepGoing -randomizeAllSpecs -progress --nodes 4 \
+    ginkgo -r -compilers 1 -keepGoing -randomizeAllSpecs -progress --nodes 4 \
             ${BUILD_VARIANT_FLAGS} -- \
             -test.cpuprofile profile.cpu \
             -test.blockprofile profile.block \

--- a/build-tools/build-debug-artifacts.sh
+++ b/build-tools/build-debug-artifacts.sh
@@ -9,16 +9,7 @@ CURDIR="$(dirname $BASH_SOURCE)"
 
 . $CURDIR/_build-lib.sh
 
-# Build the builder image.
-$CURDIR/build-devel-image.sh
-
 # Build artifacts using the build image
 export build_img=$BUILD_DBG_IMG_TAG
+$CURDIR/run-in-docker.sh make verify
 $CURDIR/run-in-docker.sh ./build-tools/dbg-build.sh
-
-if $CLEAN_BUILD; then
-  docker rmi $build_img
-fi
-
-# Now ready to run ./build-debug-images.sh
-

--- a/build-tools/build-release-artifacts.sh
+++ b/build-tools/build-release-artifacts.sh
@@ -9,9 +9,6 @@ CURDIR="$(dirname $BASH_SOURCE)"
 
 . $CURDIR/_build-lib.sh
 
-# Build the builder image.
-$CURDIR/build-devel-image.sh
-
 # Build artifacts using the build image
 $CURDIR/run-in-docker.sh ./build-tools/rel-build.sh
 

--- a/build-tools/fmt.sh
+++ b/build-tools/fmt.sh
@@ -9,8 +9,5 @@ if [ "$CHANGED_FILES" != "" ]; then
     printf "\n\n\nFiles requiring modification:\n\n$CHANGED_FILES\n\n\n";
 fi
 
-# FIXME(lenny) When Gitlab CI will upload artifacts even on build then
-# write the diff to a file and upload it instead of writing the diff
-# only to the logs.
 git diff --exit-code
 exit $?


### PR DESCRIPTION
Problem: The travis build was taking a long time due to the devel containers
being built more times than necessary.

Solution: Remove unnecessary devel builds. Also specified the number of compilers
used in the Ginkgo build. This *may* help with ginkgo run times, though
that has yet to be seen.