### PR TITLE
Client and server ssl annotations for Routes

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -543,6 +543,21 @@ Supported Route Configurations
 
    - To expose a Service on any other ports. **specify the port in the Route config's "Port" field**.
 
+Supported annotations
+`````````````````````
+
++------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
+| Annotation                         | Type        | Required  | Description                                                                         | Default     |
++====================================+=============+===========+=====================================================================================+=============+
+| virtual-server.f5.com/clientssl    | string      | Optional  | The name of a pre-configured client ssl profile on the BIG-IP system.               | N/A         |
+|                                    |             |           | The controller uses this profile instead of the certificate and key within the      |             |
+|                                    |             |           | Route's configuration.                                                              |             |
++------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
+| virtual-server.f5.com/serverssl    | string      | Optional  | The name of a pre-configured server ssl profile on the BIG-IP system.               | N/A         |
+|                                    |             |           | The controller uses this profile instead of the certificate within the              |             |
+|                                    |             |           | Route's configuration.                                                              |             |
++------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
+
 Please see the example configuration files for more details.
 
 Example Configuration Files

--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -173,6 +173,7 @@ func (appMgr *Manager) outputConfigLocked() {
 				log.Infof("Wrote %v Virtual Server configs", virtualCount)
 				if log.LL_DEBUG == log.GetLogLevel() {
 					// Remove customProfiles from output
+					// FIXME (sberman): Issue #365
 					for partition, _ := range resources {
 						resources[partition].CustomProfiles = []CustomProfile{}
 					}

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -481,7 +481,7 @@ var _ = Describe("Resource Config Tests", func() {
 					Key:         "key",
 				},
 			}
-			route := test.NewRoute("route", "1", namespace, spec)
+			route := test.NewRoute("route", "1", namespace, spec, nil)
 			ps := portStruct{
 				protocol: "https",
 				port:     443,
@@ -506,7 +506,7 @@ var _ = Describe("Resource Config Tests", func() {
 					Name: "bar",
 				},
 			}
-			route2 := test.NewRoute("route2", "1", namespace, spec)
+			route2 := test.NewRoute("route2", "1", namespace, spec, nil)
 			ps = portStruct{
 				protocol: "http",
 				port:     80,

--- a/pkg/appmanager/routing_test.go
+++ b/pkg/appmanager/routing_test.go
@@ -99,7 +99,7 @@ var _ = Describe("Routing Tests", func() {
 					Termination: routeapi.TLSTerminationEdge,
 				},
 			}
-			ok := appMgr.addRoute(test.NewRoute(routeName, "1", namespace, spec))
+			ok := appMgr.addRoute(test.NewRoute(routeName, "1", namespace, spec, nil))
 			Expect(ok).To(BeTrue(), "Route resource should be processed.")
 		}
 

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -32,7 +32,7 @@ type (
 		IApps              []IApp              `json:"iapps,omitempty"`
 	}
 
-	// Config for a single resource (ConfigMap or Ingress)
+	// Config for a single resource (ConfigMap, Ingress, or Route)
 	ResourceConfig struct {
 		MetaData metaData `json:"-"`
 		Virtual  Virtual  `json:"virtual,omitempty"`
@@ -46,6 +46,15 @@ type (
 		Active       bool
 		NodePort     int32
 		ResourceType string
+		// Only used for Routes (for keeping track of annotated profiles)
+		RouteProfs map[routeKey]string
+	}
+
+	// Key used to store annotated profiles for a route
+	routeKey struct {
+		Name      string
+		Namespace string
+		Context   string
 	}
 
 	// Reference to pre-existing profiles

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -149,7 +149,13 @@ func NewIngress(id, rv, namespace string,
 }
 
 // NewRoute returns a new route object
-func NewRoute(id, rv, namespace string, spec routeapi.RouteSpec) *routeapi.Route {
+func NewRoute(
+	id,
+	rv,
+	namespace string,
+	spec routeapi.RouteSpec,
+	annotations map[string]string,
+) *routeapi.Route {
 	return &routeapi.Route{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Route",
@@ -159,6 +165,7 @@ func NewRoute(id, rv, namespace string, spec routeapi.RouteSpec) *routeapi.Route
 			Name:            id,
 			ResourceVersion: rv,
 			Namespace:       namespace,
+			Annotations:     annotations,
 		},
 		Spec: spec,
 	}


### PR DESCRIPTION
Problem: Users may not want to use the certs/keys exposed in the Route resource
configuration. Instead, a user wants to use a pre-defined profile from the BIG-IP
to be linked to the Route.

Solution: Add annotations for Route resources to allow users to specify profiles on the BIG-IP
to use instead of creating a custom profile from the certs/keys within the Route config.