### PR TITLE
targetPort flexibility for Routes

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -540,14 +540,6 @@ Supported Route Configurations
 |                         |                   |                   |         |                 | SNI and forward the re-encrypted traffic.                               |
 +-------------------------+-------------------+-------------------+---------+-----------------+-------------------------------------------------------------------------+
 
-.. important::
-
-   - By default, the Controller configures all pool members for Passthrough or Re-encrypt Routes on port 443.
-     The Controller expects a Service running on 443 for these types of Routes.
-
-   - For Edge and Unsecured Route types, the default backend port is 80.
-
-   - To expose a Service on any other port, **specify the port number in the Route config's "Port: TargetPort" field**.
 
 Supported annotations
 `````````````````````

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -14,6 +14,17 @@ Added Functionality
 * Resolve the first host name in an Ingress to an IP address using a local or custom DNS server. The controller
   configures the virtual server with this address.
 
+Bug Fixes
+`````````
+* OpenShift Route targetPort field is no longer required if the port is not 80 or 443.
+* Properly configures named targetPorts in OpenShift Route configurations.
+
+Limitations
+~~~~~~~~~~~
+
+* If a Route configuration contains no targetPort, the controller uses the first port it sees
+  on the referenced Service. The controller does not use all ports.
+
 v1.2.0
 ------
 

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1120,7 +1120,7 @@ func (appMgr *Manager) syncRoutes(
 			{protocol: "https", port: DEFAULT_HTTPS_PORT}}
 		for _, ps := range pStructs {
 			rsCfg, err, pool := createRSConfigFromRoute(route,
-				*appMgr.resources, appMgr.routeConfig, ps)
+				*appMgr.resources, appMgr.routeConfig, ps, appInf.svcInformer.GetIndexer())
 			if err != nil {
 				// We return err if there was an error creating a rule
 				log.Warningf("%v", err)
@@ -1176,7 +1176,8 @@ func (appMgr *Manager) syncRoutes(
 					cfg = &rsCfg
 					// If the current rsCfg is inactive, we shouldn't deactivate
 					// other configs for other pools. Only this pool (rsCfg) will be disabled.
-					cfg.MetaData.Active = mdActive
+					// If the rsCfg IS active, then stored cfg should be active
+					cfg.MetaData.Active = mdActive || rsCfg.MetaData.Active
 					appMgr.resources.Assign(keys[i], cfg.Virtual.VirtualServerName, cfg)
 				}
 			}

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -2879,12 +2879,12 @@ var _ = Describe("AppManager Tests", func() {
 					spec := routeapi.RouteSpec{
 						Host: "foobar.com",
 						Path: "/foo",
-						Port: &routeapi.RoutePort{
-							TargetPort: intstr.IntOrString{IntVal: 80},
-						},
 						To: routeapi.RouteTargetReference{
 							Kind: "Service",
 							Name: "foo",
+						},
+						Port: &routeapi.RoutePort{
+							TargetPort: intstr.FromString("foo-80"),
 						},
 						TLS: &routeapi.TLSConfig{
 							Termination: "edge",
@@ -2899,7 +2899,7 @@ var _ = Describe("AppManager Tests", func() {
 					resources := mockMgr.resources()
 					// Associate a service
 					fooSvc := test.NewService("foo", "1", namespace, "NodePort",
-						[]v1.ServicePort{{Port: 80, NodePort: 37001}})
+						[]v1.ServicePort{{Name: "foo-80", Port: 80, NodePort: 37001}})
 					r = mockMgr.addService(fooSvc)
 					Expect(r).To(BeTrue(), "Service should be processed.")
 					Expect(resources.Count()).To(Equal(2))

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -475,6 +475,9 @@ var _ = Describe("Resource Config Tests", func() {
 					Kind: "Service",
 					Name: "foo",
 				},
+				Port: &routeapi.RoutePort{
+					TargetPort: intstr.FromInt(80),
+				},
 				TLS: &routeapi.TLSConfig{
 					Termination: "edge",
 					Certificate: "cert",
@@ -490,7 +493,7 @@ var _ = Describe("Resource Config Tests", func() {
 				HttpVs:  "ose-vserver",
 				HttpsVs: "https-ose-vserver",
 			}
-			cfg, _, _ := createRSConfigFromRoute(route, Resources{}, rc, ps)
+			cfg, _, _ := createRSConfigFromRoute(route, Resources{}, rc, ps, nil)
 			Expect(cfg.Virtual.VirtualServerName).To(Equal("https-ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_foo"))
 			Expect(cfg.Pools[0].ServiceName).To(Equal("foo"))
@@ -505,13 +508,16 @@ var _ = Describe("Resource Config Tests", func() {
 					Kind: "Service",
 					Name: "bar",
 				},
+				Port: &routeapi.RoutePort{
+					TargetPort: intstr.FromInt(80),
+				},
 			}
 			route2 := test.NewRoute("route2", "1", namespace, spec, nil)
 			ps = portStruct{
 				protocol: "http",
 				port:     80,
 			}
-			cfg, _, _ = createRSConfigFromRoute(route2, Resources{}, rc, ps)
+			cfg, _, _ = createRSConfigFromRoute(route2, Resources{}, rc, ps, nil)
 			Expect(cfg.Virtual.VirtualServerName).To(Equal("ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_bar"))
 			Expect(cfg.Pools[0].ServiceName).To(Equal("bar"))


### PR DESCRIPTION
Problem: OpenShift users would need to hard code a Route's targetPort if the port was
something other than what we already assumed. This was an inconvenience for the user. The controller
also would not recognize port names, such as "8080-tcp", rather than port numbers. The OpenShift
GUI creates Routes in this manner.

Solution: The controller will now accept port numbers or port names in the targetPort field
in a Route config. If this field is not provided, then the controller will grab the first port
off of the service that the Route references.

Fixes #350