### PR TITLE
Update docs for config health monitors, recv field

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -461,19 +461,31 @@ Backend
 
 The ``backend`` section tells the |kctlr| about the Service you want to manage.
 
-+---------------+-----------+-----------+-----------+-------------------------------+---------------------------+
-| Property      | Type      | Required  | Default   | Description                   | Allowed Values            |
-+===============+===========+===========+===========+===============================+===========================+
-| ServiceName   | string    | Required  | none      | The `Kubernetes Service`_     |                           |
-|               |           |           |           | representing the server pool. |                           |
-+---------------+-----------+-----------+-----------+-------------------------------+---------------------------+
-| ServicePort   | integer   | Required  | none      | Kubernetes Service port       |                           |
-|               |           |           |           | number                        |                           |
-+---------------+-----------+-----------+-----------+-------------------------------+---------------------------+
-| healthMonitors| JSON      | Optional  | none      | Array of TCP, UDP or HTTP     |                           |
-|               | object    |           |           | Health Monitors.              |                           |
-|               | array     |           |           |                               |                           |
-+---------------+-----------+-----------+-----------+-------------------------------+---------------------------+
++---------------------------+-----------+-----------+-------------+---------------------------------+---------------------------+
+| Property                  | Type      | Required  | Default     | Description                     | Allowed Values            |
++===========================+===========+===========+=============+=================================+===========================+
+| ServiceName               | string    | Required  | none        | The `Kubernetes Service`_       |                           |
+|                           |           |           |             | representing the server pool.   |                           |
++---------------------------+-----------+-----------+-------------+---------------------------------+---------------------------+
+| ServicePort               | integer   | Required  | none        | Kubernetes Service port         |                           |
+|                           |           |           |             | number                          |                           |
++---------------------------+-----------+-----------+-------------+---------------------------------+---------------------------+
+| healthMonitors            | JSON      | Optional  | none        | Array of TCP, UDP or HTTP       |                           |
+|                           | object    |           |             | Health Monitors.                |                           |
+|                           | array     |           |             |                                 |                           |
++---------------+-----------+-----------+-----------+-------------+---------------------------------+---------------------------+
+|               | protocol  | string    | Required  | N/A         | Protocol used to confim health. | http, tcp, udp            |
++---------------+-----------+-----------+-----------+-------------+---------------------------------+---------------------------+
+|               | interval  | integer   | Optional  | 5           | Seconds between health queries. | 1 to 86,400.              |
++---------------+-----------+-----------+-----------+-------------+---------------------------------+---------------------------+
+|               | timeout   | integer   | Optional  | 16          | Seconds before query fails.     | Integer from 1 to 86,400. |
++---------------+-----------+-----------+-----------+-------------+---------------------------------+---------------------------+
+|               | send      | string    | Optional  | "GET /\r\n" | HTTP request string to send.    | String values.            |
++---------------+-----------+-----------+-----------+-------------+---------------------------------+---------------------------+
+|               | recv      | string    | Optional  | none        | String or RegEx pattern to      | String or valid RegEx.    |
+|               |           |           |           |             | match in first 5,120 bytes of   |                           |
+|               |           |           |           |             | backend response.               |                           |
++---------------+-----------+-----------+-----------+-------------+---------------------------------+---------------------------+
 
 .. _ingress resources:
 
