### PR TITLE
Unit tests for A/B deployment

### DIFF
--- a/pkg/appmanager/healthMonitors_test.go
+++ b/pkg/appmanager/healthMonitors_test.go
@@ -986,7 +986,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			r = mockMgr.addService(fooSvc)
 			Expect(r).To(BeTrue(), "Service should be processed.")
 			resources := mockMgr.resources()
-			Expect(resources.PoolCount()).To(Equal(2))
+			Expect(resources.PoolCount()).To(Equal(1))
 
 			// The first test uses an explicit server name
 			vsCfgFoo, found := resources.Get(svcKey, "https-ose-vserver")

--- a/pkg/appmanager/profiles_test.go
+++ b/pkg/appmanager/profiles_test.go
@@ -114,7 +114,7 @@ var _ = Describe("AppManager Profile Tests", func() {
 			r = mockMgr.addEndpoints(endpts)
 			Expect(r).To(BeTrue(), "Endpoints should be processed.")
 			resources := mockMgr.resources()
-			Expect(resources.PoolCount()).To(Equal(2))
+			Expect(resources.PoolCount()).To(Equal(1))
 			Expect(resources.CountOf(svcKey)).To(Equal(2))
 			httpCfg, found := resources.Get(svcKey, formatIngressVSName("1.2.3.4", 80))
 			Expect(found).To(BeTrue())

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -244,7 +244,8 @@ var _ = Describe("Resource Config Tests", func() {
 
 		It("can count all pool resources", func() {
 			// Test PoolCount() to make sure we count all items
-			Expect(rs.PoolCount()).To(Equal(nbrBackends * nbrCfgsPer))
+			// Only one pool gets created for all configs
+			Expect(rs.PoolCount()).To(Equal(1))
 		})
 
 		It("can count all virtual resources", func() {


### PR DESCRIPTION
Adding two new unit tests for A/B deployment. The first test verifies that alternate backends in Routes create the correct number of pools and rules. The second test verifies that the data groups are correctly populated with the weights and corresponding pool names (for each path).

Also fixed the PoolCount method to correctly count the number of pools (formerly it would count configs per svcKey, which resulted in duplicates in some cases).