### PR TITLE
Remove f5-sdk dependency from K8s/OS ctlr

### DIFF
--- a/python/k8s-build-requirements.txt
+++ b/python/k8s-build-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@9761c6f05226c562688502c879f21d3e955621b1#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@4c0a4fc9b15ef0adacdd45bdaf789ddfdbb68f5c#egg=f5-cccl
 pytest==3.0.2
 mock
 flake8

--- a/python/k8s-runtime-requirements.txt
+++ b/python/k8s-runtime-requirements.txt
@@ -1,6 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@9761c6f05226c562688502c879f21d3e955621b1#egg=f5-cccl
-f5-icontrol-rest==1.3.0
-f5-sdk==3.0.1
+-e git+https://github.com/f5devcentral/f5-cccl.git@4c0a4fc9b15ef0adacdd45bdaf789ddfdbb68f5c#egg=f5-cccl
 pyinotify==0.9.6
 ipaddress==1.0.17
 PyJWT==1.4.0

--- a/python/tests/test_bigipconfigdriver.py
+++ b/python/tests/test_bigipconfigdriver.py
@@ -113,10 +113,9 @@ _expected_bigip_config = {
 }
 
 
-class MockMgr(bigipconfigdriver.K8sCloudServiceManager):
+class MockMgr(bigipconfigdriver.CloudServiceManager):
     def __init__(self, fail=False, notify_event=None, notify_after=0,
                  handle_results=None):
-        self._cloud = 'k8s'
         self._partition = _cloud_config['bigip']['partition']
         self.calls = 0
         self._fail = fail
@@ -1245,7 +1244,7 @@ def test_confighandler_backoff_time(request):
         assert handler._interval.is_running() is False
 
 
-class MockApplyConfigMgr(bigipconfigdriver.K8sCloudServiceManager):
+class MockApplyConfigMgr(bigipconfigdriver.CloudServiceManager):
 
     def __init__(self, returns):
         self._returns = returns


### PR DESCRIPTION
Moved code that configures vxlan tunnels and custom profiles via the f5-sdk
to CCCL and removed the dependency upon the f5-sdk and f5-icontrol-rest.