### PR TITLE
Add balance route annotation

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -628,6 +628,8 @@ Supported Route Annotations
 +----------------------------------------+-------------+-----------+--------------------------------------------------------------------------------+-------------+
 | Annotation                             | Type        | Required  | Description                                                                    | Default     |
 +========================================+=============+===========+================================================================================+=============+
+| virtual-server.f5.com/balance          | string      | Optional  | Specifies the load balancing mode.                                             | round-robin |
++----------------------------------------+-------------+-----------+--------------------------------------------------------------------------------+-------------+
 | virtual-server.f5.com/clientssl        | string      | Optional  | The name of a pre-configured client ssl profile on the BIG-IP system.          | N/A         |
 |                                        |             |           | The controller uses this profile instead of the certificate and key within the |             |
 |                                        |             |           | Route's configuration.                                                         |             |

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -18,6 +18,7 @@ Added Functionality
 * Support for ``recv`` strings in health monitors for ConfigMaps, Ingresses, and Routes.
 * Support UDP in ConfigMaps (includes proxy type and health monitors).
 * Provide Controller version info in the container and logs.
+* Support for 'virtual-server.f5.com/balance' annotation for Routes.
 
 Bug Fixes
 `````````

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -943,12 +943,18 @@ func createRSConfigFromRoute(
 			log.Warningf("%v", err)
 		}
 	}
+	var balance string
+	if bal, ok := route.ObjectMeta.Annotations[f5VsBalanceAnnotation]; ok {
+		balance = bal
+	} else {
+		balance = DEFAULT_BALANCE
+	}
 
 	// Create the pool
 	pool := Pool{
 		Name:        formatRoutePoolName(route),
 		Partition:   DEFAULT_PARTITION,
-		Balance:     DEFAULT_BALANCE,
+		Balance:     balance,
 		ServiceName: route.Spec.To.Name,
 		ServicePort: backendPort,
 	}


### PR DESCRIPTION
Problem: Routes would default to using round-robin as their load balancing method, without
the ability to configure a different method.

Solution: Routes can now be annotated with the 'virtual-server.f5.com/balance' annotation, similar
to Ingress, in order to use a different LB method than round robin.

Fixes #491