### PR TITLE
Default IP for Ingress

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -88,6 +88,7 @@ var (
 	manageRoutes      *bool
 	nodeLabelSelector *string
 	resolveIngNames   *string
+	defaultIngIP      *string
 	useSecrets        *bool
 
 	bigIPURL        *string
@@ -187,6 +188,9 @@ func _init() {
 		"Optional, direct the controller to resolve host names in Ingresses into IP addresses. "+
 			"The 'LOOKUP' option will use the controller's built-in DNS. "+
 			"Any other string will be used as a custom DNS server, either by name or IP address.")
+	defaultIngIP = kubeFlags.String("default-ingress-ip", "",
+		"Optional, the controller will configure a virtual server with this IP address for "+
+			"any Ingress with the annotation 'virtual-server.f5.com/ip:controller-default'.")
 	useSecrets = kubeFlags.Bool("use-secrets", true,
 		"Optional, enable/disable use of Secrets for Ingress or ConfigMap SSL Profiles.")
 
@@ -499,6 +503,7 @@ func main() {
 		RouteConfig:       routeConfig,
 		NodeLabelSelector: *nodeLabelSelector,
 		ResolveIngress:    *resolveIngNames,
+		DefaultIngIP:      *defaultIngIP,
 		UseSecrets:        *useSecrets,
 	}
 

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -120,6 +120,12 @@ Kubernetes
 +-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
 | Parameter             | Type    | Required | Default           | Description                             | Allowed Values |
 +=======================+=========+==========+===================+=========================================+================+
+| default-ingress-ip    | string  | Optional | n/a               | The controller configures a virtual     |                |
+|                       |         |          |                   | server at this IP address for all       |                |
+|                       |         |          |                   | Ingresses with the annotation:          |                |
+|                       |         |          |                   | ``virtual-server.f5.com/ip:             |                |
+|                       |         |          |                   | 'controller-default'``                  |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
 | kubeconfig            | string  | Optional | ./config          | Path to the *kubeconfig* file           |                |
 +-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
 | namespace             | string  | Optional | All               | Kubernetes namespace(s) to watch        |                |
@@ -502,7 +508,9 @@ Supported annotations
 +------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
 | Annotation                         | Type        | Required  | Description                                                                         | Default     |
 +====================================+=============+===========+=====================================================================================+=============+
-| virtual-server.f5.com/ip           | string      | Required  | The IP address you want to assign to the virtual server.                            | N/A         |
+| virtual-server.f5.com/ip           | string      | Required  | The IP address you want to assign to the virtual server. Can also set the           | N/A         |
+|                                    |             |           | annotation value as "controller-default" to use the ``default-ingress-ip``          |             |
+|                                    |             |           | specified in the Configuration Parameters above.                                    |             |
 +------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+
 | virtual-server.f5.com/partition    | string      | Optional  | The BIG-IP partition in which the Controller should create/update/delete            | N/A         |
 |                                    |             |           | objects for this Ingress.                                                           |             |

--- a/pkg/appmanager/healthMonitors.go
+++ b/pkg/appmanager/healthMonitors.go
@@ -117,7 +117,8 @@ func (appMgr *Manager) notifyUnusedHealthMonitorRules(
 }
 
 func (appMgr *Manager) handleSingleServiceHealthMonitors(
-	rsName string,
+	rsName,
+	poolName string,
 	cfg *ResourceConfig,
 	ing *v1beta1.Ingress,
 	monitors AnnotationHealthMonitors,
@@ -136,8 +137,8 @@ func (appMgr *Manager) handleSingleServiceHealthMonitors(
 	if nil != err {
 		log.Errorf("%s", err.Error())
 		appMgr.recordIngressEvent(ing, "MonitorError", err.Error())
-		mon := cfg.Virtual.PoolName + "_0_http"
-		_, pool := splitBigipPath(cfg.Virtual.PoolName, false)
+		mon := poolName + "_0_http"
+		_, pool := splitBigipPath(poolName, false)
 		cfg.RemoveMonitor(pool, mon)
 		return
 	}
@@ -146,7 +147,7 @@ func (appMgr *Manager) handleSingleServiceHealthMonitors(
 	defer appMgr.resources.Unlock()
 	for _, paths := range htpMap {
 		for _, ruleData := range paths {
-			appMgr.assignMonitorToPool(cfg, cfg.Virtual.PoolName, ruleData)
+			appMgr.assignMonitorToPool(cfg, poolName, ruleData)
 		}
 	}
 

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -449,7 +449,7 @@ var _ = Describe("Resource Config Tests", func() {
 				protocol: "http",
 				port:     80,
 			}
-			cfg := createRSConfigFromIngress(ingress, &Resources{}, namespace, nil, ps)
+			cfg := createRSConfigFromIngress(ingress, &Resources{}, namespace, nil, ps, "")
 			Expect(cfg.Pools[0].Balance).To(Equal("round-robin"))
 			Expect(cfg.Virtual.Partition).To(Equal("velcro"))
 			Expect(cfg.Virtual.VirtualAddress.BindAddr).To(Equal("1.2.3.4"))
@@ -467,7 +467,7 @@ var _ = Describe("Resource Config Tests", func() {
 				protocol: "http",
 				port:     100,
 			}
-			cfg = createRSConfigFromIngress(ingress, &Resources{}, namespace, nil, ps)
+			cfg = createRSConfigFromIngress(ingress, &Resources{}, namespace, nil, ps, "")
 			Expect(cfg.Pools[0].Balance).To(Equal("foobar"))
 			Expect(cfg.Virtual.VirtualAddress.Port).To(Equal(int32(100)))
 
@@ -475,8 +475,17 @@ var _ = Describe("Resource Config Tests", func() {
 				map[string]string{
 					k8sIngressClass: "notf5",
 				})
-			cfg = createRSConfigFromIngress(ingress, &Resources{}, namespace, nil, ps)
+			cfg = createRSConfigFromIngress(ingress, &Resources{}, namespace, nil, ps, "")
 			Expect(cfg).To(BeNil())
+
+			// Use controller default IP
+			defaultIng := test.NewIngress("ingress", "1", namespace, ingressConfig,
+				map[string]string{
+					f5VsBindAddrAnnotation:  "controller-default",
+					f5VsPartitionAnnotation: "velcro",
+				})
+			cfg = createRSConfigFromIngress(defaultIng, &Resources{}, namespace, nil, ps, "5.6.7.8")
+			Expect(cfg.Virtual.VirtualAddress.BindAddr).To(Equal("5.6.7.8"))
 		})
 
 		It("properly configures route resources", func() {

--- a/pkg/appmanager/validateResources.go
+++ b/pkg/appmanager/validateResources.go
@@ -109,8 +109,14 @@ func (appMgr *Manager) checkValidIngress(
 	var keyList []*serviceQueueKey
 	// Depending on the Ingress, we may loop twice here, once for http and once for https
 	for _, portStruct := range appMgr.virtualPorts(ing) {
-		rsCfg := createRSConfigFromIngress(ing, appMgr.resources,
-			namespace, appInf.svcInformer.GetIndexer(), portStruct)
+		rsCfg := createRSConfigFromIngress(
+			ing,
+			appMgr.resources,
+			namespace,
+			appInf.svcInformer.GetIndexer(),
+			portStruct,
+			appMgr.defaultIngIP,
+		)
 		rsName := formatIngressVSName(bindAddr, portStruct.port)
 		// If rsCfg is nil, delete any resources tied to this Ingress
 		if rsCfg == nil {


### PR DESCRIPTION
Problem: Customers don't want to specify IP addresses in their Ingress configs, since Ingresses live close to the applications (not the networking configuration).

Solution: The controller now supports a "default-ingress-ip" configuration parameter that will be used as the IP address for all Ingresses with the annotation "virtual-server.f5.com/ip:controller-default". Ingresses without this annotation will be configured with their own specified IP.

Fixed an issue regarding health monitors on shared single service ingresses not being configured properly. Also updated ingress vs names to include a route domain with a "." delimiter instead of "-". Finally, fixed an issue where new policies were not being set properly on existing configs.