### PR TITLE
Create resource copy for debug logging

### DIFF
--- a/python/bigipconfigdriver.py
+++ b/python/bigipconfigdriver.py
@@ -204,7 +204,6 @@ def create_ltm_config(partition, config):
     if 'resources' in config and partition in config['resources']:
         ltm = config['resources'][partition]
 
-    log.debug("LTM Config: %s", json.dumps(ltm))
     return ltm
 
 


### PR DESCRIPTION
Problem: When debug logging, customProfiles were removed from the resources struct. This could cause future syncing issues because we removed a reference to the profiles, so our internal store was in an incorrect state.

Solution: Don't touch the resources blob when attempting to alter what is logged (customProfiles in this case). Instead, create a value copy of the resources into a new struct, leaving out the profiles. Log this new copied struct, which avoids us from altering our internal store.

Fixes #365 