### PR TITLE
Process multiple services per route definition

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ check-gopath:
 
 pre-build:
 	git status
-	git describe --all --long
+	git describe --all --long --always
 
 prod-build: pre-build
 	@echo "Building with minimal instrumentation..."

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -601,8 +601,10 @@ func (appMgr *Manager) enqueueIngress(obj interface{}) {
 }
 
 func (appMgr *Manager) enqueueRoute(obj interface{}) {
-	if ok, key := appMgr.checkValidRoute(obj); ok {
-		appMgr.vsQueue.Add(*key)
+	if ok, keys := appMgr.checkValidRoute(obj); ok {
+		for _, key := range keys {
+			appMgr.vsQueue.Add(*key)
+		}
 	}
 }
 

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -576,41 +576,46 @@ func (m *mockAppManager) deleteIngress(ing *v1beta1.Ingress) bool {
 }
 
 func (m *mockAppManager) addRoute(route *routeapi.Route) bool {
-	ok, vsKey := m.appMgr.checkValidRoute(route)
+	ok, keys := m.appMgr.checkValidRoute(route)
 	if ok {
 		appInf, _ := m.appMgr.getNamespaceInformer(route.ObjectMeta.Namespace)
 		appInf.routeInformer.GetStore().Add(route)
-		mtx := m.getVsMutex(*vsKey)
-		mtx.Lock()
-		defer mtx.Unlock()
-		m.appMgr.syncVirtualServer(*vsKey)
-
+		for _, vsKey := range keys {
+			mtx := m.getVsMutex(*vsKey)
+			mtx.Lock()
+			defer mtx.Unlock()
+			m.appMgr.syncVirtualServer(*vsKey)
+		}
 	}
 	return ok
 }
 
 func (m *mockAppManager) updateRoute(route *routeapi.Route) bool {
-	ok, vsKey := m.appMgr.checkValidRoute(route)
+	ok, keys := m.appMgr.checkValidRoute(route)
 	if ok {
 		appInf, _ := m.appMgr.getNamespaceInformer(route.ObjectMeta.Namespace)
 		appInf.routeInformer.GetStore().Update(route)
-		mtx := m.getVsMutex(*vsKey)
-		mtx.Lock()
-		defer mtx.Unlock()
-		m.appMgr.syncVirtualServer(*vsKey)
+		for _, vsKey := range keys {
+			mtx := m.getVsMutex(*vsKey)
+			mtx.Lock()
+			defer mtx.Unlock()
+			m.appMgr.syncVirtualServer(*vsKey)
+		}
 	}
 	return ok
 }
 
 func (m *mockAppManager) deleteRoute(route *routeapi.Route) bool {
-	ok, vsKey := m.appMgr.checkValidRoute(route)
+	ok, keys := m.appMgr.checkValidRoute(route)
 	if ok {
 		appInf, _ := m.appMgr.getNamespaceInformer(route.ObjectMeta.Namespace)
 		appInf.routeInformer.GetStore().Delete(route)
-		mtx := m.getVsMutex(*vsKey)
-		mtx.Lock()
-		defer mtx.Unlock()
-		m.appMgr.syncVirtualServer(*vsKey)
+		for _, vsKey := range keys {
+			mtx := m.getVsMutex(*vsKey)
+			mtx.Lock()
+			defer mtx.Unlock()
+			m.appMgr.syncVirtualServer(*vsKey)
+		}
 	}
 	return ok
 }

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -220,6 +220,29 @@ func formatIngressPoolName(namespace, ingName, svc string) string {
 	return fmt.Sprintf("ingress_%s_%s_%s", namespace, ingName, svc)
 }
 
+func getRouteCanonicalService(route *routeapi.Route) string {
+	return route.Spec.To.Name
+}
+
+// return the services associated with a route
+func getRouteServiceNames(route *routeapi.Route) []string {
+	numOfSvcs := 1
+	if route.Spec.AlternateBackends != nil {
+		numOfSvcs += len(route.Spec.AlternateBackends)
+	}
+	svcs := make([]string, numOfSvcs)
+
+	svcIndex := 0
+	if route.Spec.AlternateBackends != nil {
+		for _, svc := range route.Spec.AlternateBackends {
+			svcs[svcIndex], svcIndex = svc.Name, svcIndex+1
+		}
+	}
+	svcs[svcIndex] = getRouteCanonicalService(route)
+
+	return svcs
+}
+
 // format the pool name for a Route
 func formatRoutePoolName(route *routeapi.Route) string {
 	return fmt.Sprintf("openshift_%s_%s",

--- a/pkg/appmanager/validateResources.go
+++ b/pkg/appmanager/validateResources.go
@@ -178,7 +178,8 @@ func (appMgr *Manager) checkValidIngress(
 
 func (appMgr *Manager) checkValidRoute(
 	obj interface{},
-) (bool, *serviceQueueKey) {
+) (bool, []*serviceQueueKey) {
+	var allKeys []*serviceQueueKey
 	route := obj.(*routeapi.Route)
 	namespace := route.ObjectMeta.Namespace
 	_, ok := appMgr.getNamespaceInformer(namespace)
@@ -186,9 +187,13 @@ func (appMgr *Manager) checkValidRoute(
 		// Not watching this namespace
 		return false, nil
 	}
-	key := &serviceQueueKey{
-		ServiceName: route.Spec.To.Name,
-		Namespace:   namespace,
+	svcNames := getRouteServiceNames(route)
+	for _, svcName := range svcNames {
+		key := &serviceQueueKey{
+			ServiceName: svcName,
+			Namespace:   namespace,
+		}
+		allKeys = append(allKeys, key)
 	}
-	return true, key
+	return true, allKeys
 }


### PR DESCRIPTION
Problem:  Need to be able to handle the alternateBackends definition
in the route spec.  This is used to specify addition services to use
for A/B deployments

Solution: Updated the route handling to return an array of services
instead of just one.