### PR TITLE
Update microdnf packages during rhel build

### DIFF
--- a/build-tools/Dockerfile.rhel7.runtime
+++ b/build-tools/Dockerfile.rhel7.runtime
@@ -26,6 +26,7 @@ COPY k8s-runtime-requirements.txt /tmp/k8s-runtime-requirements.txt
 RUN microdnf --enablerepo=rhel-7-server-rpms --enablerepo=rhel-7-server-optional-rpms \
       --enablerepo=rhel-server-rhscl-7-rpms install --nodocs \
       golang-github-cpuguy83-go-md2man python27-python-pip git && \
+    microdnf update && \
     go-md2man -in /tmp/help.md -out /help.1 && rm -f /tmp/help.md && \
     source scl_source enable python27 && \
     pip install --no-cache-dir --upgrade pip && \


### PR DESCRIPTION
Problem: RedHat pushes security updates out and requires they be installed into
all images in their catalog.

Solution: Have microdnf update container packages to ensure that the latest security
packages are installed when the RHEL image is built.