### PR TITLE
Add missing version prefix while deploying docs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,7 +49,7 @@ deploy:
       repo: F5Networks/k8s-bigip-ctlr
       condition: $TRAVIS_BRANCH == *"-stable"
     script:
-      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/k8s-bigip-ctlr $CTLR_VERSION
+      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/k8s-bigip-ctlr v$CTLR_VERSION
 
 notifications:
   slack:


### PR DESCRIPTION
Problem:
The previous commit to add support for version agnostic
deploy documentation missed adding the version prefix 'v'.

Solution:
Added missing version prefix.

Testing:
Ran these changes on the stable branch to see that the docs deploy step
was executed.

affects-branches: master, 1.2-stable