### PR TITLE
Restore customProfiles after removing from debug

### DIFF
--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -140,9 +140,10 @@ func (appMgr *Manager) outputConfigLocked() {
 				log.Infof("Wrote %v Virtual Server and %v IApp configs",
 					virtualCount, iappCount)
 				if log.LL_DEBUG == log.GetLogLevel() {
-					// Remove customProfiles from output
-					// FIXME (sberman): Issue #365
+					// Remove customProfiles from output (save for later)
+					savedProfs := make(map[string][]CustomProfile)
 					for partition, _ := range resources {
+						savedProfs[partition] = resources[partition].CustomProfiles
 						resources[partition].CustomProfiles = []CustomProfile{}
 					}
 					output, err := json.Marshal(resources)
@@ -150,6 +151,10 @@ func (appMgr *Manager) outputConfigLocked() {
 						log.Warningf("Failed creating output debug log: %v", err)
 					} else {
 						log.Debugf("Resources: %s", output)
+					}
+					// Repopulate resources with the removed profiles
+					for partition, profs := range savedProfs {
+						resources[partition].CustomProfiles = profs
 					}
 				}
 			case e := <-errCh:


### PR DESCRIPTION
Problem: CustomProfiles are removed from debug output for security reasons. Sometimes during
syncing, though, the deleted profiles would cause BIG-IP errors (the controller would try to
delete the non-existent profiles).

Solution: After removing the profiles for debug output, restore the profiles back into the
resources config so there aren't any problems with the profiles being missing during future
syncs.

Fixes #365 