### PR TITLE
Refactor internal configuration data structure.

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -415,7 +415,7 @@ func main() {
 	}
 
 	appmanager.DEFAULT_PARTITION = (*bigIPPartitions)[0]
-  appmanager.RegisterBigIPSchemaTypes()
+	appmanager.RegisterBigIPSchemaTypes()
 
 	if _, isSet := os.LookupEnv("SCALE_PERF_ENABLE"); isSet {
 		now := time.Now()

--- a/pkg/appmanager/healthMonitors.go
+++ b/pkg/appmanager/healthMonitors.go
@@ -87,7 +87,7 @@ func (appMgr *Manager) assignMonitorToPool(
 				// appending a '0' is sufficient.
 				Name:      poolName + "_0_http",
 				Partition: partition,
-				Protocol:  "http",
+				Type:      "http",
 				Interval:  ruleData.healthMon.Interval,
 				Send:      ruleData.healthMon.Send,
 				Timeout:   ruleData.healthMon.Timeout,
@@ -222,7 +222,7 @@ func (appMgr *Manager) handleMultiServiceHealthMonitors(
 				continue
 			}
 			for _, pol := range cfg.Policies {
-				if pol.Name != cfg.Virtual.VirtualServerName {
+				if pol.Name != cfg.Virtual.Name {
 					continue
 				}
 				for _, rule := range pol.Rules {

--- a/pkg/appmanager/healthMonitors_test.go
+++ b/pkg/appmanager/healthMonitors_test.go
@@ -68,7 +68,7 @@ var _ = Describe("Health Monitor Tests", func() {
 		Expect(len(rc.Pools)).To(BeNumerically(">", 0))
 		poolNdx := -1
 		for i, pool := range rc.Pools {
-			if pool.Partition == rc.Virtual.Partition &&
+			if pool.Partition == rc.GetPartition() &&
 				pool.ServiceName == svcName &&
 				pool.ServicePort == int32(svcPort) {
 				poolNdx = i
@@ -212,8 +212,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			Expect(len(rc.Pools)).To(BeNumerically(">", 0))
 			policyNdx := -1
 			for i, pol := range rc.Policies {
-				if pol.Name == rc.Virtual.VirtualServerName &&
-					pol.Partition == rc.Virtual.Partition {
+				if pol.Name == rc.Virtual.Name &&
+					pol.Partition == rc.GetPartition() {
 					policyNdx = i
 					break
 				}
@@ -222,7 +222,7 @@ var _ = Describe("Health Monitor Tests", func() {
 
 			poolNdx := -1
 			for i, pool := range rc.Pools {
-				if pool.Partition == rc.Virtual.Partition &&
+				if pool.Partition == rc.GetPartition() &&
 					pool.ServiceName == svcName &&
 					pool.ServicePort == int32(svcPort) {
 					poolNdx = i


### PR DESCRIPTION
Problem:
The configuration data structure has become unruly and needs to be
simplified.

Solution:
The following changes were made to the configuration data structure:
1. Only one copy of the resource configuration is stored, instead of
   one per backend.
2. Struct members that are not part of the CCCL schema but still
   required internally are no longer serialized.
3. Many of the configuration structures have changed to be close to the
   output CCCL format, which requires fewer transformations between
   formats. Moved format conversions out of the config writing code and
   instead initialize the structs correctly when they are created.
4. Client SSL profiles are now stored along with server SSL and other
   profiles in the Profiles array.
5. The Virtual struct no longer contains members for IApps, as there is
   a dedicated struct for them that is used instead of the Virtual struct
   when a ConfigMap object references an IApp.
6. Updated unit tests as needed.

Fixes VEL-1073

affects-branches: master