### PR TITLE
CCCL update to remove cert/key files

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -17,7 +17,8 @@ Added Functionality
 Bug Fixes
 `````````
 * OpenShift Route targetPort field is no longer required if the port is not 80 or 443.
-* Properly configures named targetPorts in OpenShift Route configurations.
+* Properly configure named targetPorts in OpenShift Route configurations.
+* Remove ssl certificate lists for deleted custom profiles.
 
 Limitations
 ~~~~~~~~~~~

--- a/python/k8s-build-requirements.txt
+++ b/python/k8s-build-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@9d0546b332503fae3bee256e4d61400c3813eb86#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@9764f43b57271e8da31b78b8e14515825da8147a#egg=f5-cccl
 pytest==3.0.2
 mock
 flake8

--- a/python/k8s-runtime-requirements.txt
+++ b/python/k8s-runtime-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@9d0546b332503fae3bee256e4d61400c3813eb86#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@9764f43b57271e8da31b78b8e14515825da8147a#egg=f5-cccl
 pyinotify==0.9.6
 ipaddress==1.0.17
 PyJWT==1.4.0


### PR DESCRIPTION
Problem: Certificate and key files are not being cleaned up when their associated
profiles are deleted.

Solution: CCCL now removes these files when profiles are removed.