### PR TITLE
WIP: Deploy docs in stable branches (do not merge)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,9 +45,9 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      repo: F5Networks/k8s-bigip-ctlr
       condition: $TRAVIS_BRANCH == *"-stable"
     script:
+      - echo "[INFO] REMOVE: running docs deploy step"
       - ctlr_ver=$(echo $TRAVIS_BRANCH | sed s/-stable//g)
       - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/k8s-bigip-ctlr $ctlr_ver
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,12 @@ deploy:
   - provider: script
     skip_cleanup: true
     on:
-      branch: 1.2-stable
+      all_branches: true
       repo: F5Networks/k8s-bigip-ctlr
+      condition: $TRAVIS_BRANCH == *"-stable"
     script:
-      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/k8s-bigip-ctlr v1.2
+      - ctlr_ver=$(echo $TRAVIS_BRANCH | sed s/-stable//g)
+      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/k8s-bigip-ctlr $ctlr_ver
 
 notifications:
   slack:


### PR DESCRIPTION
Problem:
The current logic in the travis file has specific knowledge about
version numbers for stable branches when deploying product docs to
clouddocs. This should be done in a version agnostic manner.

Solution:
Added logic to the docs deploy step so that it is applicable across all
stable branches.

Testing:
Ran these changes on the stable branch to see that the docs deploy step
was executed.

(cherry picked from commit bf676c4db9f4ecd3e04fd470c4d73e1cc3e37525)