### PR TITLE
Shared Ingress support

### DIFF
--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -1114,7 +1114,7 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
 
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(Equal(1),
 					"Virtual servers should have entry.")
 				_, ok := resources.Get(
@@ -1128,7 +1128,7 @@ var _ = Describe("AppManager Tests", func() {
 
 				r = mockMgr.addConfigMap(cfgFoo)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(Equal(1),
 					"Virtual servers should have entry.")
 				_, ok = resources.Get(
@@ -1142,7 +1142,7 @@ var _ = Describe("AppManager Tests", func() {
 
 				r = mockMgr.addConfigMap(cfgFoo)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(Equal(1),
 					"Virtual servers should have entry.")
 				_, ok = resources.Get(
@@ -1168,7 +1168,7 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
 
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(Equal(1),
 					"Virtual servers should have entry.")
 
@@ -1233,7 +1233,7 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
 
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(3))
+				Expect(resources.PoolCount()).To(Equal(3))
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 8080, namespace})).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 9090, namespace})).To(Equal(1))
@@ -1245,7 +1245,7 @@ var _ = Describe("AppManager Tests", func() {
 				r = mockMgr.updateService(newFoo)
 				Expect(r).To(BeTrue(), "Service should be processed.")
 
-				Expect(resources.Count()).To(Equal(3))
+				Expect(resources.PoolCount()).To(Equal(3))
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 8080, namespace})).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 9090, namespace})).To(Equal(1))
@@ -1277,7 +1277,7 @@ var _ = Describe("AppManager Tests", func() {
 
 				r = mockMgr.updateService(newFoo2)
 				Expect(r).To(BeTrue(), "Service should be processed.")
-				Expect(resources.Count()).To(Equal(3))
+				Expect(resources.PoolCount()).To(Equal(3))
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 8080, namespace})).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 9090, namespace})).To(Equal(1))
@@ -1401,7 +1401,7 @@ var _ = Describe("AppManager Tests", func() {
 					defer GinkgoRecover()
 					r := mockMgr.deleteConfigMap(cfgFoo)
 					Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-					Expect(resources.Count()).To(Equal(1))
+					Expect(resources.PoolCount()).To(Equal(1))
 
 					mapCh <- struct{}{}
 				}()
@@ -1551,7 +1551,7 @@ var _ = Describe("AppManager Tests", func() {
 				case <-time.After(time.Second * 30):
 					Fail("Timed out expecting service channel notification.")
 				}
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				validateConfig(mw, oneSvcTwoPodsConfig)
 			})
 
