### PR TITLE
Set InsecureEdgeTerminationPolicy affects all Route objects.

### DIFF
--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -97,10 +97,10 @@ func (appMgr *Manager) outputConfigLocked() {
 	}
 	for intDgKey, intDgMap := range appMgr.intDgMap {
 		initPartitionData(resources, intDgKey.Partition)
-		if len(intDgMap) > 0 {
-			for _, intDg := range intDgMap {
-				resources[intDgKey.Partition].InternalDataGroups = append(resources[intDgKey.Partition].InternalDataGroups, *intDg)
-			}
+		// Join all namespace DG's into one DG before adding.
+		flatDg := intDgMap.FlattenNamespaces()
+		if nil != flatDg {
+			resources[intDgKey.Partition].InternalDataGroups = append(resources[intDgKey.Partition].InternalDataGroups, *flatDg)
 		} else {
 			// The data group is required, but we have no information.
 			resources[intDgKey.Partition].InternalDataGroups = append(resources[intDgKey.Partition].InternalDataGroups, *NewInternalDataGroup(intDgKey.Name, intDgKey.Partition))

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -501,7 +501,9 @@ var _ = Describe("Resource Config Tests", func() {
 				HttpVs:  "ose-vserver",
 				HttpsVs: "https-ose-vserver",
 			}
-			cfg, _, _ := createRSConfigFromRoute(route, Resources{}, rc, ps, nil)
+			svcFwdRulesMap := NewServiceFwdRuleMap()
+			cfg, _, _ := createRSConfigFromRoute(route, Resources{}, rc, ps, nil,
+				svcFwdRulesMap)
 			Expect(cfg.Virtual.Name).To(Equal("https-ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_foo"))
 			Expect(cfg.Pools[0].ServiceName).To(Equal("foo"))
@@ -525,7 +527,8 @@ var _ = Describe("Resource Config Tests", func() {
 				protocol: "http",
 				port:     80,
 			}
-			cfg, _, _ = createRSConfigFromRoute(route2, Resources{}, rc, ps, nil)
+			cfg, _, _ = createRSConfigFromRoute(route2, Resources{}, rc, ps, nil,
+				svcFwdRulesMap)
 			Expect(cfg.Virtual.Name).To(Equal("ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_bar"))
 			Expect(cfg.Pools[0].ServiceName).To(Equal("bar"))


### PR DESCRIPTION
Problem:
Since there is only one virtual for HTTP OpenShift Routes, any Route
that specifies that HTTP should be redirected to HTTPS affects all
Routes.

Solution:
1. The controller now maintains a new data group for HTTP redirects.
2. Updated the HTTP redirect IRule to perform a lookup to the new data
   group by host and path to determine if the HTTP request should be
   redirected.
3. The controller keeps the redirect data group updated for both
   OpenShift Route and Ingress resources to prevent the need to
   maintain 2 IRules for HTTP redirect and to automatically do the
   right thing when shared-ip for Ingress is implemented. This required
   some the existing data group handling code to be moved so it would
   be able to work across resource types (previously it was only used
   by Routes).
4. Removed some dead code from handleIngressTls left over from the
   first generation of HTTP redirect (policy based).
5. Discovered and fixed an issue with potential duplicate data when
   combining data group records from multiple namespaces.
6. Updated existing unit tests and wrote 2 new ones to test the new
   functionality for Routes and Ingresses.

Fixes #341

affects-branches: master