### PR TITLE
Added irule and datagroup support for A/B deployments in non-TLS envi…

### DIFF
--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -3183,9 +3183,9 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(hostDg[namespace].Records[1].Name).To(Equal(hostName1))
 					Expect(hostDg[namespace].Records[0].Name).To(Equal(hostName2))
 					Expect(hostDg[namespace].Records[1].Data).To(Equal(formatRoutePoolName(
-						route1, getRouteCanonicalService(route1))))
+						route1, getRouteCanonicalServiceName(route1))))
 					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(
-						route2, getRouteCanonicalService(route2))))
+						route2, getRouteCanonicalServiceName(route2))))
 
 					rs, ok = resources.Get(
 						serviceKey{svcName2, 443, namespace}, "ose-vserver")
@@ -3204,7 +3204,7 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(len(hostDg[namespace].Records)).To(Equal(1))
 					Expect(hostDg[namespace].Records[0].Name).To(Equal(hostName1))
 					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(
-						route1, getRouteCanonicalService(route1))))
+						route1, getRouteCanonicalServiceName(route1))))
 				})
 
 				It("configures reencrypt routes", func() {
@@ -3254,7 +3254,7 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(len(hostDg[namespace].Records)).To(Equal(1))
 					Expect(hostDg[namespace].Records[0].Name).To(Equal(hostName))
 					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(
-						route, getRouteCanonicalService(route))))
+						route, getRouteCanonicalServiceName(route))))
 
 					customProfiles := mockMgr.customProfiles()
 					// Should be 2 profiles from Spec, 2 defaults (clientssl and serverssl)

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -236,39 +236,67 @@ func formatIngressRuleName(host, path, pool string) string {
 	return rule
 }
 
