### PR TITLE
Added creation of pools for alternateBackends (openshift only)

### DIFF
--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -3182,8 +3182,10 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(len(hostDg[namespace].Records)).To(Equal(2))
 					Expect(hostDg[namespace].Records[1].Name).To(Equal(hostName1))
 					Expect(hostDg[namespace].Records[0].Name).To(Equal(hostName2))
-					Expect(hostDg[namespace].Records[1].Data).To(Equal(formatRoutePoolName(route1)))
-					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(route2)))
+					Expect(hostDg[namespace].Records[1].Data).To(Equal(formatRoutePoolName(
+						route1, getRouteCanonicalService(route1))))
+					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(
+						route2, getRouteCanonicalService(route2))))
 
 					rs, ok = resources.Get(
 						serviceKey{svcName2, 443, namespace}, "ose-vserver")
@@ -3201,7 +3203,8 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(found).To(BeTrue())
 					Expect(len(hostDg[namespace].Records)).To(Equal(1))
 					Expect(hostDg[namespace].Records[0].Name).To(Equal(hostName1))
-					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(route1)))
+					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(
+						route1, getRouteCanonicalService(route1))))
 				})
 
 				It("configures reencrypt routes", func() {
@@ -3250,7 +3253,8 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(found).To(BeTrue())
 					Expect(len(hostDg[namespace].Records)).To(Equal(1))
 					Expect(hostDg[namespace].Records[0].Name).To(Equal(hostName))
-					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(route)))
+					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(
+						route, getRouteCanonicalService(route))))
 
 					customProfiles := mockMgr.customProfiles()
 					// Should be 2 profiles from Spec, 2 defaults (clientssl and serverssl)

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -259,10 +259,22 @@ func getRouteServiceNames(route *routeapi.Route) []string {
 	return svcs
 }
 
+// Verify if the service is associated with the route
+func existsRouteServiceName(route *routeapi.Route, expSvcName string) bool {
+	// We don't expect an extensive list, so we're not using a map
+	svcNames := getRouteServiceNames(route)
+	for _, svcName := range svcNames {
+		if expSvcName == svcName {
+			return true
+		}
+	}
+	return false
+}
+
 // format the pool name for a Route
-func formatRoutePoolName(route *routeapi.Route) string {
+func formatRoutePoolName(route *routeapi.Route, svcName string) string {
 	return fmt.Sprintf("openshift_%s_%s",
-		route.ObjectMeta.Namespace, route.Spec.To.Name)
+		route.ObjectMeta.Namespace, svcName)
 }
 
 // format the Rule name for a Route
@@ -930,6 +942,7 @@ func createRSConfigFromIngress(
 
 func createRSConfigFromRoute(
 	route *routeapi.Route,
+	svcName string,
 	resources Resources,
 	routeConfig RouteConfig,
 	pStruct portStruct,
@@ -955,13 +968,13 @@ func createRSConfigFromRoute(
 		if strVal == "" {
 			backendPort = route.Spec.Port.TargetPort.IntVal
 		} else {
-			backendPort, err = getServicePort(route, svcIndexer, strVal)
+			backendPort, err = getServicePort(route, svcName, svcIndexer, strVal)
 			if nil != err {
 				log.Warningf("%v", err)
 			}
 		}
 	} else {
-		backendPort, err = getServicePort(route, svcIndexer, "")
+		backendPort, err = getServicePort(route, svcName, svcIndexer, "")
 		if nil != err {
 			log.Warningf("%v", err)
 		}
@@ -969,10 +982,10 @@ func createRSConfigFromRoute(
 
 	// Create the pool
 	pool := Pool{
-		Name:        formatRoutePoolName(route),
+		Name:        formatRoutePoolName(route, svcName),
 		Partition:   DEFAULT_PARTITION,
 		Balance:     DEFAULT_BALANCE,
-		ServiceName: route.Spec.To.Name,
+		ServiceName: svcName,
 		ServicePort: backendPort,
 	}
 	// Create the rule
@@ -1460,11 +1473,11 @@ func NewCustomProfile(
 // else return the first port found from a Route's service.
 func getServicePort(
 	route *routeapi.Route,
+	svcName string,
 	svcIndexer cache.Indexer,
 	name string,
 ) (int32, error) {
 	ns := route.ObjectMeta.Namespace
-	svcName := route.Spec.To.Name
 	key := ns + "/" + svcName
 
 	obj, found, err := svcIndexer.GetByKey(key)

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -516,8 +516,8 @@ var _ = Describe("Resource Config Tests", func() {
 				HttpsVs: "https-ose-vserver",
 			}
 			svcFwdRulesMap := NewServiceFwdRuleMap()
-			cfg, _, _ := createRSConfigFromRoute(route, Resources{}, rc, ps, nil,
-				svcFwdRulesMap)
+			cfg, _, _ := createRSConfigFromRoute(route, getRouteCanonicalService(route),
+				Resources{}, rc, ps, nil, svcFwdRulesMap)
 			Expect(cfg.Virtual.Name).To(Equal("https-ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_foo"))
 			Expect(cfg.Pools[0].ServiceName).To(Equal("foo"))
@@ -541,8 +541,8 @@ var _ = Describe("Resource Config Tests", func() {
 				protocol: "http",
 				port:     80,
 			}
-			cfg, _, _ = createRSConfigFromRoute(route2, Resources{}, rc, ps, nil,
-				svcFwdRulesMap)
+			cfg, _, _ = createRSConfigFromRoute(route2, getRouteCanonicalService(route2),
+				Resources{}, rc, ps, nil, svcFwdRulesMap)
 			Expect(cfg.Virtual.Name).To(Equal("ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_bar"))
 			Expect(cfg.Pools[0].ServiceName).To(Equal("bar"))

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -394,7 +394,8 @@ func updateDataGroupForPassthroughRoute(
 	dgMap InternalDataGroupMap,
 ) {
 	hostName := route.Spec.Host
-	poolName := formatRoutePoolName(route)
+	svcName := getRouteCanonicalService(route)
+	poolName := formatRoutePoolName(route, svcName)
 	updateDataGroup(dgMap, passthroughHostsDgName,
 		partition, namespace, hostName, poolName)
 }
@@ -407,7 +408,8 @@ func updateDataGroupForReencryptRoute(
 	dgMap InternalDataGroupMap,
 ) {
 	hostName := route.Spec.Host
-	poolName := formatRoutePoolName(route)
+	svcName := getRouteCanonicalService(route)
+	poolName := formatRoutePoolName(route, svcName)
 	updateDataGroup(dgMap, reencryptHostsDgName,
 		partition, namespace, hostName, poolName)
 }


### PR DESCRIPTION
Problem: Each route may specify multipe services.  We need pools
created for each of these services.

Solution: During route sync, determine if the service belongs to
the route and process accordingly.