### PR TITLE
fix VERSION_BUILD log error

### DIFF
--- a/python/bigipconfigdriver.py
+++ b/python/bigipconfigdriver.py
@@ -697,7 +697,7 @@ def _handle_vxlan_config(config):
 
 def _set_user_agent():
     try:
-        with open('VERSION_BUILD.json', 'r') as version_file:
+        with open('/app/python/VERSION_BUILD.json', 'r') as version_file:
             data = json.load(version_file)
             user_agent = \
                 "k8s-bigip-ctlr-" + data['version'] + '-' + data['build']


### PR DESCRIPTION
Problem:
- set_user_agent() incorrectly targeted `VERSION_BUILD.json` without `/app/python/` prefix generating an Error log entry at start up.

Solution:
- added full path

Tests:
- spun up controller and confirmed message no longer showing

fixes #464