### PR TITLE
Sync profiles for Ingresses

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -863,7 +863,7 @@ func (appMgr *Manager) syncVirtualServer(sKey serviceQueueKey) error {
 		stats.vsUpdated, stats.vsFound, stats.vsDeleted)
 
 	// delete any custom profiles that are no longer referenced
-	appMgr.deleteUnusedProfiles(appInf, sKey.Namespace)
+	appMgr.deleteUnusedProfiles(appInf, sKey.Namespace, &stats)
 
 	if stats.vsUpdated > 0 || stats.vsDeleted > 0 || stats.cpUpdated > 0 ||
 		stats.dgUpdated > 0 {

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -1016,6 +1016,8 @@ func createRSConfigFromRoute(
 func (rc *ResourceConfig) copyConfig(cfg *ResourceConfig) {
 	rc.MetaData = cfg.MetaData
 	rc.Virtual = cfg.Virtual
+	rc.Virtual.Profiles = make([]ProfileRef, len(cfg.Virtual.Profiles))
+	copy(rc.Virtual.Profiles, cfg.Virtual.Profiles)
 	rc.Pools = make(Pools, len(cfg.Pools))
 	copy(rc.Pools, cfg.Pools)
 	rc.Monitors = make(Monitors, len(cfg.Monitors))


### PR DESCRIPTION
Problem: Now that Ingresses are built off of existing configs, it is important that
all data is correctly copied to each new config. Profiles were not being correctly copied
when an Ingress was updated, causing some intermittent issues.

Solution: Correctly copy profiles when updating an existing config. Also ensured that configs are
written out when profiles are updated.