### PR TITLE
Ingress events for multiple namespaces are confusing

### DIFF
--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -34,7 +34,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	"k8s.io/client-go/tools/record"
 )
 
 func init() {
@@ -520,7 +519,9 @@ func (m *mockAppManager) deleteEndpoints(ep *v1.Endpoints) bool {
 func (m *mockAppManager) addIngress(ing *v1beta1.Ingress) bool {
 	ok, keys := m.appMgr.checkValidIngress(ing)
 	if ok {
-		appInf, _ := m.appMgr.getNamespaceInformer(ing.ObjectMeta.Namespace)
+		ns := ing.ObjectMeta.Namespace
+		m.appMgr.kubeClient.ExtensionsV1beta1().Ingresses(ns).Create(ing)
+		appInf, _ := m.appMgr.getNamespaceInformer(ns)
 		appInf.ingInformer.GetStore().Add(ing)
 		for _, vsKey := range keys {
 			mtx := m.getVsMutex(*vsKey)
@@ -535,7 +536,14 @@ func (m *mockAppManager) addIngress(ing *v1beta1.Ingress) bool {
 func (m *mockAppManager) updateIngress(ing *v1beta1.Ingress) bool {
 	ok, keys := m.appMgr.checkValidIngress(ing)
 	if ok {
-		appInf, _ := m.appMgr.getNamespaceInformer(ing.ObjectMeta.Namespace)
+		ns := ing.ObjectMeta.Namespace
+		_, err := m.appMgr.kubeClient.ExtensionsV1beta1().Ingresses(ns).Update(ing)
+		if nil != err {
+			// This can happen when an ingress is ignored by checkValidIngress
+			// before, but now has been updated to be accepted.
+			m.appMgr.kubeClient.ExtensionsV1beta1().Ingresses(ns).Create(ing)
+		}
+		appInf, _ := m.appMgr.getNamespaceInformer(ns)
 		appInf.ingInformer.GetStore().Update(ing)
 		for _, vsKey := range keys {
 			mtx := m.getVsMutex(*vsKey)
@@ -550,7 +558,10 @@ func (m *mockAppManager) updateIngress(ing *v1beta1.Ingress) bool {
 func (m *mockAppManager) deleteIngress(ing *v1beta1.Ingress) bool {
 	ok, keys := m.appMgr.checkValidIngress(ing)
 	if ok {
-		appInf, _ := m.appMgr.getNamespaceInformer(ing.ObjectMeta.Namespace)
+		name := ing.ObjectMeta.Name
+		ns := ing.ObjectMeta.Namespace
+		m.appMgr.kubeClient.ExtensionsV1beta1().Ingresses(ns).Delete(name, nil)
+		appInf, _ := m.appMgr.getNamespaceInformer(ns)
 		appInf.ingInformer.GetStore().Delete(ing)
 		for _, vsKey := range keys {
 			mtx := m.getVsMutex(*vsKey)
@@ -612,6 +623,15 @@ func (m *mockAppManager) addNamespace(ns *v1.Namespace) bool {
 		m.appMgr.syncNamespace(ns.ObjectMeta.Name)
 	}
 	return found
+}
+
+func (m *mockAppManager) getFakeEvents(ns string) []FakeEvent {
+	nen := m.appMgr.eventNotifier.getNotifierForNamespace(ns, nil)
+	if nil != nen {
+		fakeRecorder := nen.recorder.(*FakeEventRecorder)
+		return fakeRecorder.Events
+	}
+	return []FakeEvent{}
 }
 
 func generateExpectedAddrs(port int32, ips []string) []Member {
@@ -790,7 +810,7 @@ var _ = Describe("AppManager Tests", func() {
 			appMgr = NewManager(&Params{
 				ConfigWriter: mw,
 				IsNodePort:   true,
-				InitialState: true,
+				initialState: true,
 			})
 		})
 
@@ -799,7 +819,7 @@ var _ = Describe("AppManager Tests", func() {
 			appMgr = NewManager(&Params{
 				ConfigWriter:      mw,
 				IsNodePort:        true,
-				InitialState:      true,
+				initialState:      true,
 				NodeLabelSelector: "label",
 				UseNodeInternal:   false,
 			})
@@ -1058,17 +1078,15 @@ var _ = Describe("AppManager Tests", func() {
 				Sections:  make(map[string]interface{}),
 			}
 			fakeClient := fake.NewSimpleClientset()
-			fakeRecorder := record.NewFakeRecorder(100)
 			Expect(fakeClient).ToNot(BeNil())
-			Expect(fakeRecorder).ToNot(BeNil())
 
 			mockMgr = newMockAppManager(&Params{
-				KubeClient:    fakeClient,
-				ConfigWriter:  mw,
-				restClient:    test.CreateFakeHTTPClient(),
-				RouteClientV1: test.CreateFakeHTTPClient(),
-				IsNodePort:    true,
-				EventRecorder: fakeRecorder,
+				KubeClient:      fakeClient,
+				ConfigWriter:    mw,
+				restClient:      test.CreateFakeHTTPClient(),
+				RouteClientV1:   test.CreateFakeHTTPClient(),
+				IsNodePort:      true,
+				broadcasterFunc: NewFakeEventBroadcaster,
 			})
 		})
 		AfterEach(func() {
@@ -2568,6 +2586,11 @@ var _ = Describe("AppManager Tests", func() {
 					[]v1.ServicePort{{Port: 80, NodePort: 37001}})
 				r = mockMgr.addService(fooSvc)
 				Expect(r).To(BeTrue(), "Service should be processed.")
+				events := mockMgr.getFakeEvents(namespace)
+				Expect(len(events)).To(Equal(1))
+				Expect(events[0].Namespace).To(Equal(namespace))
+				Expect(events[0].Name).To(Equal("ingress"))
+				Expect(events[0].Reason).To(Equal("ResourceConfigured"))
 
 				rs, ok := resources.Get(
 					serviceKey{"foo", 80, "default"}, "default_ingress-ingress_http")
@@ -2589,6 +2612,11 @@ var _ = Describe("AppManager Tests", func() {
 				r = mockMgr.updateIngress(ingress2)
 				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
 				Expect(resources.Count()).To(Equal(1))
+				events = mockMgr.getFakeEvents(namespace)
+				Expect(len(events)).To(Equal(2))
+				Expect(events[1].Namespace).To(Equal(namespace))
+				Expect(events[1].Name).To(Equal("ingress"))
+				Expect(events[1].Reason).To(Equal("ResourceConfigured"))
 
 				rs, ok = resources.Get(
 					serviceKey{"foo", 80, "default"}, "default_ingress-ingress_http")
@@ -2602,6 +2630,8 @@ var _ = Describe("AppManager Tests", func() {
 				r = mockMgr.deleteIngress(ingress2)
 				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
 				Expect(resources.Count()).To(Equal(0))
+				events = mockMgr.getFakeEvents(namespace)
+				Expect(len(events)).To(Equal(2))
 
 				// Shouldn't process Ingress with non-F5 class
 				// https://github.com/F5Networks/k8s-bigip-ctlr/issues/311
@@ -2616,10 +2646,14 @@ var _ = Describe("AppManager Tests", func() {
 				r = mockMgr.updateIngress(ingressNotf5)
 				Expect(r).To(BeTrue(), "Ingress resource should be processed when flipping from notf5 to f5.")
 				Expect(resources.Count()).To(Equal(1))
+				events = mockMgr.getFakeEvents(namespace)
+				Expect(len(events)).To(Equal(3))
 				ingressNotf5.Annotations[k8sIngressClass] = "notf5again"
 				r = mockMgr.updateIngress(ingressNotf5)
 				Expect(r).To(BeFalse(), "Ingress resource should be destroyed when flipping from f5 to notf5again.")
 				Expect(resources.Count()).To(Equal(0))
+				events = mockMgr.getFakeEvents(namespace)
+				Expect(len(events)).To(Equal(3))
 
 				// Multi-service Ingress
 				ingressConfig = v1beta1.IngressSpec{
@@ -2682,6 +2716,8 @@ var _ = Describe("AppManager Tests", func() {
 					})
 				r = mockMgr.addIngress(ingress3)
 				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
+				events = mockMgr.getFakeEvents(namespace)
+				Expect(len(events)).To(Equal(4))
 				// 4 rules, but only 3 backends specified. We should have 3 keys stored, one for
 				// each backend
 				Expect(resources.Count()).To(Equal(3))
@@ -2731,6 +2767,8 @@ var _ = Describe("AppManager Tests", func() {
 				rs, ok = resources.Get(
 					serviceKey{"foo", 80, "default"}, "default_ingress-ingress_http")
 				Expect(len(rs.Policies[0].Rules)).To(Equal(2))
+				events = mockMgr.getFakeEvents(namespace)
+				Expect(len(events)).To(Equal(5))
 			})
 
 			Context("Routes", func() {
@@ -3115,24 +3153,72 @@ var _ = Describe("AppManager Tests", func() {
 				mockMgr.appMgr.resolveIng = "LOOKUP"
 				// Empty host (then add one)
 				hostResolution("", false, true)
+				expectedEventCt := 4 // # expected events
+				events := mockMgr.getFakeEvents(namespace)
+				Expect(len(events)).To(Equal(expectedEventCt))
+				Expect(events[0].Reason).To(Equal("DNSResolutionError"))
+				Expect(events[1].Reason).To(Equal("ResourceConfigured"))
+				Expect(events[2].Reason).To(Equal("HostResolvedSuccessfully"))
+				Expect(events[3].Reason).To(Equal("ResourceConfigured"))
+				// each following test will skip events handled here
+				ignoreEventCt := expectedEventCt
+
 				// Bad host
 				hostResolution("doesn't.exist", false, false)
+				expectedEventCt = 2
+				events = mockMgr.getFakeEvents(namespace)
+				events = events[ignoreEventCt:]
+				Expect(events[0].Reason).To(Equal("DNSResolutionError"))
+				Expect(events[1].Reason).To(Equal("ResourceConfigured"))
+				ignoreEventCt += expectedEventCt
+
 				// Good host
 				hostResolution("f5.com", true, false)
+				expectedEventCt = 2
+				events = mockMgr.getFakeEvents(namespace)
+				events = events[ignoreEventCt:]
+				Expect(events[0].Reason).To(Equal("HostResolvedSuccessfully"))
+				Expect(events[1].Reason).To(Equal("ResourceConfigured"))
+				ignoreEventCt += expectedEventCt
 
 				// Use a non-existent custom DNS server
 				mockMgr.appMgr.resolveIng = "BadCustomDNS"
 				// Good host; bad DNS
 				hostResolution("google.com", false, false)
+				events = mockMgr.getFakeEvents(namespace)
+				events = events[ignoreEventCt:]
+				ignoreEventCt += expectedEventCt
+				Expect(events[0].Reason).To(Equal("DNSResolutionError"))
+				Expect(events[1].Reason).To(Equal("ResourceConfigured"))
+				expectedEventCt = 2
 
 				// Use a valid custom DNS server (hostname)
 				mockMgr.appMgr.resolveIng = "pdns130.f5.com."
 				hostResolution("f5.com", true, false)
+				events = mockMgr.getFakeEvents(namespace)
+				events = events[ignoreEventCt:]
+				ignoreEventCt += expectedEventCt
+				Expect(events[0].Reason).To(Equal("HostResolvedSuccessfully"))
+				Expect(events[1].Reason).To(Equal("ResourceConfigured"))
+				expectedEventCt = 2
+
 				// Use a valid custom DNS server (ip address)
 				mockMgr.appMgr.resolveIng = "193.221.113.53"
 				hostResolution("msn.com", true, false)
+				events = mockMgr.getFakeEvents(namespace)
+				events = events[ignoreEventCt:]
+				ignoreEventCt += expectedEventCt
+				Expect(events[0].Reason).To(Equal("HostResolvedSuccessfully"))
+				Expect(events[1].Reason).To(Equal("ResourceConfigured"))
+				expectedEventCt = 2
+
 				// Good DNS, bad host
 				hostResolution("doesn't.exist", false, false)
+				events = mockMgr.getFakeEvents(namespace)
+				events = events[ignoreEventCt:]
+				ignoreEventCt += expectedEventCt
+				Expect(events[0].Reason).To(Equal("DNSResolutionError"))
+				Expect(events[1].Reason).To(Equal("ResourceConfigured"))
 			})
 		})
 

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -626,7 +626,7 @@ func (m *mockAppManager) addNamespace(ns *v1.Namespace) bool {
 }
 
 func (m *mockAppManager) getFakeEvents(ns string) []FakeEvent {
-	nen := m.appMgr.eventNotifier.getNotifierForNamespace(ns, nil)
+	nen := m.appMgr.eventNotifier.getNotifierForNamespace(ns)
 	if nil != nen {
 		fakeRecorder := nen.recorder.(*FakeEventRecorder)
 		return fakeRecorder.Events

--- a/pkg/appmanager/eventNotifier.go
+++ b/pkg/appmanager/eventNotifier.go
@@ -1,0 +1,133 @@
+/*-
+ * Copyright (c) 2016,2017, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package appmanager
+
+import (
+	"strings"
+	"sync"
+
+	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/client-go/tools/record"
+)
+
+type (
+	NamespaceEventNotifierMap map[string]*NamespaceEventNotifier
+
+	NewBroadcasterFunc func() record.EventBroadcaster
+
+	EventNotifier struct {
+		mutex           sync.Mutex
+		notifierMap     map[string]*NamespaceEventNotifier
+		broadcasterFunc NewBroadcasterFunc
+	}
+
+	NamespaceEventNotifier struct {
+		broadcaster record.EventBroadcaster
+		recorder    record.EventRecorder
+	}
+)
+
+func NewEventNotifier(bfunc NewBroadcasterFunc) *EventNotifier {
+	if nil == bfunc {
+		// No broadcaster func provided (unit testing), use real one.
+		bfunc = record.NewBroadcaster
+	}
+	return &EventNotifier{
+		notifierMap:     make(map[string]*NamespaceEventNotifier),
+		broadcasterFunc: bfunc,
+	}
+}
+
+func (en *EventNotifier) getNotifierForNamespace(
+	namespace string,
+	coreIntf corev1.CoreV1Interface,
+) *NamespaceEventNotifier {
+
+	en.mutex.Lock()
+	defer en.mutex.Unlock()
+
+	evNotifier, found := en.notifierMap[namespace]
+	if !found {
+		if nil == coreIntf {
+			// Don't create notifier for this namespace (unit testing)
+			return nil
+		}
+		source := v1.EventSource{Component: "k8s-bigip-ctlr"}
+		broadcaster := en.broadcasterFunc()
+		recorder := broadcaster.NewRecorder(scheme.Scheme, source)
+		evNotifier = &NamespaceEventNotifier{
+			broadcaster: broadcaster,
+			recorder:    recorder,
+		}
+		en.notifierMap[namespace] = evNotifier
+		broadcaster.StartRecordingToSink(&corev1.EventSinkImpl{
+			Interface: coreIntf.Events(namespace),
+		})
+	}
+	return evNotifier
+}
+
+func (en *EventNotifier) deleteNotifierForNamespace(namespace string) {
+	en.mutex.Lock()
+	defer en.mutex.Unlock()
+	delete(en.notifierMap, namespace)
+}
+
+func (nen *NamespaceEventNotifier) recordEvent(
+	obj runtime.Object,
+	eventType,
+	reason,
+	message string,
+) {
+	nen.recorder.Event(obj, eventType, reason, message)
+}
+
+// This function expects either an Ingress resource or the name of a VS for
+// an Ingress.
+func (appMgr *Manager) recordIngressEvent(ing *v1beta1.Ingress,
+	reason,
+	message,
+	rsName string) {
+	var namespace string
+	if ing != nil {
+		namespace = ing.ObjectMeta.Namespace
+	} else {
+		namespace = strings.Split(rsName, "_")[0]
+		name := rsName[len(namespace)+1 : len(rsName)-len("-ingress")]
+		// If we aren't given an Ingress resource, we use the name to find it
+		var err error
+		if ing == nil {
+			ing, err = appMgr.kubeClient.Extensions().Ingresses(namespace).
+				Get(name, metav1.GetOptions{})
+			if nil != err {
+				log.Warningf("Could not find Ingress resource '%v'.", name)
+				return
+			}
+		}
+	}
+
+	// Create the event
+	evNotifier := appMgr.eventNotifier.getNotifierForNamespace(
+		namespace, appMgr.kubeClient.Core())
+	evNotifier.recordEvent(ing, v1.EventTypeNormal, reason, message)
+}

--- a/pkg/appmanager/eventNotifier_test.go
+++ b/pkg/appmanager/eventNotifier_test.go
@@ -1,0 +1,204 @@
+/*-
+ * Copyright (c) 2016,2017, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package appmanager
+
+import (
+	"fmt"
+
+	"github.com/F5Networks/k8s-bigip-ctlr/pkg/test"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
+	"k8s.io/client-go/tools/record"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func NewFakeEventBroadcaster() record.EventBroadcaster {
+	return &FakeEventBroadcaster{}
+}
+
+func NewFakeEvent(
+	obj interface{},
+	eventType string,
+	reason string,
+	message string,
+) FakeEvent {
+
+	namespace := ""
+	name := ""
+
+	// Only Ingress objects are supported more, others added easily here.
+	switch obj.(type) {
+	case *v1beta1.Ingress:
+		ing := obj.(*v1beta1.Ingress)
+		namespace = ing.ObjectMeta.Namespace
+		name = ing.ObjectMeta.Name
+	default:
+		// Set namespace and name to the error message
+		namespace = fmt.Sprintf("NewFakeEvent: Unhandled object type: %T\n", obj)
+		name = namespace
+	}
+
+	return FakeEvent{
+		Namespace: namespace,
+		Name:      name,
+		EventType: eventType,
+		Reason:    reason,
+		Message:   message,
+	}
+}
+
+type FakeEventBroadcaster struct {
+	EventRecorder FakeEventRecorder
+}
+
+type FakeEventRecorder struct {
+	Events []FakeEvent
+}
+
+type FakeEvent struct {
+	Namespace string
+	Name      string
+	EventType string
+	Reason    string
+	Message   string
+}
+
+// record.EventBroadcaster interface methods
+func (feb *FakeEventBroadcaster) StartEventWatcher(eventHandler func(*v1.Event)) watch.Interface {
+	return nil
+}
+
+func (feb *FakeEventBroadcaster) StartRecordingToSink(sink record.EventSink) watch.Interface {
+	return nil
+}
+
+func (feb *FakeEventBroadcaster) StartLogging(logf func(format string, args ...interface{})) watch.Interface {
+	return nil
+}
+
+func (feb *FakeEventBroadcaster) NewRecorder(scheme *runtime.Scheme, source v1.EventSource) record.EventRecorder {
+	return &feb.EventRecorder
+}
+
+// record.EventRecorder interface methods
+func (fer *FakeEventRecorder) Event(obj runtime.Object, eventType, reason, message string) {
+	ev := NewFakeEvent(obj, eventType, reason, message)
+	fer.Events = append(fer.Events, ev)
+}
+
+func (fer *FakeEventRecorder) Eventf(obj runtime.Object, eventType, reason, messageFmt string, args ...interface{}) {
+	ev := NewFakeEvent(obj, eventType, reason, fmt.Sprintf(messageFmt, args...))
+	fer.Events = append(fer.Events, ev)
+}
+
+func (fer *FakeEventRecorder) PastEventf(obj runtime.Object, timestamp metav1.Time, eventType, reason, messageFmt string, args ...interface{}) {
+	ev := NewFakeEvent(obj, eventType, reason, fmt.Sprintf(messageFmt, args...)+" @ "+timestamp.String())
+	fer.Events = append(fer.Events, ev)
+}
+
+// Unit tests
+var _ = Describe("Event Notifier Tests", func() {
+	Describe("Using Mock Manager", func() {
+		var mockMgr *mockAppManager
+		var mw *test.MockWriter
+		var namespaces []string
+		BeforeEach(func() {
+			//RegisterBigIPSchemaTypes()
+
+			mw = &test.MockWriter{
+				FailStyle: test.Success,
+				Sections:  make(map[string]interface{}),
+			}
+			fakeClient := fake.NewSimpleClientset()
+			Expect(fakeClient).ToNot(BeNil())
+
+			mockMgr = newMockAppManager(&Params{
+				KubeClient:      fakeClient,
+				ConfigWriter:    mw,
+				restClient:      test.CreateFakeHTTPClient(),
+				RouteClientV1:   test.CreateFakeHTTPClient(),
+				IsNodePort:      true,
+				broadcasterFunc: NewFakeEventBroadcaster,
+			})
+			namespaces = []string{"ns0", "ns1", "ns2", "ns3", "ns4", "ns5"}
+			err := mockMgr.startNonLabelMode(namespaces)
+			Expect(err).To(BeNil())
+		})
+		AfterEach(func() {
+			mockMgr.shutdown()
+		})
+		deployIngress := func(ingNbr int) {
+			svcName := "service"
+			var svcPort int32 = 80
+
+			svcPorts := []v1.ServicePort{newServicePort("port0", svcPort)}
+			svc := test.NewService(svcName, "1", namespaces[ingNbr],
+				v1.ServiceTypeClusterIP, svcPorts)
+			r := mockMgr.addService(svc)
+			Expect(r).To(BeTrue(), "Service should be processed.")
+
+			emptyIps := []string{}
+			readyIps := []string{fmt.Sprintf("10.2.96.%d", ingNbr)}
+			endpts := test.NewEndpoints(svcName, "1", namespaces[ingNbr], readyIps,
+				emptyIps, convertSvcPortsToEndpointPorts(svcPorts))
+			r = mockMgr.addEndpoints(endpts)
+			Expect(r).To(BeTrue(), "Endpoints should be processed.")
+
+			bindAddr := fmt.Sprintf("1.0.0.%d", ingNbr)
+			ing := test.NewIngress("ingress", "1", namespaces[ingNbr],
+				v1beta1.IngressSpec{
+					Backend: &v1beta1.IngressBackend{
+						ServiceName: svcName,
+						ServicePort: intstr.IntOrString{IntVal: svcPort},
+					},
+				},
+				map[string]string{
+					f5VsBindAddrAnnotation:  bindAddr,
+					f5VsPartitionAnnotation: "velcro",
+				},
+			)
+			r = mockMgr.addIngress(ing)
+			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
+		}
+
+		It("multiple namespace ingress", func() {
+			// Deploy a Service and Ingress in each namespace
+			for i, _ := range namespaces {
+				deployIngress(i)
+			}
+
+			// Make sure the ingress events are in the correct namespace.
+			for _, ns := range namespaces {
+				events := mockMgr.getFakeEvents(ns)
+				// This use case currently only creates 1 event.
+				Expect(len(events)).To(Equal(1))
+				for _, event := range events {
+					// Regardless of length test, make sure all events match ns.
+					Expect(event.Namespace).To(Equal(ns))
+				}
+			}
+		})
+	})
+})

--- a/pkg/appmanager/healthMonitors_test.go
+++ b/pkg/appmanager/healthMonitors_test.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	"k8s.io/client-go/tools/record"
 )
 
 var _ = Describe("Health Monitor Tests", func() {
@@ -39,17 +38,15 @@ var _ = Describe("Health Monitor Tests", func() {
 			Sections:  make(map[string]interface{}),
 		}
 		fakeClient := fake.NewSimpleClientset()
-		fakeRecorder := record.NewFakeRecorder(100)
 		Expect(fakeClient).ToNot(BeNil())
-		Expect(fakeRecorder).ToNot(BeNil())
 
 		mockMgr = newMockAppManager(&Params{
-			KubeClient:    fakeClient,
-			ConfigWriter:  mw,
-			restClient:    test.CreateFakeHTTPClient(),
-			RouteClientV1: test.CreateFakeHTTPClient(),
-			IsNodePort:    true,
-			EventRecorder: fakeRecorder,
+			KubeClient:      fakeClient,
+			ConfigWriter:    mw,
+			restClient:      test.CreateFakeHTTPClient(),
+			RouteClientV1:   test.CreateFakeHTTPClient(),
+			IsNodePort:      true,
+			broadcasterFunc: NewFakeEventBroadcaster,
 		})
 		namespace = "default"
 		err := mockMgr.startNonLabelMode([]string{namespace})

--- a/pkg/appmanager/profiles_test.go
+++ b/pkg/appmanager/profiles_test.go
@@ -30,7 +30,6 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
-	"k8s.io/client-go/tools/record"
 )
 
 var _ = Describe("AppManager Profile Tests", func() {
@@ -46,17 +45,15 @@ var _ = Describe("AppManager Profile Tests", func() {
 				Sections:  make(map[string]interface{}),
 			}
 			fakeClient := fake.NewSimpleClientset()
-			fakeRecorder := record.NewFakeRecorder(100)
 			Expect(fakeClient).ToNot(BeNil())
-			Expect(fakeRecorder).ToNot(BeNil())
 
 			mockMgr = newMockAppManager(&Params{
-				KubeClient:    fakeClient,
-				ConfigWriter:  mw,
-				restClient:    test.CreateFakeHTTPClient(),
-				RouteClientV1: test.CreateFakeHTTPClient(),
-				IsNodePort:    true,
-				EventRecorder: fakeRecorder,
+				KubeClient:      fakeClient,
+				ConfigWriter:    mw,
+				restClient:      test.CreateFakeHTTPClient(),
+				RouteClientV1:   test.CreateFakeHTTPClient(),
+				IsNodePort:      true,
+				broadcasterFunc: NewFakeEventBroadcaster,
 			})
 			namespace = "default"
 			mockMgr.appMgr.routeConfig = RouteConfig{


### PR DESCRIPTION
Problem:
The controller was creating only one event broadcaster for all
namespaces, which is not correct. This causes errors when broadcasting
events once an event is generated for a second namespace.

Solution:
1. Added some new infrastructure to support one event broadcaster per
   namespace.
2. Moved all of the event notification code to eventNotifier.go.
3. Updated existing Ingress tests to validate events.
4. Added a new unit test to validate the new one event broadcaster per
   namespace functionality.
5. Updated some methods in mockAppManager for Ingress objects to update
   the fake kube client with Ingress objects to allow the correct code
   path for events to be followed (like it happens in production).
6. Some cleanup around the Params structure where it was allowing
   public access to members intended only for unit tests.

Fixes #417

affects-branches: master