### PR TITLE
Fix VXLAN tunnel record names for consistency

### DIFF
--- a/pkg/vxlan/vxlanMgr.go
+++ b/pkg/vxlan/vxlanMgr.go
@@ -173,7 +173,7 @@ func ipv4ToMac(addr string) string {
 	for i, val := range ip {
 		intIP[i], _ = strconv.Atoi(val)
 	}
-	return fmt.Sprintf("0a:0a:%x:%x:%x:%x", intIP[0], intIP[1], intIP[2], intIP[3])
+	return fmt.Sprintf("0a:0a:%02x:%02x:%02x:%02x", intIP[0], intIP[1], intIP[2], intIP[3])
 }
 
 // Listen for updates from appmanager containing pod names (for arp entries)

--- a/pkg/vxlan/vxlanMgr_test.go
+++ b/pkg/vxlan/vxlanMgr_test.go
@@ -162,19 +162,19 @@ var _ = Describe("VxlanMgr Tests", func() {
 			TunnelName: "vxlan500",
 			Records: []fdbRecord{
 				fdbRecord{
-					Name:     "0a:0a:7f:1:1:2",
+					Name:     "0a:0a:7f:01:01:02",
 					Endpoint: "127.1.1.2",
 				},
 				fdbRecord{
-					Name:     "0a:0a:7f:0:0:4",
+					Name:     "0a:0a:7f:00:00:04",
 					Endpoint: "127.0.0.4",
 				},
 				fdbRecord{
-					Name:     "0a:0a:7f:1:1:5",
+					Name:     "0a:0a:7f:01:01:05",
 					Endpoint: "127.1.1.5",
 				},
 				fdbRecord{
-					Name:     "0a:0a:7f:0:0:7",
+					Name:     "0a:0a:7f:00:00:07",
 					Endpoint: "127.0.0.7",
 				},
 			},
@@ -201,23 +201,23 @@ var _ = Describe("VxlanMgr Tests", func() {
 			TunnelName: "vxlan500",
 			Records: []fdbRecord{
 				fdbRecord{
-					Name:     "0a:0a:7f:0:0:0",
+					Name:     "0a:0a:7f:00:00:00",
 					Endpoint: "127.0.0.0",
 				},
 				fdbRecord{
-					Name:     "0a:0a:7f:0:0:1",
+					Name:     "0a:0a:7f:00:00:01",
 					Endpoint: "127.0.0.1",
 				},
 				fdbRecord{
-					Name:     "0a:0a:7f:0:0:2",
+					Name:     "0a:0a:7f:00:00:02",
 					Endpoint: "127.0.0.2",
 				},
 				fdbRecord{
-					Name:     "0a:0a:7f:0:0:3",
+					Name:     "0a:0a:7f:00:00:03",
 					Endpoint: "127.0.0.3",
 				},
 				fdbRecord{
-					Name:     "0a:0a:7f:0:0:6",
+					Name:     "0a:0a:7f:00:00:06",
 					Endpoint: "127.0.0.6",
 				},
 			},


### PR DESCRIPTION
Problem: The custom record names that were created for OpenShift didn't match the formatting
of the record names as they came back from the BIG-IP. Leading zeroes were stripped by the controller, but not by the BIG-IP.

Solution: Ensure that leading zeroes in the tunnel record names are retained to match the BIG-IP config.

Fixes #461 