### PR TITLE
IRules with leading or trailing whitespace sync constantly

### DIFF
--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -198,8 +198,8 @@ func processIngressRules(
 }
 
 func httpRedirectIRule(port int32) string {
-	iRuleCode := fmt.Sprintf(`
-	when HTTP_REQUEST {
+	iRuleCode := fmt.Sprintf(
+		`when HTTP_REQUEST {
        HTTP::redirect https://[getfield [HTTP::host] ":" 1]:%d[HTTP::uri]
     }`, port)
 
@@ -207,8 +207,7 @@ func httpRedirectIRule(port int32) string {
 }
 
 func sslPassthroughIRule() string {
-	iRuleCode := `
-when CLIENT_ACCEPTED {
+	iRuleCode := `when CLIENT_ACCEPTED {
 	TCP::collect
 }
 
@@ -305,8 +304,7 @@ when CLIENT_DATA {
 	}
 
 	TCP::release
-}
-`
+}`
 	return iRuleCode
 }
 


### PR DESCRIPTION
Problem:
CCCL 'loses' leading and trailing whitespace, and therefore constantly
needs to push the IRule to the BIG-IP.

Solution:
CCCL issue 183 addresses the CCCL bug, but this commit removes leading
and trailing whitespace from the 2 existing IRules to avoid the issue.

Fixes #410

affects-branches: master, 1.3-stable