### PR TITLE
Allow users to disable Secret SSL loading

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -82,6 +82,7 @@ var (
 	manageRoutes      *bool
 	nodeLabelSelector *string
 	resolveIngNames   *string
+	useSecrets        *bool
 
 	bigIPURL        *string
 	bigIPUsername   *string
@@ -162,7 +163,8 @@ func _init() {
 			"'cluster' will use service endpoints. "+
 			"The BIG-IP must be able access the cluster network")
 	inCluster = kubeFlags.Bool("running-in-cluster", true,
-		"Optional, if this controller is running in a kubernetes cluster, use the pod secrets for creating a Kubernetes client.")
+		"Optional, if this controller is running in a kubernetes cluster,"+
+			"use the pod secrets for creating a Kubernetes client.")
 	kubeConfig = kubeFlags.String("kubeconfig", "./config",
 		"Optional, absolute path to the kubeconfig file")
 	namespaceLabel = kubeFlags.String("namespace-label", "",
@@ -175,6 +177,8 @@ func _init() {
 		"Optional, direct the controller to resolve host names in Ingresses into IP addresses. "+
 			"The 'LOOKUP' option will use the controller's built-in DNS. "+
 			"Any other string will be used as a custom DNS server, either by name or IP address.")
+	useSecrets = kubeFlags.Bool("use-secrets", true,
+		"Optional, enable/disable use of Secrets for Ingress or ConfigMap SSL Profiles.")
 
 	// If the flag is specified with no argument, default to LOOKUP
 	kubeFlags.Lookup("resolve-ingress-names").NoOptDefVal = "LOOKUP"
@@ -442,6 +446,7 @@ func main() {
 		RouteConfig:       routeConfig,
 		NodeLabelSelector: *nodeLabelSelector,
 		ResolveIngress:    *resolveIngNames,
+		UseSecrets:        *useSecrets,
 	}
 
 	gs := globalSection{

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -64,130 +64,136 @@ Controller Configuration Parameters
 -----------------------------------
 The configuration parameters below are global to the |kctlr|.
 
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| Parameter           | Type    | Required | Default           | Description                             | Allowed Values |
-+=====================+=========+==========+===================+=========================================+================+
-| bigip-username      | string  | Required | n/a               | BIG-IP iControl REST username           |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| bigip-password      | string  | Required | n/a               | BIG-IP iControl REST password           |                |
-|                     |         |          |                   | [#secrets]_                             |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| bigip-url           | string  | Required | n/a               | BIG-IP admin IP address                 |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| bigip-partition     | string  | Required | n/a               | The BIG-IP partition in which           |                |
-|                     |         |          |                   | to configure objects.                   |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| namespace           | string  | Optional | All               | Kubernetes namespace(s) to watch        |                |
-|                     |         |          |                   |                                         |                |
-|                     |         |          |                   | - may be a comma-separated list         |                |
-|                     |         |          |                   | - watches all namespaces by default     |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| namespace-label     | string  | Optional | n/a               | Tells the ``k8s-bigip-ctlr`` to watch   |                |
-|                     |         |          |                   | any namespace with this label           |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| kubeconfig          | string  | Optional | ./config          | Path to the *kubeconfig* file           |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| python-basedir      | string  | Optional | /app/python       | Path to python utilities                |                |
-|                     |         |          |                   | directory                               |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| running-in-cluster  | boolean | Optional | true              | Indicates whether or not a              | true, false    |
-|                     |         |          |                   | kubernetes cluster started              |                |
-|                     |         |          |                   | ``k8s-bigip-ctlr``                      |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| use-node-internal   | boolean | Optional | true              | filter Kubernetes InternalIP            | true, false    |
-|                     |         |          |                   | addresses for pool members              |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| verify-interval     | integer | Optional | 30                | In seconds, interval at which           |                |
-|                     |         |          |                   | to verify the BIG-IP                    |                |
-|                     |         |          |                   | configuration.                          |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| node-poll-interval  | integer | Optional | 30                | In seconds, interval at which           |                |
-|                     |         |          |                   | to poll the cluster for its             |                |
-|                     |         |          |                   | node members.                           |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| node-label-selector | string  | Optional | n/a               | Tells the ``k8s-bigip-ctlr`` to watch   |                |
-|                     |         |          |                   | only nodes with this label              |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| log-level           | string  | Optional | INFO              | Log level                               | INFO,          |
-|                     |         |          |                   |                                         | DEBUG,         |
-|                     |         |          |                   |                                         | CRITICAL,      |
-|                     |         |          |                   |                                         | WARNING,       |
-|                     |         |          |                   |                                         | ERROR          |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| resolve-ingress-names | string  | Optional | n/a             | Tells the controller to resolve the     |                |
-|                       |         |          |                 | first Host in an Ingress resource to an |                |
-|                       |         |          |                 | IP address. This IP address will be     |                |
-|                       |         |          |                 | used as the virtual server address for  |                |
-|                       |         |          |                 | the Ingress resource.                   |                |
-|                       |         |          |                 |                                         |                |
-|                       |         |          |                 | A value of "LOOKUP" will use local DNS  |                |
-|                       |         |          |                 | to resolve the Host. Any other value    |                |
-|                       |         |          |                 | is a custom DNS server and the          |                |
-|                       |         |          |                 | controller sends resolution queries     |                |
-|                       |         |          |                 | through that server instead.            |                |
-|                       |         |          |                 |                                         |                |
-|                       |         |          |                 | Specifying the flag with no argument    |                |
-|                       |         |          |                 | will default to LOOKUP.                 |                |
-+-----------------------+---------+----------+-----------------+-----------------------------------------+----------------+
-| pool-member-type    | string  | Optional | nodeport          | The type of BIG-IP pool members you want| cluster,       |
-|                     |         |          |                   | to create.                              | nodeport       |
-|                     |         |          |                   |                                         |                |
-|                     |         |          |                   | Use ``cluster`` to create pool members  |                |
-|                     |         |          |                   | for each of the endpoints for the       |                |
-|                     |         |          |                   | Service (the pod's InternalIP)          |                |
-|                     |         |          |                   |                                         |                |
-|                     |         |          |                   | Use ``nodeport`` to create pool members |                |
-|                     |         |          |                   | for each schedulable node using the     |                |
-|                     |         |          |                   | Service's NodePort.                     |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| openshift-sdn-name  | string  | Optional | n/a               | Name of the VXLAN set up on the BIG-IP  |                |
-|                     |         |          |                   | system that corresponds to an Openshift |                |
-|                     |         |          |                   | SDN HostSubnet.                         |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| manage-routes       | boolean | Optional | false             | Indicates if ``k8s-bigip-ctlr`` should  | true, false    |
-|                     |         |          |                   | handle OpenShift Route objects.         |                |
-|                     |         |          |                   |                                         |                |
-|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| route-vserver-addr  | string  | Optional | n/a               | Bind address for virtual server for     |                |
-|                     |         |          |                   | OpenShift Route objects.                |                |
-|                     |         |          |                   |                                         |                |
-|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| route-label         | string  | Optional | n/a               | Tells the ``k8s-bigip-ctlr`` to only    |                |
-|                     |         |          |                   | watch for OpenShift Route objects with  |                |
-|                     |         |          |                   | the ``f5type`` label set to this value. |                |
-|                     |         |          |                   |                                         |                |
-|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| route-http-vserver  | string  | Optional | ose-vserver       | The name of the http virtual server for |                |
-|                     |         |          |                   | OpenShift Routes.                       |                |
-|                     |         |          |                   |                                         |                |
-|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| route-https-vserver | string  | Optional | https-ose-vserver | The name of the https virtual server    |                |
-|                     |         |          |                   | for OpenShift Routes.                   |                |
-|                     |         |          |                   |                                         |                |
-|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| default-client-ssl  | string  | Optional | n/a               | Specify the name of a user created      |                |
-|                     |         |          |                   | client ssl profile that will be         |                |
-|                     |         |          |                   | attached to the route https vserver and |                |
-|                     |         |          |                   | used as default for SNI. This profile   |                |
-|                     |         |          |                   | must have the Default for SNI field     |                |
-|                     |         |          |                   | enabled.                                |                |
-|                     |         |          |                   |                                         |                |
-|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
-| default-server-ssl  | string  | Optional | n/a               | Specify the name of a user created      |                |
-|                     |         |          |                   | server ssl profile that will be         |                |
-|                     |         |          |                   | attached to the route https vserver and |                |
-|                     |         |          |                   | used as default for SNI. This profile   |                |
-|                     |         |          |                   | must have the Default for SNI field     |                |
-|                     |         |          |                   | enabled.                                |                |
-|                     |         |          |                   |                                         |                |
-|                     |         |          |                   | **Only applicable in OpenShift.**       |                |
-+---------------------+---------+----------+-------------------+-----------------------------------------+----------------+
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| Parameter             | Type    | Required | Default           | Description                             | Allowed Values |
++=======================+=========+==========+===================+=========================================+================+
+| bigip-username        | string  | Required | n/a               | BIG-IP iControl REST username           |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| bigip-password        | string  | Required | n/a               | BIG-IP iControl REST password           |                |
+|                       |         |          |                   | [#secrets]_                             |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| bigip-url             | string  | Required | n/a               | BIG-IP admin IP address                 |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| bigip-partition       | string  | Required | n/a               | The BIG-IP partition in which           |                |
+|                       |         |          |                   | to configure objects.                   |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| namespace             | string  | Optional | All               | Kubernetes namespace(s) to watch        |                |
+|                       |         |          |                   |                                         |                |
+|                       |         |          |                   | - may be a comma-separated list         |                |
+|                       |         |          |                   | - watches all namespaces by default     |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| namespace-label       | string  | Optional | n/a               | Tells the ``k8s-bigip-ctlr`` to watch   |                |
+|                       |         |          |                   | any namespace with this label           |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| kubeconfig            | string  | Optional | ./config          | Path to the *kubeconfig* file           |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| python-basedir        | string  | Optional | /app/python       | Path to python utilities                |                |
+|                       |         |          |                   | directory                               |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| running-in-cluster    | boolean | Optional | true              | Indicates whether or not a              | true, false    |
+|                       |         |          |                   | kubernetes cluster started              |                |
+|                       |         |          |                   | ``k8s-bigip-ctlr``                      |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| use-node-internal     | boolean | Optional | true              | filter Kubernetes InternalIP            | true, false    |
+|                       |         |          |                   | addresses for pool members              |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| verify-interval       | integer | Optional | 30                | In seconds, interval at which           |                |
+|                       |         |          |                   | to verify the BIG-IP                    |                |
+|                       |         |          |                   | configuration.                          |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| node-poll-interval    | integer | Optional | 30                | In seconds, interval at which           |                |
+|                       |         |          |                   | to poll the cluster for its             |                |
+|                       |         |          |                   | node members.                           |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| node-label-selector   | string  | Optional | n/a               | Tells the ``k8s-bigip-ctlr`` to watch   |                |
+|                       |         |          |                   | only nodes with this label              |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| log-level             | string  | Optional | INFO              | Log level                               | INFO,          |
+|                       |         |          |                   |                                         | DEBUG,         |
+|                       |         |          |                   |                                         | CRITICAL,      |
+|                       |         |          |                   |                                         | WARNING,       |
+|                       |         |          |                   |                                         | ERROR          |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| resolve-ingress-names | string  | Optional | n/a               | Tells the controller to resolve the     |                |
+|                       |         |          |                   | first Host in an Ingress resource to an |                |
+|                       |         |          |                   | IP address. This IP address will be     |                |
+|                       |         |          |                   | used as the virtual server address for  |                |
+|                       |         |          |                   | the Ingress resource.                   |                |
+|                       |         |          |                   |                                         |                |
+|                       |         |          |                   | A value of "LOOKUP" will use local DNS  |                |
+|                       |         |          |                   | to resolve the Host. Any other value    |                |
+|                       |         |          |                   | is a custom DNS server and the          |                |
+|                       |         |          |                   | controller sends resolution queries     |                |
+|                       |         |          |                   | through that server instead.            |                |
+|                       |         |          |                   |                                         |                |
+|                       |         |          |                   | Specifying the flag with no argument    |                |
+|                       |         |          |                   | will default to LOOKUP.                 |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| pool-member-type      | string  | Optional | nodeport          | The type of BIG-IP pool members you want| cluster,       |
+|                       |         |          |                   | to create.                              | nodeport       |
+|                       |         |          |                   |                                         |                |
+|                       |         |          |                   | Use ``cluster`` to create pool members  |                |
+|                       |         |          |                   | for each of the endpoints for the       |                |
+|                       |         |          |                   | Service (the pod's InternalIP)          |                |
+|                       |         |          |                   |                                         |                |
+|                       |         |          |                   | Use ``nodeport`` to create pool members |                |
+|                       |         |          |                   | for each schedulable node using the     |                |
+|                       |         |          |                   | Service's NodePort.                     |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| openshift-sdn-name    | string  | Optional | n/a               | Name of the VXLAN set up on the BIG-IP  |                |
+|                       |         |          |                   | system that corresponds to an Openshift |                |
+|                       |         |          |                   | SDN HostSubnet.                         |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| manage-routes         | boolean | Optional | false             | Indicates if ``k8s-bigip-ctlr`` should  | true, false    |
+|                       |         |          |                   | handle OpenShift Route objects.         |                |
+|                       |         |          |                   |                                         |                |
+|                       |         |          |                   | **Only applicable in OpenShift.**       |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| route-vserver-addr    | string  | Optional | n/a               | Bind address for virtual server for     |                |
+|                       |         |          |                   | OpenShift Route objects.                |                |
+|                       |         |          |                   |                                         |                |
+|                       |         |          |                   | **Only applicable in OpenShift.**       |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| route-label           | string  | Optional | n/a               | Tells the ``k8s-bigip-ctlr`` to only    |                |
+|                       |         |          |                   | watch for OpenShift Route objects with  |                |
+|                       |         |          |                   | the ``f5type`` label set to this value. |                |
+|                       |         |          |                   |                                         |                |
+|                       |         |          |                   | **Only applicable in OpenShift.**       |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| route-http-vserver    | string  | Optional | ose-vserver       | The name of the http virtual server for |                |
+|                       |         |          |                   | OpenShift Routes.                       |                |
+|                       |         |          |                   |                                         |                |
+|                       |         |          |                   | **Only applicable in OpenShift.**       |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| route-https-vserver   | string  | Optional | https-ose-vserver | The name of the https virtual server    |                |
+|                       |         |          |                   | for OpenShift Routes.                   |                |
+|                       |         |          |                   |                                         |                |
+|                       |         |          |                   | **Only applicable in OpenShift.**       |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| default-client-ssl    | string  | Optional | n/a               | Specify the name of a user created      |                |
+|                       |         |          |                   | client ssl profile that will be         |                |
+|                       |         |          |                   | attached to the route https vserver and |                |
+|                       |         |          |                   | used as default for SNI. This profile   |                |
+|                       |         |          |                   | must have the Default for SNI field     |                |
+|                       |         |          |                   | enabled.                                |                |
+|                       |         |          |                   |                                         |                |
+|                       |         |          |                   | **Only applicable in OpenShift.**       |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| default-server-ssl    | string  | Optional | n/a               | Specify the name of a user created      |                |
+|                       |         |          |                   | server ssl profile that will be         |                |
+|                       |         |          |                   | attached to the route https vserver and |                |
+|                       |         |          |                   | used as default for SNI. This profile   |                |
+|                       |         |          |                   | must have the Default for SNI field     |                |
+|                       |         |          |                   | enabled.                                |                |
+|                       |         |          |                   |                                         |                |
+|                       |         |          |                   | **Only applicable in OpenShift.**       |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| use-secrets           | boolean | Optional | true              | Tells the controller whether or not     | true, false    |
+|                       |         |          |                   | to load SSL profiles from Kubernetes    |                |
+|                       |         |          |                   | Secrets for Ingresses and ConfigMaps.   |                |
+|                       |         |          |                   | If false, the controller will only use  |                |
+|                       |         |          |                   | profiles from the BIG-IP system.        |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
 
 .. note::
 

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -2797,6 +2797,7 @@ var _ = Describe("AppManager Tests", func() {
 			})
 
 			It("creates ssl profiles from Secrets", func() {
+				mockMgr.appMgr.useSecrets = true
 				// Create a secret
 				secret := &v1.Secret{
 					ObjectMeta: metav1.ObjectMeta{
@@ -2859,6 +2860,11 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(len(customProfiles)).To(Equal(2))
 				mockMgr.deleteConfigMap(secretCfg)
 				Expect(len(customProfiles)).To(Equal(1))
+
+				// Turn off secret loading; should remove the customProfile
+				mockMgr.appMgr.useSecrets = false
+				mockMgr.updateIngress(ingress)
+				Expect(len(customProfiles)).To(Equal(0))
 			})
 
 			Context("Routes", func() {


### PR DESCRIPTION
Problem: Users may be uncomfortable with the controller looking for Secrets for custom SSL
profile loading. Even if a user doesn't provide a secret name to the Ingress or ConfigMap,
the controller still looks for a secret before defaulting to a BIG-IP profile.

Solution: Add a CLI flag to disable the controller from ever trying to look for Secrets to
load SSL profiles from. By default, this flag is enabled to true (backwards compatability),
but the user can set to false if desired.