@@ -1602,7 +1602,7 @@ var _ = Describe("AppManager Tests", func() {
 				r := mockMgr.addConfigMap(cfgFoo)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				rs, ok := resources.Get(
 					serviceKey{"foo", 80, namespace}, formatConfigMapVSName(cfgFoo))
 				Expect(ok).To(BeTrue())
@@ -1610,7 +1610,7 @@ var _ = Describe("AppManager Tests", func() {
 				// Second ConfigMap added
 				r = mockMgr.addConfigMap(cfgBar)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 				rs, ok = resources.Get(
 					serviceKey{"foo", 80, namespace}, formatConfigMapVSName(cfgFoo))
 				Expect(ok).To(BeTrue())
@@ -1623,7 +1623,7 @@ var _ = Describe("AppManager Tests", func() {
 				// Service ADDED
 				r = mockMgr.addService(foo)
 				Expect(r).To(BeTrue(), "Service should be processed.")
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 				rs, ok = resources.Get(
 					serviceKey{"foo", 80, namespace}, formatConfigMapVSName(cfgFoo))
 				Expect(ok).To(BeTrue())
@@ -1633,7 +1633,7 @@ var _ = Describe("AppManager Tests", func() {
 				// Second Service ADDED
 				r = mockMgr.addService(bar)
 				Expect(r).To(BeTrue(), "Service should be processed.")
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 				rs, ok = resources.Get(
 					serviceKey{"bar", 80, namespace}, formatConfigMapVSName(cfgBar))
 				Expect(ok).To(BeTrue())
@@ -1643,7 +1643,7 @@ var _ = Describe("AppManager Tests", func() {
 				// ConfigMap ADDED second foo port
 				r = mockMgr.addConfigMap(cfgFoo8080)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(3))
+				Expect(resources.PoolCount()).To(Equal(3))
 				rs, ok = resources.Get(
 					serviceKey{"foo", 8080, namespace}, formatConfigMapVSName(cfgFoo8080))
 				Expect(ok).To(BeTrue())
@@ -1663,7 +1663,7 @@ var _ = Describe("AppManager Tests", func() {
 				// ConfigMap ADDED third foo port
 				r = mockMgr.addConfigMap(cfgFoo9090)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(4))
+				Expect(resources.PoolCount()).To(Equal(4))
 				rs, ok = resources.Get(
 					serviceKey{"foo", 9090, namespace}, formatConfigMapVSName(cfgFoo9090))
 				Expect(ok).To(BeTrue())
@@ -1691,7 +1691,7 @@ var _ = Describe("AppManager Tests", func() {
 				n, err = fakeClient.Core().Nodes().List(metav1.ListOptions{})
 				Expect(err).To(BeNil(), "Should not fail listing nodes.")
 				mockMgr.processNodeUpdate(n.Items, err)
-				Expect(resources.Count()).To(Equal(4))
+				Expect(resources.PoolCount()).To(Equal(4))
 				rs, ok = resources.Get(
 					serviceKey{"foo", 80, namespace}, formatConfigMapVSName(cfgFoo))
 				Expect(ok).To(BeTrue())
@@ -1721,7 +1721,7 @@ var _ = Describe("AppManager Tests", func() {
 				// ConfigMap DELETED third foo port
 				r = mockMgr.deleteConfigMap(cfgFoo9090)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(3))
+				Expect(resources.PoolCount()).To(Equal(3))
 				Expect(resources.CountOf(serviceKey{"foo", 9090, namespace})).To(
 					Equal(0), "Virtual servers should not contain removed port.")
 				Expect(resources.CountOf(serviceKey{"foo", 8080, namespace})).To(
@@ -1734,7 +1734,7 @@ var _ = Describe("AppManager Tests", func() {
 				// ConfigMap UPDATED second foo port
 				r = mockMgr.updateConfigMap(cfgFoo8080)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(3))
+				Expect(resources.PoolCount()).To(Equal(3))
 				Expect(resources.CountOf(serviceKey{"foo", 8080, namespace})).To(
 					Equal(1), "Virtual servers should contain remaining ports.")
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(
@@ -1745,7 +1745,7 @@ var _ = Describe("AppManager Tests", func() {
 				// ConfigMap DELETED second foo port
 				r = mockMgr.deleteConfigMap(cfgFoo8080)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 				Expect(resources.CountOf(serviceKey{"foo", 8080, namespace})).To(
 					Equal(0), "Virtual servers should not contain removed port.")
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(
@@ -1761,7 +1761,7 @@ var _ = Describe("AppManager Tests", func() {
 				n, err = fakeClient.Core().Nodes().List(metav1.ListOptions{})
 				Expect(err).To(BeNil(), "Should not fail listing nodes.")
 				mockMgr.processNodeUpdate(n.Items, err)
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 				rs, ok = resources.Get(
 					serviceKey{"foo", 80, namespace}, formatConfigMapVSName(cfgFoo))
 				Expect(ok).To(BeTrue())
@@ -1777,7 +1777,7 @@ var _ = Describe("AppManager Tests", func() {
 				// ConfigMap DELETED
 				r = mockMgr.deleteConfigMap(cfgFoo)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(
 					Equal(0), "Config map should be removed after delete.")
 				validateConfig(mw, oneSvcOneNodeConfig)
@@ -1785,7 +1785,7 @@ var _ = Describe("AppManager Tests", func() {
 				// Service deleted
 				r = mockMgr.deleteService(bar)
 				Expect(r).To(BeTrue(), "Service should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				validateConfig(mw, emptyConfig)
 			})
 
@@ -1801,7 +1801,7 @@ var _ = Describe("AppManager Tests", func() {
 				r := mockMgr.addConfigMap(noschemakey)
 				Expect(r).To(BeFalse(), "Config map should not be processed.")
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(0))
+				Expect(resources.PoolCount()).To(Equal(0))
 
 				// Config map with no data key
 				nodatakey := test.NewConfigMap("nodata", "1", namespace, map[string]string{
@@ -1813,7 +1813,7 @@ var _ = Describe("AppManager Tests", func() {
 					"Should receive 'no data' error.")
 				r = mockMgr.addConfigMap(nodatakey)
 				Expect(r).To(BeFalse(), "Config map should not be processed.")
-				Expect(resources.Count()).To(Equal(0))
+				Expect(resources.PoolCount()).To(Equal(0))
 
 				// Config map with bad json
 				badjson := test.NewConfigMap("badjson", "1", namespace, map[string]string{
@@ -1826,7 +1826,7 @@ var _ = Describe("AppManager Tests", func() {
 					"invalid character '/' looking for beginning of value"))
 				r = mockMgr.addConfigMap(badjson)
 				Expect(r).To(BeFalse(), "Config map should not be processed.")
-				Expect(resources.Count()).To(Equal(0))
+				Expect(resources.PoolCount()).To(Equal(0))
 
 				// Config map with extra keys
 				extrakeys := test.NewConfigMap("extrakeys", "1", namespace, map[string]string{
@@ -1840,7 +1840,7 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(err).To(BeNil(), "Should not receive errors.")
 				r = mockMgr.addConfigMap(extrakeys)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				resources.Delete(serviceKey{"foo", 80, namespace},
 					formatConfigMapVSName(extrakeys))
 
@@ -1854,7 +1854,7 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(err).To(BeNil(), "Should not receive errors.")
 				r = mockMgr.addConfigMap(defaultModeAndBalance)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 
 				rs, ok := resources.Get(
 					serviceKey{"bar", 80, namespace}, formatConfigMapVSName(defaultModeAndBalance))
@@ -1912,7 +1912,7 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(ok).To(BeFalse(), "Config map should not be added if namespace does not match flag.")
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(
 					Equal(1), "Virtual servers should contain original config.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 
 				r = mockMgr.updateConfigMap(cfgBar)
 				Expect(r).To(BeFalse(), "Config map should not be processed.")
@@ -1921,7 +1921,7 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(ok).To(BeFalse(), "Config map should not be added if namespace does not match flag.")
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(
 					Equal(1), "Virtual servers should contain original config.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 
 				r = mockMgr.deleteConfigMap(cfgBar)
 				Expect(r).To(BeFalse(), "Config map should not be processed.")
@@ -2008,7 +2008,7 @@ var _ = Describe("AppManager Tests", func() {
 				r := mockMgr.addConfigMap(cfgIapp1)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				rs, ok := resources.Get(
 					serviceKey{"iapp1", 80, namespace}, formatConfigMapVSName(cfgIapp1))
 				Expect(ok).To(BeTrue())
@@ -2016,7 +2016,7 @@ var _ = Describe("AppManager Tests", func() {
 				// Second ConfigMap ADDED
 				r = mockMgr.addConfigMap(cfgIapp2)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 				rs, ok = resources.Get(
 					serviceKey{"iapp1", 80, namespace}, formatConfigMapVSName(cfgIapp1))
 				Expect(ok).To(BeTrue())
@@ -2024,7 +2024,7 @@ var _ = Describe("AppManager Tests", func() {
 				// Service ADDED
 				r = mockMgr.addService(iapp1)
 				Expect(r).To(BeTrue(), "Service should be processed.")
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 				rs, ok = resources.Get(
 					serviceKey{"iapp1", 80, namespace}, formatConfigMapVSName(cfgIapp1))
 				Expect(ok).To(BeTrue())
@@ -2033,7 +2033,7 @@ var _ = Describe("AppManager Tests", func() {
 				// Second Service ADDED
 				r = mockMgr.addService(iapp2)
 				Expect(r).To(BeTrue(), "Service should be processed.")
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 				rs, ok = resources.Get(
 					serviceKey{"iapp1", 80, namespace}, formatConfigMapVSName(cfgIapp1))
 				Expect(ok).To(BeTrue())
@@ -2046,12 +2046,12 @@ var _ = Describe("AppManager Tests", func() {
 				// ConfigMap UPDATED
 				r = mockMgr.updateConfigMap(cfgIapp1)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 
 				// Service UPDATED
 				r = mockMgr.updateService(iapp1)
 				Expect(r).To(BeTrue(), "Service should be processed.")
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 
 				// Nodes ADDED
 				_, err = fakeClient.Core().Nodes().Create(extraNode)
@@ -2059,7 +2059,7 @@ var _ = Describe("AppManager Tests", func() {
 				n, err = fakeClient.Core().Nodes().List(metav1.ListOptions{})
 				Expect(err).To(BeNil(), "Should not fail listing nodes.")
 				mockMgr.processNodeUpdate(n.Items, err)
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 				rs, ok = resources.Get(
 					serviceKey{"iapp1", 80, namespace}, formatConfigMapVSName(cfgIapp1))
 				Expect(ok).To(BeTrue())
@@ -2080,7 +2080,7 @@ var _ = Describe("AppManager Tests", func() {
 				n, err = fakeClient.Core().Nodes().List(metav1.ListOptions{})
 				Expect(err).To(BeNil(), "Should not fail listing nodes.")
 				mockMgr.processNodeUpdate(n.Items, err)
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 				rs, ok = resources.Get(
 					serviceKey{"iapp1", 80, namespace}, formatConfigMapVSName(cfgIapp1))
 				Expect(ok).To(BeTrue())
@@ -2096,7 +2096,7 @@ var _ = Describe("AppManager Tests", func() {
 				// ConfigMap DELETED
 				r = mockMgr.deleteConfigMap(cfgIapp1)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"iapp1", 80, namespace})).To(
 					Equal(0), "Config map should be removed after delete.")
 				validateConfig(mw, oneIappOneNodeConfig)
@@ -2104,7 +2104,7 @@ var _ = Describe("AppManager Tests", func() {
 				// Service DELETED
 				r = mockMgr.deleteService(iapp2)
 				Expect(r).To(BeTrue(), "Service should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				validateConfig(mw, emptyConfig)
 			})
 
@@ -2138,7 +2138,7 @@ var _ = Describe("AppManager Tests", func() {
 				r := mockMgr.addConfigMap(noBindAddr)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 
 				rs, ok := resources.Get(
 					serviceKey{"foo", 80, namespace}, formatConfigMapVSName(noBindAddr))
@@ -2180,7 +2180,7 @@ var _ = Describe("AppManager Tests", func() {
 				r := mockMgr.addConfigMap(noVirtualAddress)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 
 				rs, ok := resources.Get(
 					serviceKey{"foo", 80, namespace}, formatConfigMapVSName(noVirtualAddress))
@@ -2246,7 +2246,7 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(r).To(BeTrue(), "Service should be processed.")
 
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(len(svcPorts)))
+				Expect(resources.PoolCount()).To(Equal(len(svcPorts)))
 				for _, p := range svcPorts {
 					Expect(resources.CountOf(serviceKey{"foo", p.Port, namespace})).To(Equal(1))
 					rs, ok := resources.Get(
@@ -2313,7 +2313,7 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(r).To(BeTrue(), "Service should be processed.")
 
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(len(svcPorts)))
+				Expect(resources.PoolCount()).To(Equal(len(svcPorts)))
 				for _, p := range svcPorts {
 					Expect(resources.CountOf(serviceKey{"foo", p.Port, namespace})).To(Equal(1))
 				}
@@ -2401,20 +2401,20 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
 
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(len(svcPorts)))
+				Expect(resources.PoolCount()).To(Equal(len(svcPorts)))
 				validateServiceIps(svcName, namespace, svcPorts, svcPodIps, resources)
 
 				// delete the service and make sure the IPs go away on the VS
 				r = mockMgr.deleteService(foo)
 				Expect(r).To(BeTrue(), "Service should be processed.")
-				Expect(resources.Count()).To(Equal(len(svcPorts)))
+				Expect(resources.PoolCount()).To(Equal(len(svcPorts)))
 				validateServiceIps(svcName, namespace, svcPorts, nil, resources)
 
 				// re-add the service
 				foo.ObjectMeta.ResourceVersion = "2"
 				r = mockMgr.addService(foo)
 				Expect(r).To(BeTrue(), "Service should be processed.")
-				Expect(resources.Count()).To(Equal(len(svcPorts)))
+				Expect(resources.PoolCount()).To(Equal(len(svcPorts)))
 				validateServiceIps(svcName, namespace, svcPorts, svcPodIps, resources)
 			})
 
@@ -2441,7 +2441,7 @@ var _ = Describe("AppManager Tests", func() {
 
 				// no virtual servers yet
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(0))
+				Expect(resources.PoolCount()).To(Equal(0))
 
 				// add a config map
 				cfgFoo := test.NewConfigMap("foomap", "1", namespace, map[string]string{
@@ -2449,7 +2449,7 @@ var _ = Describe("AppManager Tests", func() {
 					"data":   configmapFoo})
 				r = mockMgr.addConfigMap(cfgFoo)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				validateServiceIps(svcName, namespace, svcPorts[:1], svcPodIps, resources)
 
 				// add another
@@ -2458,13 +2458,13 @@ var _ = Describe("AppManager Tests", func() {
 					"data":   configmapFoo8080})
 				r = mockMgr.addConfigMap(cfgFoo8080)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 				validateServiceIps(svcName, namespace, svcPorts[:2], svcPodIps, resources)
 
 				// remove first one
 				r = mockMgr.deleteConfigMap(cfgFoo)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				validateServiceIps(svcName, namespace, svcPorts[1:2], svcPodIps, resources)
 			})
 
@@ -2491,7 +2491,7 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
 
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(Equal(1),
 					"Virtual servers should have an entry.")
 
@@ -2505,7 +2505,7 @@ var _ = Describe("AppManager Tests", func() {
 
 				r = mockMgr.addService(foo)
 				Expect(r).To(BeTrue(), "Service should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 80, namespace})).To(Equal(1),
 					"Virtual servers should have an entry.")
 			})
@@ -2547,28 +2547,34 @@ var _ = Describe("AppManager Tests", func() {
 				}`
 
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(0))
+				Expect(resources.PoolCount()).To(Equal(0))
 				r = mockMgr.addConfigMap(test.NewConfigMap("cmap-1", "1", namespace, map[string]string{
 					"schema": schemaUrl,
 					"data":   fmt.Sprintf(vsTemplate, 5, 80),
 				}))
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				r = mockMgr.updateConfigMap(test.NewConfigMap("cmap-1", "2", namespace, map[string]string{
 					"schema": schemaUrl,
 					"data":   fmt.Sprintf(vsTemplate, 5, 80),
 				}))
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				r = mockMgr.addConfigMap(test.NewConfigMap("cmap-2", "1", namespace, map[string]string{
 					"schema": schemaUrl,
 					"data":   fmt.Sprintf(vsTemplate, 5, 8080),
 				}))
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 			})
 
 			It("configures virtual servers via Ingress", func() {
+				// Add a service
+				fooSvc := test.NewService("foo", "1", namespace, "NodePort",
+					[]v1.ServicePort{{Port: 80, NodePort: 37001}})
+				r := mockMgr.addService(fooSvc)
+				Expect(r).To(BeTrue(), "Service should be processed.")
+
 				ingressConfig := v1beta1.IngressSpec{
 					Backend: &v1beta1.IngressBackend{
 						ServiceName: "foo",
@@ -2581,23 +2587,19 @@ var _ = Describe("AppManager Tests", func() {
 						f5VsBindAddrAnnotation:  "1.2.3.4",
 						f5VsPartitionAnnotation: "velcro",
 					})
-				r := mockMgr.addIngress(ingress)
+				r = mockMgr.addIngress(ingress)
 				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(1))
-				// Associate a service
-				fooSvc := test.NewService("foo", "1", namespace, "NodePort",
-					[]v1.ServicePort{{Port: 80, NodePort: 37001}})
-				r = mockMgr.addService(fooSvc)
-				Expect(r).To(BeTrue(), "Service should be processed.")
+
 				events := mockMgr.getFakeEvents(namespace)
 				Expect(len(events)).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				Expect(events[0].Namespace).To(Equal(namespace))
 				Expect(events[0].Name).To(Equal("ingress"))
 				Expect(events[0].Reason).To(Equal("ResourceConfigured"))
 
 				rs, ok := resources.Get(
-					serviceKey{"foo", 80, "default"}, "default_ingress-ingress_http")
+					serviceKey{"foo", 80, "default"}, formatIngressVSName("1.2.3.4", 80))
 				Expect(ok).To(BeTrue(), "Ingress should be accessible.")
 				Expect(rs).ToNot(BeNil(), "Ingress should be object.")
 				Expect(rs.MetaData.Active).To(BeTrue())
@@ -2615,7 +2617,7 @@ var _ = Describe("AppManager Tests", func() {
 					})
 				r = mockMgr.updateIngress(ingress2)
 				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				events = mockMgr.getFakeEvents(namespace)
 				Expect(len(events)).To(Equal(2))
 				Expect(events[1].Namespace).To(Equal(namespace))
@@ -2623,7 +2625,7 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(events[1].Reason).To(Equal("ResourceConfigured"))
 
 				rs, ok = resources.Get(
-					serviceKey{"foo", 80, "default"}, "default_ingress-ingress_http")
+					serviceKey{"foo", 80, "default"}, formatIngressVSName("5.6.7.8", 443))
 				Expect(ok).To(BeTrue(), "Ingress should be accessible.")
 				Expect(rs).ToNot(BeNil(), "Ingress should be object.")
 
@@ -2633,7 +2635,7 @@ var _ = Describe("AppManager Tests", func() {
 				// Delete the Ingress resource
 				r = mockMgr.deleteIngress(ingress2)
 				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
-				Expect(resources.Count()).To(Equal(0))
+				Expect(resources.PoolCount()).To(Equal(0))
 				events = mockMgr.getFakeEvents(namespace)
 				Expect(len(events)).To(Equal(2))
 
@@ -2645,17 +2647,17 @@ var _ = Describe("AppManager Tests", func() {
 					})
 				r = mockMgr.addIngress(ingressNotf5)
 				Expect(r).To(BeFalse(), "Ingress resource should not be processed.")
-				Expect(resources.Count()).To(Equal(0))
+				Expect(resources.PoolCount()).To(Equal(0))
 				ingressNotf5.Annotations[k8sIngressClass] = "f5"
 				r = mockMgr.updateIngress(ingressNotf5)
 				Expect(r).To(BeTrue(), "Ingress resource should be processed when flipping from notf5 to f5.")
-				Expect(resources.Count()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(1))
 				events = mockMgr.getFakeEvents(namespace)
 				Expect(len(events)).To(Equal(3))
 				ingressNotf5.Annotations[k8sIngressClass] = "notf5again"
 				r = mockMgr.updateIngress(ingressNotf5)
 				Expect(r).To(BeFalse(), "Ingress resource should be destroyed when flipping from f5 to notf5again.")
-				Expect(resources.Count()).To(Equal(0))
+				Expect(resources.PoolCount()).To(Equal(0))
 				events = mockMgr.getFakeEvents(namespace)
 				Expect(len(events)).To(Equal(3))
 
@@ -2724,14 +2726,14 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(len(events)).To(Equal(4))
 				// 4 rules, but only 3 backends specified. We should have 3 keys stored, one for
 				// each backend
-				Expect(resources.Count()).To(Equal(3))
+				Expect(resources.PoolCount()).To(Equal(3))
 				rs, ok = resources.Get(
-					serviceKey{"foo", 80, "default"}, "default_ingress-ingress_http")
+					serviceKey{"foo", 80, "default"}, formatIngressVSName("1.2.3.4", 80))
 				Expect(len(rs.Policies[0].Rules)).To(Equal(4))
 				mockMgr.deleteService(fooSvc)
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 				rs, ok = resources.Get(
-					serviceKey{"bar", 80, "default"}, "default_ingress-ingress_http")
+					serviceKey{"bar", 80, "default"}, formatIngressVSName("1.2.3.4", 80))
 				Expect(len(rs.Policies[0].Rules)).To(Equal(2))
 
 				mockMgr.deleteIngress(ingress3)
@@ -2765,14 +2767,35 @@ var _ = Describe("AppManager Tests", func() {
 						f5VsBindAddrAnnotation:  "1.2.3.4",
 						f5VsPartitionAnnotation: "velcro",
 					})
+				// Add ingress with same ip (should use shared virtual)
+				ingress5 := test.NewIngress("ingressShared", "3", namespace,
+					v1beta1.IngressSpec{
+						Backend: &v1beta1.IngressBackend{
+							ServiceName: "foobar",
+							ServicePort: intstr.IntOrString{IntVal: 80},
+						},
+					},
+					map[string]string{
+						f5VsBindAddrAnnotation:  "1.2.3.4",
+						f5VsPartitionAnnotation: "velcro",
+					})
 				r = mockMgr.addIngress(ingress4)
 				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
-				Expect(resources.Count()).To(Equal(2))
+				r = mockMgr.addIngress(ingress5)
+				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
+				Expect(resources.VirtualCount()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(3))
 				rs, ok = resources.Get(
-					serviceKey{"foo", 80, "default"}, "default_ingress-ingress_http")
+					serviceKey{"foo", 80, "default"}, formatIngressVSName("1.2.3.4", 80))
 				Expect(len(rs.Policies[0].Rules)).To(Equal(2))
 				events = mockMgr.getFakeEvents(namespace)
-				Expect(len(events)).To(Equal(5))
+				Expect(len(events)).To(Equal(8))
+
+				mockMgr.deleteIngress(ingress5)
+				Expect(resources.VirtualCount()).To(Equal(1))
+				Expect(resources.PoolCount()).To(Equal(2))
+				mockMgr.deleteService(fooSvc)
+				Expect(resources.PoolCount()).To(Equal(1))
 			})
 
 			It("properly configures redirect data group for ingress", func() {
@@ -2968,7 +2991,7 @@ var _ = Describe("AppManager Tests", func() {
 						[]v1.ServicePort{{Name: "foo-80", Port: 80, NodePort: 37001}})
 					r = mockMgr.addService(fooSvc)
 					Expect(r).To(BeTrue(), "Service should be processed.")
-					Expect(resources.Count()).To(Equal(2))
+					Expect(resources.PoolCount()).To(Equal(2))
 
 					rs, ok := resources.Get(
 						serviceKey{"foo", 80, "default"}, "https-ose-vserver")
@@ -3003,7 +3026,7 @@ var _ = Describe("AppManager Tests", func() {
 						[]v1.ServicePort{{Port: 80, NodePort: 37001}})
 					mockMgr.addService(barSvc)
 					Expect(r).To(BeTrue(), "Service should be processed.")
-					Expect(resources.Count()).To(Equal(4))
+					Expect(resources.PoolCount()).To(Equal(4))
 
 					rs, ok = resources.Get(
 						serviceKey{"bar", 80, "default"}, "https-ose-vserver")
@@ -3019,7 +3042,7 @@ var _ = Describe("AppManager Tests", func() {
 					// Delete a Route resource
 					r = mockMgr.deleteRoute(route2)
 					Expect(r).To(BeTrue(), "Route resource should be processed.")
-					Expect(resources.Count()).To(Equal(2))
+					Expect(resources.PoolCount()).To(Equal(2))
 					rs, ok = resources.Get(
 						serviceKey{"foo", 80, "default"}, "https-ose-vserver")
 					Expect(len(rs.Policies[0].Rules)).To(Equal(1))
@@ -3060,7 +3083,7 @@ var _ = Describe("AppManager Tests", func() {
 						[]v1.ServicePort{{Port: 443, NodePort: 37001}})
 					r = mockMgr.addService(fooSvc)
 					Expect(r).To(BeTrue(), "Service should be processed.")
-					Expect(resources.Count()).To(Equal(2))
+					Expect(resources.PoolCount()).To(Equal(2))
 
 					hostName2 := "barfoo.com"
 					svcName2 := "bar"
@@ -3084,7 +3107,7 @@ var _ = Describe("AppManager Tests", func() {
 						[]v1.ServicePort{{Port: 443, NodePort: 37001}})
 					mockMgr.addService(barSvc)
 					Expect(r).To(BeTrue(), "Service should be processed.")
-					Expect(resources.Count()).To(Equal(4))
+					Expect(resources.PoolCount()).To(Equal(4))
 
 					// Check state.
 					rs, ok := resources.Get(
@@ -3121,7 +3144,7 @@ var _ = Describe("AppManager Tests", func() {
 					// Delete a Route resource and make sure the data groups are cleaned up.
 					r = mockMgr.deleteRoute(route2)
 					Expect(r).To(BeTrue(), "Route resource should be processed.")
-					Expect(resources.Count()).To(Equal(2))
+					Expect(resources.PoolCount()).To(Equal(2))
 					hostDg, found = mockMgr.appMgr.intDgMap[hostDgKey]
 					Expect(found).To(BeTrue())
 					Expect(len(hostDg[namespace].Records)).To(Equal(1))
@@ -3155,7 +3178,7 @@ var _ = Describe("AppManager Tests", func() {
 						[]v1.ServicePort{{Port: 443, NodePort: 37001}})
 					r = mockMgr.addService(fooSvc)
 					Expect(r).To(BeTrue(), "Service should be processed.")
-					Expect(resources.Count()).To(Equal(2))
+					Expect(resources.PoolCount()).To(Equal(2))
 
 					rs, ok := resources.Get(
 						serviceKey{"foo", 443, "default"}, "https-ose-vserver")
@@ -3200,10 +3223,8 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(rs.Virtual.GetProfileCountByContext(customProfileServer)).To(Equal(2))
 				})
 
-				// Note: Once we move to the single config per virtual model, this test
-				// can be removed
 				It("doesn't update stored route configs during processing", func() {
-					spec := routeapi.RouteSpec{
+					spec1 := routeapi.RouteSpec{
 						Host: "foo.com",
 						Path: "/foo",
 						To: routeapi.RouteTargetReference{
@@ -3216,7 +3237,20 @@ var _ = Describe("AppManager Tests", func() {
 							Key:         "key",
 						},
 					}
-					route := test.NewRoute("route", "1", namespace, spec, nil)
+					spec2 := routeapi.RouteSpec{
+						Host: "foo.com",
+						Path: "/bar",
+						To: routeapi.RouteTargetReference{
+							Kind: "Service",
+							Name: "foo",
+						},
+						TLS: &routeapi.TLSConfig{
+							Termination: "edge",
+							Certificate: "cert",
+							Key:         "key",
+						},
+					}
+					route := test.NewRoute("route", "1", namespace, spec1, nil)
 					mockMgr.addRoute(route)
 
 					fooSvc := test.NewService("foo", "1", namespace, "NodePort",
@@ -3233,7 +3267,7 @@ var _ = Describe("AppManager Tests", func() {
 					// Add a new route, our stored config (rs), should not have been
 					// updated locally. It should only update when we get it again.
 					// This confirms that we aren't updating a pointer.
-					route2 := test.NewRoute("route2", "1", namespace, spec, nil)
+					route2 := test.NewRoute("route2", "1", namespace, spec2, nil)
 					mockMgr.addRoute(route2)
 					Expect(len(rs.Policies[0].Rules)).To(Equal(1))
 					rs, _ = resources.Get(
@@ -3398,22 +3432,25 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
 
 				resources := mockMgr.resources()
-				rs, ok := resources.Get(
-					serviceKey{"foo", 80, "default"}, "default_ingress-ingress_http")
-				Expect(ok).To(BeTrue())
+				Expect(resources.PoolCount()).To(Equal(1))
+				var bindAddr string
+				for _, cfg := range resources.GetAllResources() {
+					bindAddr = cfg.Virtual.VirtualAddress.BindAddr
+				}
 				if expAddr {
-					Expect(len(rs.Virtual.VirtualAddress.BindAddr)).To(BeNumerically(">", 0))
+					Expect(len(bindAddr)).To(BeNumerically(">", 0))
 				} else {
-					Expect(len(rs.Virtual.VirtualAddress.BindAddr)).To(Equal(0))
+					Expect(len(bindAddr)).To(Equal(0))
 				}
 				// Verify addition of host name works as expected
 				if update {
 					ingress.Spec.Rules[0].Host = "f5.com"
 					mockMgr.updateIngress(ingress)
-					rs, ok := resources.Get(
-						serviceKey{"foo", 80, "default"}, "default_ingress-ingress_http")
-					Expect(ok).To(BeTrue())
-					Expect(len(rs.Virtual.VirtualAddress.BindAddr)).To(BeNumerically(">", 0))
+					Expect(resources.PoolCount()).To(Equal(1))
+					for _, cfg := range resources.GetAllResources() {
+						bindAddr = cfg.Virtual.VirtualAddress.BindAddr
+					}
+					Expect(len(bindAddr)).To(BeNumerically(">", 0))
 				}
 				mockMgr.deleteIngress(ingress)
 			}
@@ -3793,7 +3830,7 @@ var _ = Describe("AppManager Tests", func() {
 				mockMgr.addService(svcNs1)
 				mockMgr.addService(svcNs2)
 
-				spec := routeapi.RouteSpec{
+				spec1 := routeapi.RouteSpec{
 					Host: "foobar.com",
 					Path: "/foo",
 					Port: &routeapi.RoutePort{
@@ -3809,15 +3846,31 @@ var _ = Describe("AppManager Tests", func() {
 						Key:         "key",
 					},
 				}
+				spec2 := routeapi.RouteSpec{
+					Host: "foobar.com",
+					Path: "/bar",
+					Port: &routeapi.RoutePort{
+						TargetPort: intstr.IntOrString{IntVal: 80},
+					},
+					To: routeapi.RouteTargetReference{
+						Kind: "Service",
+						Name: "foo",
+					},
+					TLS: &routeapi.TLSConfig{
+						Termination: "edge",
+						Certificate: "cert",
+						Key:         "key",
+					},
+				}
 				// Create two routes with same name in different namespaces
-				route := test.NewRoute("route", "1", ns1, spec, nil)
+				route := test.NewRoute("route", "1", ns1, spec1, nil)
 				r := mockMgr.addRoute(route)
 				Expect(r).To(BeTrue(), "Route resource should be processed.")
-				route2 := test.NewRoute("route", "2", ns2, spec, nil)
+				route2 := test.NewRoute("route", "2", ns2, spec2, nil)
 				r = mockMgr.addRoute(route2)
 				Expect(r).To(BeTrue(), "Route resource should be processed.")
 				resources := mockMgr.resources()
-				Expect(resources.Count()).To(Equal(4))
+				Expect(resources.PoolCount()).To(Equal(4))
 
 				rs, ok := resources.Get(
 					serviceKey{"foo", 80, ns1}, "https-ose-vserver")
@@ -3842,7 +3895,7 @@ var _ = Describe("AppManager Tests", func() {
 
 				// Delete a route
 				mockMgr.deleteRoute(route2)
-				Expect(resources.Count()).To(Equal(2))
+				Expect(resources.PoolCount()).To(Equal(2))
 				rs, ok = resources.Get(
 					serviceKey{"foo", 80, ns1}, "https-ose-vserver")
 				Expect(ok).To(BeTrue(), "Route should be accessible.")

--- a/pkg/appmanager/eventNotifier.go
+++ b/pkg/appmanager/eventNotifier.go
@@ -17,11 +17,8 @@
 package appmanager
 
 import (
-	"strings"
 	"sync"
 
-	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"
@@ -119,26 +116,9 @@ func (nen *NamespaceEventNotifier) recordEvent(
 func (appMgr *Manager) recordIngressEvent(
 	ing *v1beta1.Ingress,
 	reason,
-	message,
-	rsName string) {
-	var namespace string
-	if ing != nil {
-		namespace = ing.ObjectMeta.Namespace
-	} else {
-		namespace = strings.Split(rsName, "_")[0]
-		name := rsName[len(namespace)+1 : len(rsName)-len("-ingress")]
-		// If we aren't given an Ingress resource, we use the name to find it
-		var err error
-		if ing == nil {
-			ing, err = appMgr.kubeClient.Extensions().Ingresses(namespace).
-				Get(name, metav1.GetOptions{})
-			if nil != err {
-				log.Warningf("Could not find Ingress resource '%v'.", name)
-				return
-			}
-		}
-	}
-
+	message string,
+) {
+	namespace := ing.ObjectMeta.Namespace
 	// Create the event
 	evNotifier := appMgr.eventNotifier.createNotifierForNamespace(
 		namespace, appMgr.kubeClient.Core())

--- a/pkg/appmanager/eventNotifier_test.go
+++ b/pkg/appmanager/eventNotifier_test.go
@@ -192,8 +192,9 @@ var _ = Describe("Event Notifier Tests", func() {
 			// Make sure the ingress events are in the correct namespace.
 			for _, ns := range namespaces {
 				events := mockMgr.getFakeEvents(ns)
-				// This use case currently only creates 1 event.
-				Expect(len(events)).To(Equal(1))
+				// This use case currently creates 2 events
+				// (ResourceConfigured and ServiceNotFound)
+				Expect(len(events)).To(Equal(2))
 				for _, event := range events {
 					// Regardless of length test, make sure all events match ns.
 					Expect(event.Namespace).To(Equal(ns))

--- a/pkg/appmanager/healthMonitors.go
+++ b/pkg/appmanager/healthMonitors.go
@@ -51,7 +51,7 @@ func (appMgr *Manager) assignHealthMonitorsByPath(
 			msg := fmt.Sprintf("Rule not found for Health Monitor host '%v'", host)
 			log.Warningf("%s", msg)
 			if ing != nil {
-				appMgr.recordIngressEvent(ing, "MonitorRuleNotFound", msg, rsName)
+				appMgr.recordIngressEvent(ing, "MonitorRuleNotFound", msg)
 			}
 			continue
 		}
@@ -61,7 +61,7 @@ func (appMgr *Manager) assignHealthMonitorsByPath(
 				mon.Path)
 			log.Warningf("%s", msg)
 			if ing != nil {
-				appMgr.recordIngressEvent(ing, "MonitorRuleNotFound", msg, rsName)
+				appMgr.recordIngressEvent(ing, "MonitorRuleNotFound", msg)
 			}
 			continue
 		}
@@ -110,7 +110,7 @@ func (appMgr *Manager) notifyUnusedHealthMonitorRules(
 				msg := fmt.Sprintf(
 					"Health Monitor path '%v' does not match any Ingress paths.",
 					ruleData.healthMon.Path)
-				appMgr.recordIngressEvent(ing, "MonitorRuleNotUsed", msg, rsName)
+				appMgr.recordIngressEvent(ing, "MonitorRuleNotUsed", msg)
 			}
 		}
 	}
@@ -135,7 +135,10 @@ func (appMgr *Manager) handleSingleServiceHealthMonitors(
 		rsName, ing, htpMap, monitors)
 	if nil != err {
 		log.Errorf("%s", err.Error())
-		appMgr.recordIngressEvent(ing, "MonitorError", err.Error(), rsName)
+		appMgr.recordIngressEvent(ing, "MonitorError", err.Error())
+		mon := cfg.Virtual.PoolName + "_0_http"
+		_, pool := splitBigipPath(cfg.Virtual.PoolName, false)
+		cfg.RemoveMonitor(pool, mon)
 		return
 	}
 
@@ -182,7 +185,7 @@ func (appMgr *Manager) handleMultiServiceHealthMonitors(
 					"Health Monitor path '%v' already exists for host '%v'",
 					path, rule.Host)
 				log.Warningf("%s", msg)
-				appMgr.recordIngressEvent(ing, "DuplicatePath", msg, rsName)
+				appMgr.recordIngressEvent(ing, "DuplicatePath", msg)
 			} else {
 				pathItem = &ruleData{
 					svcName: path.Backend.ServiceName,
@@ -201,7 +204,7 @@ func (appMgr *Manager) handleMultiServiceHealthMonitors(
 				"Health Monitor rule for host '%v' conflicts with rule for all hosts.",
 				key)
 			log.Warningf("%s", msg)
-			appMgr.recordIngressEvent(ing, "DuplicatePath", msg, rsName)
+			appMgr.recordIngressEvent(ing, "DuplicatePath", msg)
 		}
 	}
 
@@ -209,7 +212,7 @@ func (appMgr *Manager) handleMultiServiceHealthMonitors(
 		rsName, ing, htpMap, monitors)
 	if nil != err {
 		log.Errorf("%s", err.Error())
-		appMgr.recordIngressEvent(ing, "MonitorError", err.Error(), rsName)
+		appMgr.recordIngressEvent(ing, "MonitorError", err.Error())
 		return
 	}
 

--- a/pkg/appmanager/healthMonitors_test.go
+++ b/pkg/appmanager/healthMonitors_test.go
@@ -175,13 +175,13 @@ var _ = Describe("Health Monitor Tests", func() {
 					f5VsPartitionAnnotation: "velcro",
 					f5VsHttpPortAnnotation:  "443",
 					healthMonitorAnnotation: `[
-					{
-						"path":     "svc1/",
-						"send":     "HTTP GET /test1",
-						"interval": 5,
+						{
+							"path":     "svc1/",
+							"send":     "HTTP GET /test1",
+							"interval": 5,
 							"timeout":  10
-					}
-				]`,
+						}
+					]`,
 				})
 			emptyIps := []string{}
 			svcKey := serviceKey{
@@ -205,11 +205,11 @@ var _ = Describe("Health Monitor Tests", func() {
 			r = mockMgr.addEndpoints(endpts)
 			Expect(r).To(BeTrue(), "Endpoints should be processed.")
 			resources := mockMgr.resources()
-			Expect(resources.Count()).To(Equal(1))
+			Expect(resources.PoolCount()).To(Equal(1))
 
 			// The first test uses an explicit server name
 			Expect(resources.CountOf(svcKey)).To(Equal(1))
-			vsCfgFoo, found := resources.Get(svcKey, formatIngressVSName(ing, "http"))
+			vsCfgFoo, found := resources.Get(svcKey, formatIngressVSName("1.2.3.4", 443))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgFoo).ToNot(BeNil())
 			checkSingleServiceHealthMonitor(vsCfgFoo, svcName, svcPort, true)
@@ -225,7 +225,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			r = mockMgr.updateIngress(ing)
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
 			Expect(resources.CountOf(svcKey)).To(Equal(1))
-			vsCfgFoo, found = resources.Get(svcKey, formatIngressVSName(ing, "http"))
+			vsCfgFoo, found = resources.Get(svcKey, formatIngressVSName("1.2.3.4", 443))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgFoo).ToNot(BeNil())
 			checkSingleServiceHealthMonitor(vsCfgFoo, svcName, svcPort, true)
@@ -241,7 +241,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			r = mockMgr.updateIngress(ing)
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
 			Expect(resources.CountOf(svcKey)).To(Equal(1))
-			vsCfgFoo, found = resources.Get(svcKey, formatIngressVSName(ing, "http"))
+			vsCfgFoo, found = resources.Get(svcKey, formatIngressVSName("1.2.3.4", 443))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgFoo).ToNot(BeNil())
 			checkSingleServiceHealthMonitor(vsCfgFoo, svcName, svcPort, true)
@@ -256,7 +256,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			r = mockMgr.updateIngress(ing)
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
 			Expect(resources.CountOf(svcKey)).To(Equal(1))
-			vsCfgFoo, found = resources.Get(svcKey, formatIngressVSName(ing, "http"))
+			vsCfgFoo, found = resources.Get(svcKey, formatIngressVSName("1.2.3.4", 443))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgFoo).ToNot(BeNil())
 			checkSingleServiceHealthMonitor(vsCfgFoo, svcName, svcPort, false)
@@ -422,7 +422,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			r = mockMgr.addEndpoints(endpts1)
 			Expect(r).To(BeTrue(), "Endpoints should be processed.")
 			resources := mockMgr.resources()
-			Expect(resources.Count()).To(Equal(1))
+			Expect(resources.PoolCount()).To(Equal(1))
 
 			svc1Key := serviceKey{
 				Namespace:   namespace,
@@ -430,7 +430,7 @@ var _ = Describe("Health Monitor Tests", func() {
 				ServicePort: int32(svc1Port),
 			}
 			Expect(resources.CountOf(svc1Key)).To(Equal(1))
-			vsCfgFoo, found := resources.Get(svc1Key, formatIngressVSName(ing, "http"))
+			vsCfgFoo, found := resources.Get(svc1Key, formatIngressVSName("1.2.3.4", 443))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgFoo).ToNot(BeNil())
 
@@ -445,7 +445,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			Expect(r).To(BeTrue(), "Service should be processed.")
 			r = mockMgr.addEndpoints(endpts2)
 			Expect(r).To(BeTrue(), "Endpoints should be processed.")
-			Expect(resources.Count()).To(Equal(2))
+			Expect(resources.PoolCount()).To(Equal(2))
 
 			svc2Key := serviceKey{
 				Namespace:   namespace,
@@ -453,7 +453,7 @@ var _ = Describe("Health Monitor Tests", func() {
 				ServicePort: int32(svc2Port),
 			}
 			Expect(resources.CountOf(svc2Key)).To(Equal(1))
-			vsCfgBar, found := resources.Get(svc2Key, formatIngressVSName(ing, "http"))
+			vsCfgBar, found := resources.Get(svc2Key, formatIngressVSName("1.2.3.4", 443))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgBar).ToNot(BeNil())
 
@@ -468,7 +468,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			Expect(r).To(BeTrue(), "Service should be processed.")
 			r = mockMgr.addEndpoints(endpts3)
 			Expect(r).To(BeTrue(), "Endpoints should be processed.")
-			Expect(resources.Count()).To(Equal(3))
+			Expect(resources.PoolCount()).To(Equal(3))
 
 			svc3Key := serviceKey{
 				Namespace:   namespace,
@@ -476,7 +476,7 @@ var _ = Describe("Health Monitor Tests", func() {
 				ServicePort: int32(svc3Port),
 			}
 			Expect(resources.CountOf(svc3Key)).To(Equal(1))
-			vsCfgBaz, found := resources.Get(svc3Key, formatIngressVSName(ing, "http"))
+			vsCfgBaz, found := resources.Get(svc3Key, formatIngressVSName("1.2.3.4", 443))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgBaz).ToNot(BeNil())
 
@@ -601,7 +601,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
 
 			resources := mockMgr.resources()
-			Expect(resources.Count()).To(Equal(3))
+			Expect(resources.PoolCount()).To(Equal(3))
 
 			svc1aKey := serviceKey{
 				Namespace:   namespace,
@@ -609,7 +609,7 @@ var _ = Describe("Health Monitor Tests", func() {
 				ServicePort: int32(svc1aPort),
 			}
 			Expect(resources.CountOf(svc1aKey)).To(Equal(1))
-			vsCfgFoo, found := resources.Get(svc1aKey, formatIngressVSName(ing, "http"))
+			vsCfgFoo, found := resources.Get(svc1aKey, formatIngressVSName("172.16.3.2", 80))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgFoo).ToNot(BeNil())
 
@@ -619,7 +619,7 @@ var _ = Describe("Health Monitor Tests", func() {
 				ServicePort: int32(svc1bPort),
 			}
 			Expect(resources.CountOf(svc1bKey)).To(Equal(1))
-			vsCfgBar, found := resources.Get(svc1bKey, formatIngressVSName(ing, "http"))
+			vsCfgBar, found := resources.Get(svc1bKey, formatIngressVSName("172.16.3.2", 80))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgBar).ToNot(BeNil())
 
@@ -629,7 +629,7 @@ var _ = Describe("Health Monitor Tests", func() {
 				ServicePort: int32(svc2Port),
 			}
 			Expect(resources.CountOf(svc2Key)).To(Equal(1))
-			vsCfgBaz, found := resources.Get(svc2Key, formatIngressVSName(ing, "http"))
+			vsCfgBaz, found := resources.Get(svc2Key, formatIngressVSName("172.16.3.2", 80))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgBaz).ToNot(BeNil())
 
@@ -721,7 +721,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			r = mockMgr.addEndpoints(endpts1a)
 			Expect(r).To(BeTrue(), "Endpoints should be processed.")
 			resources := mockMgr.resources()
-			Expect(resources.Count()).To(Equal(1))
+			Expect(resources.PoolCount()).To(Equal(1))
 
 			svc1aKey := serviceKey{
 				Namespace:   namespace,
@@ -729,7 +729,7 @@ var _ = Describe("Health Monitor Tests", func() {
 				ServicePort: int32(svc1aPort),
 			}
 			Expect(resources.CountOf(svc1aKey)).To(Equal(1))
-			vsCfgFoo, found := resources.Get(svc1aKey, formatIngressVSName(ing, "http"))
+			vsCfgFoo, found := resources.Get(svc1aKey, formatIngressVSName("1.2.3.4", 443))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgFoo).ToNot(BeNil())
 
@@ -744,7 +744,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			Expect(r).To(BeTrue(), "Service should be processed.")
 			r = mockMgr.addEndpoints(endpts1b)
 			Expect(r).To(BeTrue(), "Endpoints should be processed.")
-			Expect(resources.Count()).To(Equal(2))
+			Expect(resources.PoolCount()).To(Equal(2))
 
 			svc1bKey := serviceKey{
 				Namespace:   namespace,
@@ -752,7 +752,7 @@ var _ = Describe("Health Monitor Tests", func() {
 				ServicePort: int32(svc1bPort),
 			}
 			Expect(resources.CountOf(svc1bKey)).To(Equal(1))
-			vsCfgBar, found := resources.Get(svc1bKey, formatIngressVSName(ing, "http"))
+			vsCfgBar, found := resources.Get(svc1bKey, formatIngressVSName("1.2.3.4", 443))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgBar).ToNot(BeNil())
 
@@ -767,7 +767,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			Expect(r).To(BeTrue(), "Service should be processed.")
 			r = mockMgr.addEndpoints(endpts2)
 			Expect(r).To(BeTrue(), "Endpoints should be processed.")
-			Expect(resources.Count()).To(Equal(3))
+			Expect(resources.PoolCount()).To(Equal(3))
 
 			svc2Key := serviceKey{
 				Namespace:   namespace,
@@ -775,7 +775,7 @@ var _ = Describe("Health Monitor Tests", func() {
 				ServicePort: int32(svc2Port),
 			}
 			Expect(resources.CountOf(svc2Key)).To(Equal(1))
-			vsCfgBaz, found := resources.Get(svc2Key, formatIngressVSName(ing, "http"))
+			vsCfgBaz, found := resources.Get(svc2Key, formatIngressVSName("1.2.3.4", 443))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgBaz).ToNot(BeNil())
 
@@ -867,7 +867,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			r = mockMgr.addEndpoints(endpts1)
 			Expect(r).To(BeTrue(), "Endpoints should be processed.")
 			resources := mockMgr.resources()
-			Expect(resources.Count()).To(Equal(1))
+			Expect(resources.PoolCount()).To(Equal(1))
 
 			svc1Key := serviceKey{
 				Namespace:   namespace,
@@ -875,7 +875,7 @@ var _ = Describe("Health Monitor Tests", func() {
 				ServicePort: int32(svc1Port),
 			}
 			Expect(resources.CountOf(svc1Key)).To(Equal(1))
-			vsCfgFoo, found := resources.Get(svc1Key, formatIngressVSName(ing, "http"))
+			vsCfgFoo, found := resources.Get(svc1Key, formatIngressVSName("1.2.3.4", 443))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgFoo).ToNot(BeNil())
 
@@ -890,7 +890,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			Expect(r).To(BeTrue(), "Service should be processed.")
 			r = mockMgr.addEndpoints(endpts2)
 			Expect(r).To(BeTrue(), "Endpoints should be processed.")
-			Expect(resources.Count()).To(Equal(2))
+			Expect(resources.PoolCount()).To(Equal(2))
 
 			svc2Key := serviceKey{
 				Namespace:   namespace,
@@ -898,7 +898,7 @@ var _ = Describe("Health Monitor Tests", func() {
 				ServicePort: int32(svc2Port),
 			}
 			Expect(resources.CountOf(svc2Key)).To(Equal(1))
-			vsCfgBar, found := resources.Get(svc2Key, formatIngressVSName(ing, "http"))
+			vsCfgBar, found := resources.Get(svc2Key, formatIngressVSName("1.2.3.4", 443))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgBar).ToNot(BeNil())
 
@@ -913,7 +913,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			Expect(r).To(BeTrue(), "Service should be processed.")
 			r = mockMgr.addEndpoints(endpts3)
 			Expect(r).To(BeTrue(), "Endpoints should be processed.")
-			Expect(resources.Count()).To(Equal(3))
+			Expect(resources.PoolCount()).To(Equal(3))
 
 			svc3Key := serviceKey{
 				Namespace:   namespace,
@@ -921,7 +921,7 @@ var _ = Describe("Health Monitor Tests", func() {
 				ServicePort: int32(svc3Port),
 			}
 			Expect(resources.CountOf(svc3Key)).To(Equal(1))
-			vsCfgBaz, found := resources.Get(svc3Key, formatIngressVSName(ing, "http"))
+			vsCfgBaz, found := resources.Get(svc3Key, formatIngressVSName("1.2.3.4", 443))
 			Expect(found).To(BeTrue())
 			Expect(vsCfgBaz).ToNot(BeNil())
 
@@ -986,7 +986,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			r = mockMgr.addService(fooSvc)
 			Expect(r).To(BeTrue(), "Service should be processed.")
 			resources := mockMgr.resources()
-			Expect(resources.Count()).To(Equal(2))
+			Expect(resources.PoolCount()).To(Equal(2))
 
 			// The first test uses an explicit server name
 			vsCfgFoo, found := resources.Get(svcKey, "https-ose-vserver")

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -242,9 +242,14 @@ var _ = Describe("Resource Config Tests", func() {
 			}
 		})
 
-		It("can count all resources", func() {
-			// Test Count() to make sure we count all items
-			Expect(rs.Count()).To(Equal(nbrBackends * nbrCfgsPer))
+		It("can count all pool resources", func() {
+			// Test PoolCount() to make sure we count all items
+			Expect(rs.PoolCount()).To(Equal(nbrBackends * nbrCfgsPer))
+		})
+
+		It("can count all virtual resources", func() {
+			// Test VirtualCount() to make sure we count all items
+			Expect(rs.VirtualCount()).To(Equal(nbrBackends * nbrCfgsPer))
 		})
 
 		It("can count configs per backend", func() {
@@ -444,7 +449,7 @@ var _ = Describe("Resource Config Tests", func() {
 				protocol: "http",
 				port:     80,
 			}
-			cfg := createRSConfigFromIngress(ingress, namespace, nil, ps)
+			cfg := createRSConfigFromIngress(ingress, &Resources{}, namespace, nil, ps)
 			Expect(cfg.Pools[0].Balance).To(Equal("round-robin"))
 			Expect(cfg.Virtual.Partition).To(Equal("velcro"))
 			Expect(cfg.Virtual.VirtualAddress.BindAddr).To(Equal("1.2.3.4"))
@@ -462,7 +467,7 @@ var _ = Describe("Resource Config Tests", func() {
 				protocol: "http",
 				port:     100,
 			}
-			cfg = createRSConfigFromIngress(ingress, namespace, nil, ps)
+			cfg = createRSConfigFromIngress(ingress, &Resources{}, namespace, nil, ps)
 			Expect(cfg.Pools[0].Balance).To(Equal("foobar"))
 			Expect(cfg.Virtual.VirtualAddress.Port).To(Equal(int32(100)))
 
@@ -470,7 +475,7 @@ var _ = Describe("Resource Config Tests", func() {
 				map[string]string{
 					k8sIngressClass: "notf5",
 				})
-			cfg = createRSConfigFromIngress(ingress, namespace, nil, ps)
+			cfg = createRSConfigFromIngress(ingress, &Resources{}, namespace, nil, ps)
 			Expect(cfg).To(BeNil())
 		})
 

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -64,7 +64,7 @@ func (r Rules) Swap(i, j int)      { r[i], r[j] = r[j], r[i] }
 
 type Routes []*routeapi.Route
 
-func createRule(uri, poolName, partition, routeName string) (*Rule, error) {
+func createRule(uri, poolName, partition, ruleName string) (*Rule, error) {
 	_u := "scheme://" + uri
 	_u = strings.TrimSuffix(_u, "/")
 	u, err := url.Parse(_u)
@@ -123,7 +123,7 @@ func createRule(uri, poolName, partition, routeName string) (*Rule, error) {
 	}
 
 	rl := Rule{
-		Name:       routeName,
+		Name:       ruleName,
 		FullURI:    uri,
 		Actions:    []*action{&a},
 		Conditions: c,
@@ -172,8 +172,9 @@ func processIngressRules(
 				if poolName == "" {
 					continue
 				}
+				ruleName := formatIngressRuleName(rule.Host, path.Path, poolName)
 				// This blank name gets overridden by an ordinal later on
-				rl, err = createRule(uri, poolName, partition, "")
+				rl, err = createRule(uri, poolName, partition, ruleName)
 				if nil != err {
 					log.Warningf("Error configuring rule: %v", err)
 					return nil
@@ -196,7 +197,6 @@ func processIngressRules(
 		sort.Sort(sort.Reverse(*rls))
 		for _, v := range *rls {
 			v.Ordinal = ordinal
-			v.Name = strconv.Itoa(ordinal)
 			ordinal++
 		}
 		wg.Done()


### PR DESCRIPTION
Add support for Ingresses with the same IP:Port specification to share virtual servers.

1. Pools for Ingresses have been renamed to exclude the name of the Ingress resource, that way multiple Ingresses using the same backend don't create new pools; the pools are shared.
2. Virtual server names are of the format "ingress_ip_port".
3. If Ingresses have different IP addresses then they will create separate virtual servers.

Closes #325