### PR TITLE
Add version and build info to Docker container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ script:
     fi
   - export BUILD_VERSION=$(build-tools/version-tool version)
   - export BUILD_INFO=$(build-tools/version-tool build-info)
+  - if [ "$TRAVIS_TAG" == "$TRAVIS_BRANCH" ]; then BUILD_VERSION=$TRAVIS_TAG; fi
   - export IMG_TAG="${BASE_PUSH_TARGET}:${TRAVIS_COMMIT}"
   - export BUILD_IMG_TAG="${BASE_PUSH_TARGET}-devel:${TRAVIS_COMMIT}"
   - export BUILD_STAMP=devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID-$(date +%s)
@@ -32,7 +33,6 @@ script:
   - make prod
   - docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
   - docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID"
-  - if [ "$TRAVIS_TAG" == "$TRAVIS_BRANCH" ]; then BUILD_VERSION=$TRAVIS_TAG; fi
   - |
     if [ "$DOCKER_READY" ]; then
       docker tag "$IMG_TAG" "$BASE_PUSH_TARGET"

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,8 @@ GOOS     = $(shell go env GOOS)
 GOARCH   = $(shell go env GOARCH)
 GOBIN    = $(GOPATH)/bin/$(GOOS)-$(GOARCH)
 
-export BUILD_VERSION := $(shell ./build-tools/version-tool version)
+NEXT_VERSION := $(shell ./build-tools/version-tool version)
+export BUILD_VERSION := $(if $(BUILD_VERSION),$(BUILD_VERSION),$(NEXT_VERSION))
 export BUILD_INFO := $(shell ./build-tools/version-tool build-info)
 
 GO_BUILD_FLAGS=-v -ldflags "-extldflags \"-static\" -X main.version=$(BUILD_VERSION) -X main.buildInfo=$(BUILD_INFO)"

--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -453,7 +453,7 @@ func main() {
 	}
 
 	if *printVersion {
-		fmt.Printf("%s\n Build: %s\n", version, buildInfo)
+		fmt.Printf("Version: %s\nBuild: %s\n", version, buildInfo)
 		os.Exit(0)
 	}
 
@@ -463,6 +463,8 @@ func main() {
 		flags.Usage()
 		os.Exit(1)
 	}
+
+	log.Infof("Starting: Version: %s, BuildInfo: %s", version, buildInfo)
 
 	appmanager.DEFAULT_PARTITION = (*bigIPPartitions)[0]
 	appmanager.RegisterBigIPSchemaTypes()


### PR DESCRIPTION
- Log the version and build info when the controller starts

- When building from a tagged CI build, use the version from the
  tag instead of the one from next-version.txt