### PR TITLE
Add docker latest tag and docker label to allow pinned image for tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
     fi
   - export IMG_TAG="${BASE_PUSH_TARGET}:${TRAVIS_COMMIT}"
   - export BUILD_IMG_TAG="${BASE_PUSH_TARGET}-devel:${TRAVIS_COMMIT}"
+  - export BUILD_STAMP=devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID-$(date +%s)
   - export CLEAN_BUILD=true
   - export BASE_OS=alpine
   - export CTLR_VERSION=$(echo $TRAVIS_BRANCH | sed s/-stable//g)
@@ -34,8 +35,11 @@ script:
     if [ "$DOCKER_READY" ]; then
       docker tag "$IMG_TAG" "$BASE_PUSH_TARGET"
       docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
-      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
-      docker push "$BASE_PUSH_TARGET"
+      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:$BUILD_STAMP"
+      docker push "$IMG_TAG"
+      docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
+      docker push "$BASE_PUSH_TARGET:$BUILD_STAMP"
+      docker push "$BASE_PUSH_TARGET:latest"
     fi
   - make docs
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,12 @@ script:
   - ./build-tools/build-debug-artifacts.sh
   - ./build-tools/build-release-artifacts.sh
   - ./build-tools/build-release-images.sh
-  - docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
-  - docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
   - |
     if [ "$DOCKER_READY" ]; then
-      docker push "$IMG_TAG"
-      docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
-      docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
+      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET"
+      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
+      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
+      docker push "$BASE_PUSH_TARGET"
     fi
   - make docs
 

--- a/build-tools/build-release-images.sh
+++ b/build-tools/build-release-images.sh
@@ -30,6 +30,7 @@ ls -la $WKDIR
 
 docker build --force-rm ${NO_CACHE_ARGS} \
   -t $IMG_TAG \
+  --label BUILD_STAMP=$BUILD_STAMP \
   -f $WKDIR/Dockerfile.runtime \
   $WKDIR
 


### PR DESCRIPTION
Problem:
- Dockerhub images did not have "latest" tag
- images need to be able to be specifically referenced in automated regression tests

Solution:
- Updated tagging to included latest
- Added timestamp to build tag and included that information as a docker label to make it available to docker inspect in regression set up.