### PR TITLE
Create Default for SNI profile for Ingress

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -922,7 +922,7 @@ func (appMgr *Manager) syncConfigMaps(
 						profileName)
 					continue
 				}
-				err, updated := appMgr.handleSslProfile(rsCfg, secret)
+				err, updated := appMgr.createSecretSslProfile(rsCfg, secret)
 				if err != nil {
 					log.Warningf("%v", err)
 					continue
@@ -1236,7 +1236,7 @@ func (appMgr *Manager) handleIngressTls(
 					rsCfg.Virtual.AddOrUpdateProfile(profRef)
 					continue
 				}
-				err, cpUpdated = appMgr.handleSslProfile(rsCfg, secret)
+				err, cpUpdated = appMgr.createSecretSslProfile(rsCfg, secret)
 				if err != nil {
 					log.Warningf("%v", err)
 					continue

--- a/pkg/appmanager/profiles_test.go
+++ b/pkg/appmanager/profiles_test.go
@@ -247,7 +247,7 @@ var _ = Describe("AppManager Profile Tests", func() {
 			mockMgr.addService(fooSvc)
 
 			customProfiles := mockMgr.customProfiles()
-			Expect(len(customProfiles)).To(Equal(1))
+			Expect(len(customProfiles)).To(Equal(2))
 
 			// Test for ConfigMap
 			var configmapSecret string = string(`{
@@ -274,10 +274,10 @@ var _ = Describe("AppManager Profile Tests", func() {
 			// This should NOT create a custom profile - it just references a
 			// pre-configured one.
 			mockMgr.addConfigMap(secretCfg)
-			Expect(len(customProfiles)).To(Equal(1))
+			Expect(len(customProfiles)).To(Equal(2))
 			// This should not affect any custom profiles.
 			mockMgr.deleteConfigMap(secretCfg)
-			Expect(len(customProfiles)).To(Equal(1))
+			Expect(len(customProfiles)).To(Equal(2))
 
 			// This should remove the custom profile.
 			mockMgr.deleteIngress(ingress)


### PR DESCRIPTION
Problem: When an Ingress had multiple Secret tls names provided, the controller
would configure these profiles on the BIG-IP without setting a default for SNI. This
would cause only one of the profiles to be linked to the virtual.

Solution: Similar to the way Route profiles are configured, if an Ingress specifies any
custom profiles, the controller will create a basic default clientssl profile for the virtual
server that will be set as default for SNI. Any Ingress profiles will then be created for the
virtual as additional profiles.

Fixes #344 