-func getRouteCanonicalService(route *routeapi.Route) string {
+func getRouteCanonicalServiceName(route *routeapi.Route) string {
 	return route.Spec.To.Name
 }
 
-// return the services associated with a route
-func getRouteServiceNames(route *routeapi.Route) []string {
+type RouteService struct {
+	weight int
+	name   string
+}
+
+// return the services associated with a route (names + weight)
+func getRouteServices(route *routeapi.Route) []RouteService {
 	numOfSvcs := 1
 	if route.Spec.AlternateBackends != nil {
 		numOfSvcs += len(route.Spec.AlternateBackends)
 	}
-	svcs := make([]string, numOfSvcs)
+	svcs := make([]RouteService, numOfSvcs)
 
 	svcIndex := 0
 	if route.Spec.AlternateBackends != nil {
 		for _, svc := range route.Spec.AlternateBackends {
-			svcs[svcIndex], svcIndex = svc.Name, svcIndex+1
+			svcs[svcIndex].name = svc.Name
+			svcs[svcIndex].weight = int(*(svc.Weight))
+			svcIndex = svcIndex + 1
 		}
 	}
-	svcs[svcIndex] = getRouteCanonicalService(route)
+	svcs[svcIndex].name = route.Spec.To.Name
+	if route.Spec.To.Weight != nil {
+		svcs[svcIndex].weight = int(*(route.Spec.To.Weight))
+	} else {
+		// Older versions of openshift do not have a weight field
+		// so we will basically ignore it.
+		svcs[svcIndex].weight = 0
+	}
 
 	return svcs
+}
+
+// return the service names associated with a route
+func getRouteServiceNames(route *routeapi.Route) []string {
+	svcs := getRouteServices(route)
+	svcNames := make([]string, len(svcs))
+	for idx, svc := range svcs {
+		svcNames[idx] = svc.name
+	}
+	return svcNames
 }
 
 // Verify if the service is associated with the route
 func existsRouteServiceName(route *routeapi.Route, expSvcName string) bool {
 	// We don't expect an extensive list, so we're not using a map
-	svcNames := getRouteServiceNames(route)
-	for _, svcName := range svcNames {
-		if expSvcName == svcName {
+	svcs := getRouteServices(route)
+	for _, svc := range svcs {
+		if expSvcName == svc.name {
 			return true
 		}
 	}
 	return false
+}
+
+func isRouteABDeployment(route *routeapi.Route) bool {
+	return route.Spec.AlternateBackends != nil && len(route.Spec.AlternateBackends) > 0
 }
 
 // format the pool name for a Route
@@ -1040,6 +1068,12 @@ func createRSConfigFromRoute(
 		}
 		rsCfg.Virtual.SetVirtualAddress(bindAddr, pStruct.port)
 		rsCfg.Pools = append(rsCfg.Pools, pool)
+	}
+
+	if isRouteABDeployment(route) {
+		ruleName := joinBigipPath(DEFAULT_PARTITION, abDeploymentIRuleName)
+		// FIXME(kenr): If no routes have A/B, we could remove the irule
+		rsCfg.Virtual.AddIRule(ruleName)
 	}
 
 	rsCfg.HandleRouteTls(route, pStruct.protocol, policyName, rule,

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -516,7 +516,7 @@ var _ = Describe("Resource Config Tests", func() {
 				HttpsVs: "https-ose-vserver",
 			}
 			svcFwdRulesMap := NewServiceFwdRuleMap()
-			cfg, _, _ := createRSConfigFromRoute(route, getRouteCanonicalService(route),
+			cfg, _, _ := createRSConfigFromRoute(route, getRouteCanonicalServiceName(route),
 				Resources{}, rc, ps, nil, svcFwdRulesMap)
 			Expect(cfg.Virtual.Name).To(Equal("https-ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_foo"))
@@ -541,7 +541,7 @@ var _ = Describe("Resource Config Tests", func() {
 				protocol: "http",
 				port:     80,
 			}
-			cfg, _, _ = createRSConfigFromRoute(route2, getRouteCanonicalService(route2),
+			cfg, _, _ = createRSConfigFromRoute(route2, getRouteCanonicalServiceName(route2),
 				Resources{}, rc, ps, nil, svcFwdRulesMap)
 			Expect(cfg.Virtual.Name).To(Equal("ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_bar"))

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -33,6 +33,7 @@ import (
 )
 
 const httpRedirectIRuleName = "http_redirect_irule"
+const abDeploymentIRuleName = "ab_deployment_irule"
 const sslPassthroughIRuleName = "openshift_passthrough_irule"
 
 // Internal data group for passthrough routes to map server names to pools.
@@ -48,6 +49,9 @@ const reencryptServerSslDgName = "ssl_reencrypt_serverssl_dg"
 // Internal data group for https redirect
 const httpsRedirectDgName = "https_redirect_dg"
 
+// Internal data group for ab deployment routes.
+const abDeploymentDgName = "ab_deployment_dg"
+
 // DataGroup flattening.
 type FlattenConflictFunc func(key, oldVal, newVal string) string
 
@@ -56,6 +60,7 @@ var groupFlattenFuncMap = map[string]FlattenConflictFunc{
 	reencryptHostsDgName:     flattenConflictWarn,
 	reencryptServerSslDgName: flattenConflictWarn,
 	httpsRedirectDgName:      flattenConflictConcat,
+	abDeploymentDgName:       flattenConflictConcat,
 }
 
 func (r Rules) Len() int           { return len(r) }
@@ -241,6 +246,35 @@ func httpRedirectIRule(port int32) string {
 	return iRuleCode
 }
 
+func abDeploymentIRule() string {
+	// The key in the data group is the specific route (name/path) to examine.
+	// The data is a list of pool/weight pairs delimited by ';'. The pair values
+	// are delineated by ','. Finally, the weight value is normalized between
+	// 0.0 and 1.0 and the pairs should be listed in ascending order or weight
+	// values.
+	iRuleCode := fmt.Sprintf(
+		`when HTTP_REQUEST priority 200 {
+			set path [string tolower [HTTP::host]][HTTP::path]
+			set ab_rule [class match -value $path equals ab_deployment_dg]
+			if {$ab_rule != ""} then {
+				set weight_selection [expr {rand()}]
+				set service_rules [split $ab_rule ";"]
+				foreach service_rule $service_rules {
+					set fields [split $service_rule ","]
+					set service_name [lindex $fields 0]
+					set weight [expr {double([lindex $fields 1])}]
+					if {$weight_selection <= $weight} then {
+						pool $service_name
+						event disable
+						break
+					}
+				}
+			}
+		}`)
+
+	return iRuleCode
+}
+
 func sslPassthroughIRule() string {
 	iRuleCode :=
 		`when CLIENT_ACCEPTED {
@@ -394,7 +428,7 @@ func updateDataGroupForPassthroughRoute(
 	dgMap InternalDataGroupMap,
 ) {
 	hostName := route.Spec.Host
-	svcName := getRouteCanonicalService(route)
+	svcName := getRouteCanonicalServiceName(route)
 	poolName := formatRoutePoolName(route, svcName)
 	updateDataGroup(dgMap, passthroughHostsDgName,
 		partition, namespace, hostName, poolName)
@@ -408,10 +442,58 @@ func updateDataGroupForReencryptRoute(
 	dgMap InternalDataGroupMap,
 ) {
 	hostName := route.Spec.Host
-	svcName := getRouteCanonicalService(route)
+	svcName := getRouteCanonicalServiceName(route)
 	poolName := formatRoutePoolName(route, svcName)
 	updateDataGroup(dgMap, reencryptHostsDgName,
 		partition, namespace, hostName, poolName)
+}
+
+// Update a data group map based on a alternativeBackends route object.
+// (ignore an service with a 0 weight value)
+func updateDataGroupForABRoute(
+	route *routeapi.Route,
+	svcName string,
+	partition string,
+	namespace string,
+	dgMap InternalDataGroupMap,
+) {
+	if !isRouteABDeployment(route) {
+		return
+	}
+
+	weightTotal := 0
+	svcs := getRouteServices(route)
+	for _, svc := range svcs {
+		weightTotal = weightTotal + svc.weight
+	}
+
+	if weightTotal == 0 {
+		// FIXME(kenr): what do we do if all services had 0 weight?
+		return
+	}
+
+	// Determine a weighted slice between 0.0 and 1.0 to match
+	// each service's weight ratio.
+	runningWeightTotal := 0
+	path := route.Spec.Path
+	if len(route.Spec.Path) == 0 {
+		path = "/"
+	}
+	key := route.Spec.Host + path
+	var entries []string
+	for _, svc := range svcs {
+		if svc.weight == 0 {
+			continue
+		}
+		runningWeightTotal = runningWeightTotal + svc.weight
+		weightedSliceThreshold := float64(runningWeightTotal) / float64(weightTotal)
+		pool := formatRoutePoolName(route, svc.name)
+		entry := fmt.Sprintf("%s,%4.3f", pool, weightedSliceThreshold)
+		entries = append(entries, entry)
+	}
+	value := strings.Join(entries, ";")
+	updateDataGroup(dgMap, abDeploymentDgName,
+		partition, namespace, key, value)
 }
 
 // Add or update a data group record


### PR DESCRIPTION
…ronments

Problem:  Need to be able to load balance, using a ratio based
algorithm, between services that are part of an A/B deployment.

Solution: Created an irule that will fire on matching host/path
and will select a particular pool based on information stored
in a datagroup.

Restrictions:  Current implementation is only for non-TLS routes.