### PR TITLE
Bigipdriver.py hangs when exceptions occur

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -29,6 +29,7 @@ Bug Fixes
 * :issues:`344` - Create default for SNI profile when using Ingress custom profiles from Secrets.
 * :issues:`460` - Remove risk that pools will update with wrong members after a node update (NodePort mode).
 * :issues:`428` - Controller writes unnecessary updates when no config changes occurred.
+* :issues:`506` - Controller stops updating BIG-IP after an exception occurs in the python driver.
 * Corrected a comparison problem in CCCL that caused unnecessary updates for BIG-IP Virtual Server resources.
 
 Limitations


### PR DESCRIPTION
Problem: If the CCCL library throws a Big-IP exception (or any
exception), or if the driver encounters an exception while reading
the config file, then the driver hangs due to the thread terminating
(but not the process).

Solution: Catch the exceptions, log an error as specific as possible,
and then enter the retry loop.

Fixes: #506 