### PR TITLE
Need to document required BIG-IP user roles

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -111,6 +111,7 @@ BIG-IP system
 | bigip-url             | string  | Required | n/a               | BIG-IP admin IP address                 |                |
 +-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
 | bigip-username        | string  | Required | n/a               | BIG-IP iControl REST username           |                |
+|                       |         |          |                   | [#username]_                            |                |
 +-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
 
 Kubernetes
@@ -133,7 +134,7 @@ Kubernetes
 |                       |         |          |                   | only nodes with this label              |                |
 +-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
 | pool-member-type      | string  | Optional | nodeport          | The type of BIG-IP pool members you want| cluster,       |
-|                       |         |          |                   | to create.                              | nodeport       |
+|                       |         |          |                   | to create. [#username]_                 | nodeport       |
 |                       |         |          |                   |                                         |                |
 |                       |         |          |                   | Use ``cluster`` to create pool members  |                |
 |                       |         |          |                   | for each of the endpoints for the       |                |
@@ -655,6 +656,7 @@ Example Configuration Files
 .. [#objectpartition] The |kctlr| creates and manages objects in the BIG-IP partition defined in the `F5 resource </containers/latest/kubernetes/index.html#f5-resource-properties>`_ ConfigMap. **It cannot manage objects in the** ``/Common`` **partition**.
 .. [#nodeport] The |kctlr| forwards traffic to the NodePort assigned to the Service by Kubernetes. See the Kubernetes `Services <http://kubernetes.io/docs/user-guide/services/>`_ documentation for more information.
 .. [#secrets] You can `secure your BIG-IP credentials </containers/latest/kubernetes/kctlr-secrets.html#secure-your-BIG-IP-credentials>`_ using a Kubernetes Secret.
+.. [#username] The BIG-IP user account must have an appropriate role defined.  For ``nodeport`` type pool members, this role must be either ``Administrator``, ``Resource Administrator``, or ``Manager``. For ``cluster`` type pool members, the user account must have either the ``Administrator`` or ``Resource Manager`` role. See `BIG-IP Users <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-concepts-11-5-0/10.html>`_ for further details.
 .. [#hm1] Required if defining the ``virtual-server.f5.com/health`` Ingress/Route annotation.
 .. [#hm2] See the **HTTP monitor settings** section of the `BIG-IP LTM Monitors Reference Guide <https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/bigip-local-traffic-manager-monitors-reference-13-0-0/3.html>`_ for more information about defining send strings.
 


### PR DESCRIPTION
Problem:
It is not clear what types of BIG-IP user roles are allowed
for the k8s controller.

Solution:
Document the required roles the controller requires for the
BIG-IP user.

Fixes #426

affects-branches: master, 1.3-stable