### PR TITLE
License info for urlib3 and chardet

### DIFF
--- a/.f5license
+++ b/.f5license
@@ -1560,3 +1560,13 @@
     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The urllib3 module has an MIT license
+- name: urllib3
+  version: 1.13.1
+  license: MIT
+
+# The chardet module has an LGPL v2.1 license
+- name: chardet
+  version: 2.3.0
+  license: LGPL v2.1


### PR DESCRIPTION
The urllib3 and chardet packages were bundled inside of requests and were
not attributed correctly. Properly attribute the licenses for these packages.