### PR TITLE
Add IApp pool members to ARP table

### DIFF
--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -114,6 +114,9 @@ func (appMgr *Manager) outputConfigLocked() {
 			for _, pool := range cfg.Pools {
 				allPoolMembers = append(allPoolMembers, pool.Members...)
 			}
+			for _, iapp := range cfg.IApps {
+				allPoolMembers = append(allPoolMembers, iapp.IAppPoolMemberTable.Members...)
+			}
 		}
 		select {
 		case appMgr.eventChan <- allPoolMembers:


### PR DESCRIPTION
Problem: IApp pool members were not properly being added to the ARP table.

Solution: Add IApp pool members to the ARP table.