### PR TITLE
Deploy docs on stable branches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ script:
   - export BUILD_IMG_TAG="${BASE_PUSH_TARGET}-devel:${TRAVIS_COMMIT}"
   - export CLEAN_BUILD=true
   - export BASE_OS=alpine
+  - export CTLR_VERSION=$(echo $TRAVIS_BRANCH | sed s/-stable//g)
   - ./build-tools/build-devel-image.sh
   - ./build-tools/run-in-docker.sh make verify
   - ./build-tools/build-debug-artifacts.sh
@@ -44,10 +45,11 @@ deploy:
   - provider: script
     skip_cleanup: true
     on:
-      branch: 1.1-stable
+      all_branches: true
       repo: F5Networks/k8s-bigip-ctlr
+      condition: $TRAVIS_BRANCH == *"-stable"
     script:
-      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/k8s-bigip-ctlr v1.1
+      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/k8s-bigip-ctlr $CTLR_VERSION
 
 notifications:
   slack:


### PR DESCRIPTION
Problem:
The current logic in the travis file has specific knowledge about
version numbers for stable branches when deploying product docs to
clouddocs. This should be done in a version agnostic manner.

Solution:
Added logic to the docs deploy step so that it is applicable across all
stable branches.

Testing:
Ran these changes on the stable branch to see that the docs deploy step
was executed.

affects-branches: master, 1.2-stable