### PR TITLE
Update yaml.v2 to latest

### DIFF
--- a/.f5license
+++ b/.f5license
@@ -530,32 +530,12 @@
     See the License for the specific language governing permissions and
     limitations under the License.
 
-# The yaml.v2 module is licensed under LGPLv3 except for the portions ported
+# The yaml.v2 module is licensed under Apache except for the portions ported
 # from the libyaml project, which are licensed under MIT.
 - name: yaml
   version: v2
+  license: Apache-2.0
   attribution_text: |
-    Copyright (c) 2011-2014 - Canonical Inc.
-
-    This software is licensed under the LGPLv3, included below.
-
-    As a special exception to the GNU Lesser General Public License version 3
-    ("LGPL3"), the copyright holders of this Library give you permission to
-    convey to a third party a Combined Work that links statically or dynamically
-    to this Library without providing any Minimal Corresponding Source or
-    Minimal Application Code as set out in 4d or providing the installation
-    information set out in section 4e, provided that you comply with the other
-    provisions of LGPL3 and provided that you meet, for the Application the
-    terms and conditions of the license(s) which apply to the Application.
-
-    Except as stated in this special exception, the provisions of LGPL3 will
-    continue to comply in full to this Library. If you modify this Library, you
-    may apply this exception to your version of this Library, but you are not
-    obliged to do so. If you do not wish to do so, delete this exception
-    statement from your version. This exception does not (and cannot) modify any
-    license terms which apply to the Application, with which you must still
-    comply.
-
     Copyright (c) 2006 Kirill Simonov
 
     Permission is hereby granted, free of charge, to any person obtaining a copy of

--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -743,7 +743,7 @@
 		},
 		{
 			"ImportPath": "gopkg.in/yaml.v2",
-			"Rev": "53feefa2559fb8dfa8d81baad31be332c97d6c77"
+			"Rev": "d670f9405373e636a5a2765eea47fac0c9bc91a4"
 		},
 		{
 			"ImportPath": "k8s.io/apimachinery/pkg/api/equality",


### PR DESCRIPTION
Bumped the commit for the yaml.v2 package to the latest in order to inherit the Apache license,
whereas this package formerly used LGPLv3.