### PR TITLE
ProcessNodeUpdate assumes ConfigMap

### DIFF
--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -45,7 +45,6 @@ type (
 
 	metaData struct {
 		Active       bool
-		NodePort     int32
 		ResourceType string
 		// Only used for Routes (for keeping track of annotated profiles)
 		RouteProfs map[routeKey]string


### PR DESCRIPTION
Problem:
The way node updates were being handled causes problems for
multi-service Ingress resources.

Solution:
Changed ProcessNodeUpdate to simply populate the virtual server work
queue when nodes change instead of having another code path that
updates configs (and incorrectly in the case of multi-service Ingress).
This allowed for the removal of the NodePort member in the meta-data
stored in resource configs. This change required some changes to
existing unit tests as follows:
1. Removed validateConfig() calls from the "should process node
   updates" test as ProcessNodeUpdate() no longer writes out configs and
   appropriate validations already exist in the test.
2. Updated one of the event count validations in the "configures
   virtual servers via Ingress" test as the test was seeing an additional
   event being sent when the NodePort member in MetaData was updated for
   the old ProcessNodeUpdate() functionality (this was a duplicate
   event message and was wrong anyways).
3. The processNodeUpdate for mockAppManager is now aware that
   ProcessNodeUpdate() is updating the work queue so it will now
   process the work queue before it returns so the resource config is
   updated appropriately.

Fixes #460

affects-branches: master