### PR TITLE
WIP - Added pools for alternate backends in route definition

### DIFF
--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -3107,8 +3107,8 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(len(hostDg[namespace].Records)).To(Equal(2))
 					Expect(hostDg[namespace].Records[1].Name).To(Equal(hostName1))
 					Expect(hostDg[namespace].Records[0].Name).To(Equal(hostName2))
-					Expect(hostDg[namespace].Records[1].Data).To(Equal(formatRoutePoolName(route1)))
-					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(route2)))
+					Expect(hostDg[namespace].Records[1].Data).To(Equal(formatRoutePoolName(route1.ObjectMeta.Namespace, route1.Spec.To.Name)))
+					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(route2.ObjectMeta.Namespace, route2.Spec.To.Name)))
 
 					rs, ok = resources.Get(
 						serviceKey{svcName2, 443, namespace}, "ose-vserver")
@@ -3126,7 +3126,7 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(found).To(BeTrue())
 					Expect(len(hostDg[namespace].Records)).To(Equal(1))
 					Expect(hostDg[namespace].Records[0].Name).To(Equal(hostName1))
-					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(route1)))
+					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(route1.ObjectMeta.Namespace, route1.Spec.To.Name)))
 				})
 
 				It("configures reencrypt routes", func() {
@@ -3175,7 +3175,7 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(found).To(BeTrue())
 					Expect(len(hostDg[namespace].Records)).To(Equal(1))
 					Expect(hostDg[namespace].Records[0].Name).To(Equal(hostName))
-					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(route)))
+					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(route.ObjectMeta.Namespace, route.Spec.To.Name)))
 
 					customProfiles := mockMgr.customProfiles()
 					// Should be 2 profiles from Spec, 2 defaults (clientssl and serverssl)

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -502,7 +502,7 @@ var _ = Describe("Resource Config Tests", func() {
 				HttpsVs: "https-ose-vserver",
 			}
 			svcFwdRulesMap := NewServiceFwdRuleMap()
-			cfg, _, _ := createRSConfigFromRoute(route, Resources{}, rc, ps, nil,
+			cfg, _, _ := createRSConfigFromRoute(route, route.Spec.To.Name, Resources{}, rc, ps, nil,
 				svcFwdRulesMap)
 			Expect(cfg.Virtual.Name).To(Equal("https-ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_foo"))
@@ -527,7 +527,7 @@ var _ = Describe("Resource Config Tests", func() {
 				protocol: "http",
 				port:     80,
 			}
-			cfg, _, _ = createRSConfigFromRoute(route2, Resources{}, rc, ps, nil,
+			cfg, _, _ = createRSConfigFromRoute(route2, route2.Spec.To.Name, Resources{}, rc, ps, nil,
 				svcFwdRulesMap)
 			Expect(cfg.Virtual.Name).To(Equal("ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_bar"))

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -389,12 +389,13 @@ func (appMgr *Manager) updatePassthroughRouteDataGroups(
 // Update a data group map based on a passthrough route object.
 func updateDataGroupForPassthroughRoute(
 	route *routeapi.Route,
+	svcName string,
 	partition string,
 	namespace string,
 	dgMap InternalDataGroupMap,
 ) {
 	hostName := route.Spec.Host
-	poolName := formatRoutePoolName(route)
+	poolName := formatRoutePoolName(route.ObjectMeta.Namespace, svcName)
 	updateDataGroup(dgMap, passthroughHostsDgName,
 		partition, namespace, hostName, poolName)
 }
@@ -402,12 +403,13 @@ func updateDataGroupForPassthroughRoute(
 // Update a data group map based on a reencrypt route object.
 func updateDataGroupForReencryptRoute(
 	route *routeapi.Route,
+	svcName string,
 	partition string,
 	namespace string,
 	dgMap InternalDataGroupMap,
 ) {
 	hostName := route.Spec.Host
-	poolName := formatRoutePoolName(route)
+	poolName := formatRoutePoolName(route.ObjectMeta.Namespace, svcName)
 	updateDataGroup(dgMap, reencryptHostsDgName,
 		partition, namespace, hostName, poolName)
 }


### PR DESCRIPTION
Problem:  A/B deployments are possible in openshift by using the
          AlternateBackends field that specifies additional services
          and weights.  The k8s controller currently ignores the
          field

Solution: Phase 1 - Create additional pools for each service listed
          in the AlternateBackends field.

Note:  A follow on commit will be required to add an irule that
       allows the use of the additional services for the route.