### PR TITLE
Added non-0 route domain support

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -415,6 +415,7 @@ func main() {
 	}
 
 	appmanager.DEFAULT_PARTITION = (*bigIPPartitions)[0]
+  appmanager.RegisterBigIPSchemaTypes()
 
 	if _, isSet := os.LookupEnv("SCALE_PERF_ENABLE"); isSet {
 		now := time.Now()

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -13,6 +13,7 @@ Added Functionality
 * Optionally disable loading of Kubernetes Secrets on an Ingress.
 * Resolve the first host name in an Ingress to an IP address using a local or custom DNS server. The controller
   configures the virtual server with this address.
+* Support for BIG-IP partitions with non-zero default route domains.
 
 Bug Fixes
 `````````
@@ -25,6 +26,8 @@ Limitations
 
 * If a Route configuration contains no targetPort, the controller uses the first port it sees
   on the referenced Service. The controller does not use all ports.
+* The default route domain for a partition managed by an F5 controller cannot be changed once a
+  controller has been deployed.  To specify a new default route domain, a new partition should be used.
 
 v1.2.0
 ------

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -1001,6 +1001,8 @@ var _ = Describe("AppManager Tests", func() {
 		var mockMgr *mockAppManager
 		var mw *test.MockWriter
 		BeforeEach(func() {
+			RegisterBigIPSchemaTypes()
+
 			mw = &test.MockWriter{
 				FailStyle: test.Success,
 				Sections:  make(map[string]interface{}),

--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -72,18 +72,23 @@ func (appMgr *Manager) outputConfigLocked() {
 				// If it's not an IApp, then it's a Virtual Server
 				if nil != cfg.Virtual.VirtualAddress {
 					// Validate the IP address, and create the destination
-					addr := net.ParseIP(cfg.Virtual.VirtualAddress.BindAddr)
+					ip, rd := split_ip_with_route_domain(cfg.Virtual.VirtualAddress.BindAddr)
+					if len(rd) > 0 {
+						rd = "%" + rd
+					}
+					addr := net.ParseIP(ip)
 					if nil != addr {
 						var format string
 						if nil != addr.To4() {
-							format = "/%s/%s:%d"
+							format = "/%s/%s%s:%d"
 						} else {
-							format = "/%s/%s.%d"
+							format = "/%s/%s%s.%d"
 						}
 						cfg.Virtual.Destination = fmt.Sprintf(
 							format,
 							cfg.Virtual.Partition,
-							cfg.Virtual.VirtualAddress.BindAddr,
+							ip,
+							rd,
 							cfg.Virtual.VirtualAddress.Port)
 						resources[cfg.Virtual.Partition].Virtuals =
 							appendVirtual(resources[cfg.Virtual.Partition].Virtuals, cfg.Virtual)

--- a/pkg/appmanager/routeDomain.go
+++ b/pkg/appmanager/routeDomain.go
@@ -1,0 +1,37 @@
+/*-
+ * Copyright (c) 2016,2017, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR conditionS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package appmanager
+
+import (
+	"regexp"
+)
+
+func split_ip_with_route_domain(address string) (ip string, rd string) {
+	// Split the address into the ip and routeDomain (optional) parts
+	//     address is of the form: <ipv4_or_ipv6>[%<routeDomainID>]
+	idRdRegex := regexp.MustCompile(`^([^%]*)%(\d+)$`)
+
+	match := idRdRegex.FindStringSubmatch(address)
+	if match != nil {
+		ip = match[1]
+		rd = match[2]
+	} else {
+		ip = address
+		rd = ""
+	}
+	return
+}

--- a/pkg/appmanager/routeDomain_test.go
+++ b/pkg/appmanager/routeDomain_test.go
@@ -1,0 +1,61 @@
+/*-
+ * Copyright (c) 2017, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package appmanager
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Route Domain", func() {
+	It("split_ip_with_route_domain", func() {
+		type testDataType struct {
+			address    string
+			expectedIP string
+			expectedRD string
+		}
+		testData := []testDataType{
+			{
+				address:    "",
+				expectedIP: "",
+				expectedRD: "",
+			}, {
+				address:    "1.2.3.4",
+				expectedIP: "1.2.3.4",
+				expectedRD: "",
+			}, {
+				address:    "fe80::",
+				expectedIP: "fe80::",
+				expectedRD: "",
+			}, {
+				address:    "1.2.3.4%56",
+				expectedIP: "1.2.3.4",
+				expectedRD: "56",
+			}, {
+				address:    "fe80::%0",
+				expectedIP: "fe80::",
+				expectedRD: "0",
+			},
+		}
+
+		for _, td := range testData {
+			ip, rd := split_ip_with_route_domain(td.address)
+			Expect(ip).To(Equal(td.expectedIP))
+			Expect(rd).To(Equal(td.expectedRD))
+		}
+	})
+})

--- a/pkg/appmanager/schema.go
+++ b/pkg/appmanager/schema.go
@@ -1,0 +1,65 @@
+/*-
+ * Copyright (c) 2016,2017, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR conditionS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package appmanager
+
+import (
+	"github.com/xeipuuv/gojsonschema"
+	"net"
+	"strconv"
+)
+
+// Big-IP ipv4/ipv6 checkers
+type BigIPv4FormatChecker struct{}
+
+func (f BigIPv4FormatChecker) IsFormat(input string) bool {
+	ip, rd := split_ip_with_route_domain(input)
+	if rd != "" {
+		if _, err := strconv.Atoi(rd); err != nil {
+			return false
+		}
+	}
+
+	address := net.ParseIP(ip)
+	if nil == address.To4() {
+		return false
+	}
+	return true
+}
+
+type BigIPv6FormatChecker struct{}
+
+func (f BigIPv6FormatChecker) IsFormat(input string) bool {
+	ip, rd := split_ip_with_route_domain(input)
+	if rd != "" {
+		if _, err := strconv.Atoi(rd); err != nil {
+			return false
+		}
+	}
+
+	address := net.ParseIP(ip)
+	if nil == address.To16() {
+		return false
+	}
+
+	return true
+}
+
+// Add new data format to the library
+func RegisterBigIPSchemaTypes() {
+	gojsonschema.FormatCheckers.Add("bigipv4", BigIPv4FormatChecker{})
+	gojsonschema.FormatCheckers.Add("bigipv6", BigIPv6FormatChecker{})
+}

--- a/pkg/appmanager/schema_test.go
+++ b/pkg/appmanager/schema_test.go
@@ -1,0 +1,109 @@
+/*-
+ * Copyright (c) 2017, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package appmanager
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Route Domain", func() {
+	It("TestBigIpv4FormatChecker", func() {
+		var schemaValidator BigIPv4FormatChecker
+
+		type testDataType struct {
+			address string
+			isValid bool
+		}
+		testData := []testDataType{
+			{
+				address: "",
+				isValid: false,
+			}, {
+				address: "1.2.3.4",
+				isValid: true,
+			}, {
+				address: "http://bad",
+				isValid: false,
+			}, {
+				address: "bad%0",
+				isValid: false,
+			}, {
+				address: "1.2.3.4%bad",
+				isValid: false,
+			}, {
+				address: "1.2.3.4%4",
+				isValid: true,
+			}, {
+				address: "::",
+				isValid: false,
+			}, {
+				address: "ff80::%12",
+				isValid: false,
+			},
+		}
+
+		for _, td := range testData {
+			isValid := schemaValidator.IsFormat(td.address)
+			Expect(isValid).To(Equal(td.isValid))
+		}
+	})
+
+	It("TestBigIpv6FormatChecker", func() {
+		var schemaValidator BigIPv6FormatChecker
+
+		// Note: IPv4 addresses are valid IPv6 addresses
+		//       (so we should always check for IPv4 first
+		//        if we need to distinguish between the two)
+		type testDataType struct {
+			address string
+			isValid bool
+		}
+		testData := []testDataType{
+			{
+				address: "",
+				isValid: false,
+			}, {
+				address: "1.2.3.4",
+				isValid: true,
+			}, {
+				address: "http://bad",
+				isValid: false,
+			}, {
+				address: "bad%0",
+				isValid: false,
+			}, {
+				address: "1.2.3.4%bad",
+				isValid: false,
+			}, {
+				address: "1.2.3.4%4",
+				isValid: true,
+			}, {
+				address: "::",
+				isValid: true,
+			}, {
+				address: "ff80::%12",
+				isValid: true,
+			},
+		}
+
+		for _, td := range testData {
+			isValid := schemaValidator.IsFormat(td.address)
+			Expect(isValid).To(Equal(td.isValid))
+		}
+	})
+})

--- a/python/k8s-build-requirements.txt
+++ b/python/k8s-build-requirements.txt
@@ -1,6 +1,6 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@9764f43b57271e8da31b78b8e14515825da8147a#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@5edac6c7be8fb105cc3394d846949c329f5b829d#egg=f5-cccl
 pytest==3.0.2
 mock
-flake8
+flake8==3.4.1
 pytest-cov==2.5.1
 coveralls==1.1

--- a/python/k8s-runtime-requirements.txt
+++ b/python/k8s-runtime-requirements.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/f5devcentral/f5-cccl.git@9764f43b57271e8da31b78b8e14515825da8147a#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@5edac6c7be8fb105cc3394d846949c329f5b829d#egg=f5-cccl
 pyinotify==0.9.6
 ipaddress==1.0.17
 PyJWT==1.4.0

--- a/schemas/bigip-virtual-server_v0.1.4.json
+++ b/schemas/bigip-virtual-server_v0.1.4.json
@@ -182,7 +182,7 @@
       "type": "object",
       "properties": {
         "bindAddr": {
-          "anyOf": [ { "format": "ipv4" }, { "format": "ipv6" } ]
+          "anyOf": [ { "format": "bigipv4" }, { "format": "bigipv6" } ]
         },
         "port": { "$ref": "#/definitions/portType" }
       },

--- a/schemas/test/test-bigip-virtual-server.js
+++ b/schemas/test/test-bigip-virtual-server.js
@@ -292,6 +292,39 @@ exports.bigipVirtualServer.invalidBindAddr = t => {
   });
 };
 
+exports.bigipVirtualServer.validBindAddr = t => {
+  let data = Object.assign({}, this.baseValidConfig);
+  data.virtualServer.frontend.virtualAddress.bindAddr = '127.1.1.1';
+
+  this.sUtil.loadSchemas(testSchema, () => {
+    let result = this.sUtil.runValidate(data, testSchema);
+    t.ok(result.valid, 'Should have been valid');
+    t.done();
+  });
+};
+
+exports.bigipVirtualServer.validBindAddrRouteDomain = t => {
+  let data = Object.assign({}, this.baseValidConfig);
+  data.virtualServer.frontend.virtualAddress.bindAddr = '127.1.1.1%44';
+
+  this.sUtil.loadSchemas(testSchema, () => {
+    let result = this.sUtil.runValidate(data, testSchema);
+    t.ok(result.valid, 'Should have been valid');
+    t.done();
+  });
+};
+
+exports.bigipVirtualServer.invalidBindAddrRouteDomain = t => {
+  let data = Object.assign({}, this.baseValidConfig);
+  data.virtualServer.frontend.virtualAddress.bindAddr = '127%44';
+
+  this.sUtil.loadSchemas(testSchema, () => {
+    let result = this.sUtil.runValidate(data, testSchema);
+    t.ok(!result.valid, 'Should have a failure');
+    t.done();
+  });
+};
+
 exports.bigipVirtualServer.invalidPort = t => {
   let data = Object.assign({}, this.baseValidConfig);
   data.virtualServer.frontend.virtualAddress.port = 0;

--- a/schemas/test/util/schema-handler.js
+++ b/schemas/test/util/schema-handler.js
@@ -17,6 +17,34 @@
 
 const fs = require('fs');
 const Validator = require('jsonschema').Validator;
+const ValidatorHelpers = require('jsonschema/lib/helpers');
+
+
+Validator.prototype.customFormats.bigipv4 = function(input) {
+   let parts = input.split("%");
+   let ip = parts[0];
+   if (parts.length === 2) {
+     let rd = parts[1];
+     if (isNaN(rd)) {
+       return false;
+     }
+   }
+
+   return ValidatorHelpers.isFormat(ip, 'ip-address');
+}
+
+Validator.prototype.customFormats.bigipv6 = function(input) {
+   let parts = input.split("%");
+   let ip = parts[0];
+   if (parts.length === 2) {
+     let rd = parts[1];
+     if (isNaN(rd)) {
+       return false;
+     }
+   }
+   return ValidatorHelpers.isFormat(ip, 'ipv6');
+}
+
 
 class SchemaHandler {
   constructor(uriRoot) {


### PR DESCRIPTION
Problem:  Need to make sure controllers handle Big-IP addresses that
          have optional route domain IDs specified.
Solution: Allowed virtual address field to contain route domains by
          updating schema to define Bigip IP formats that include
          route domains.