@@ -509,14 +521,16 @@ Supported annotations
 |                      | path        | string      | Required  | The path for the Service specified in the Ingress resource.                         | N/A         |
 |                      |             |             | [#hm1]_   |                                                                                     |             |
 +----------------------+-------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
-|                      | send        | string      | Required  | The send string to set in the health monitor. [#hm2]_                               | N/A         |
-|                      |             |             | [#hm1]_   |                                                                                     |             |
-+----------------------+-------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
 |                      | interval    | integer     | Required  | The interval at which to check the health of the virtual server.                    | N/A         |
 |                      |             |             | [#hm1]_   |                                                                                     |             |
 +----------------------+-------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
 |                      | timeout     | integer     | Required  | Number of seconds before the check times out.                                       | N/A         |
 |                      |             |             | [#hm1]_   |                                                                                     |             |
++----------------------+-------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
+|                      | send        | string      | Required  | The send string to set in the health monitor. [#hm2]_                               | N/A         |
+|                      |             |             | [#hm1]_   |                                                                                     |             |
++----------------------+-------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
+|                      | recv        | string      | Optional  | String or RegEx pattern to match in first 5,120 bytes of backend response.          | N/A         |
 +----------------------+-------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
 | ingress.kubernetes.io/allow-http   | boolean     | Optional  | Tells the Controller to allow HTTP traffic for HTTPS Ingress resources.             | false       |
 +------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
@@ -617,14 +631,16 @@ Supported annotations
 |                      | path            | string      | Required  | The path for the Service specified in the Route resource.                      | N/A         |
 |                      |                 |             | [#hm1]_   |                                                                                |             |
 +----------------------+-----------------+-------------+-----------+--------------------------------------------------------------------------------+-------------+
-|                      | send            | string      | Required  | The send string to set in the health monitor. [#hm2]_                          | N/A         |
-|                      |                 |             | [#hm1]_   |                                                                                |             |
-+----------------------+-----------------+-------------+-----------+--------------------------------------------------------------------------------+-------------+
 |                      | interval        | integer     | Required  | The interval at which to check the health of the virtual server.               | N/A         |
 |                      |                 |             | [#hm1]_   |                                                                                |             |
 +----------------------+-----------------+-------------+-----------+--------------------------------------------------------------------------------+-------------+
 |                      | timeout         | integer     | Required  | Number of seconds before the check times out.                                  | N/A         |
 |                      |                 |             | [#hm1]_   |                                                                                |             |
++----------------------+-----------------+-------------+-----------+--------------------------------------------------------------------------------+-------------+
+|                      | send            | string      | Required  | The send string to set in the health monitor. [#hm2]_                          | N/A         |
+|                      |                 |             | [#hm1]_   |                                                                                |             |
++----------------------+-----------------+-------------+-----------+--------------------------------------------------------------------------------+-------------+
+|                      | recv            | string      | Optional  | String or RegEx pattern to match in first 5,120 bytes of backend response.     | N/A         |
 +----------------------+-----------------+-------------+-----------+--------------------------------------------------------------------------------+-------------+
 | virtual-server.f5.com/secure-serverssl | boolean     | Optional  | Specify to validate the server-side SSL certificate of Re-encrypt              | false       |
 |                                        |             |           | terminated routes.                                                             |             |

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -654,6 +654,7 @@ Example Configuration Files
 - :fonticon:`fa fa-download` :download:`sample-k8s-bigip-ctlr-secrets.yaml <./_static/config_examples/sample-k8s-bigip-ctlr-secrets.yaml>`
 - :fonticon:`fa fa-download` :download:`sample-bigip-credentials-secret.yaml <./_static/config_examples/sample-bigip-credentials-secret.yaml>`
 - :fonticon:`fa fa-download` :download:`example-vs-resource.configmap.yaml <./_static/config_examples/example-vs-resource.configmap.yaml>`
+- :fonticon:`fa fa-download` :download:`example-vs-resource-udp.configmap.yaml <./_static/config_examples/example-vs-resource-udp.configmap.yaml>`
 - :fonticon:`fa fa-download` :download:`example-vs-resource.json <./_static/config_examples/example-vs-resource.json>`
 - :fonticon:`fa fa-download` :download:`example-vs-resource-iapp.json <./_static/config_examples/example-vs-resource-iapp.json>`
 - :fonticon:`fa fa-download` :download:`example-advanced-vs-resource-iapp.json <./_static/config_examples/example-advanced-vs-resource-iapp.json>`

--- a/docs/_static/config_examples/example-vs-resource-udp.configmap.yaml
+++ b/docs/_static/config_examples/example-vs-resource-udp.configmap.yaml
@@ -1,0 +1,37 @@
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: example-udp-vs
+  namespace: default
+  labels: 
+    f5type: virtual-server
+data:
+  # this example expects the vs to be backed by a udp mirror service
+  schema: "f5schemadb://bigip-virtual-server_v0.1.6.json"
+  data: |
+    {
+      "virtualServer": {
+        "frontend": {
+          "balance": "round-robin",
+          "mode": "udp",
+          "partition": "kubernetes",
+          "virtualAddress": {
+            "bindAddr": "1.2.3.4",
+            "port": 8080
+          }
+        },
+        "backend": {
+          "healthMonitors": [
+            {
+              "interval": 25,
+              "protocol": "udp",
+              "send": "This example presumes a udp mirror server",
+              "recv": "udp|regex",
+              "timeout": 20
+            }
+          ],
+          "serviceName": "example-service",
+          "servicePort": 4445
+        }
+      }
+    }


### PR DESCRIPTION
Problem:
- Virtual Server Resource backend table did not include health monitor information.
- Recv field added by #444 were not yet documented.

Solution:
- Added health monitor details for supported fields to backend table.
- Added recv field documentation to ingress/routes.
- Reordered ingress/route health annotations to reflect order of fields on health monitors within BigIP ui.

fixes #388