### PR TITLE
Add version information to rhel image build

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,6 +16,8 @@ pipeline {
           export BASE_OS=rhel7
           export GIT_COMMIT=$(git rev-parse HEAD)
           export GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          export BUILD_VERSION=$(build-tools/version-tool version)
+          export BUILD_INFO=$(build-tools/version-tool build-info)
           DOCKER_NAMESPACE="docker-registry.pdbld.f5net.com/velcro"
           BASE_PUSH_TARGET="$DOCKER_NAMESPACE/k8s-bigip-ctlr"
           export IMG_TAG="${BASE_PUSH_TARGET}:${GIT_COMMIT}-$BASE_OS"


### PR DESCRIPTION
Problem:
- Jenkinsfile that builds rhel image invokes `build-tools/build-devel-image.sh` which in turn invokes `build-tools/_build-lib.sh` which expects `BUILD_VERSION` and `BUILD_INFO` env vars, which are not present.

Solution:
- Added version tool invocations to Jenkinsfile.

fixes #453