### PR TITLE
Fix namespace bug when deleting profiles

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,6 +1,13 @@
 Release Notes for BIG-IP Controller for Kubernetes
 ==================================================
 
+v1.4.1
+------
+
+Bug Fixes
+`````````
+* :issues:`517` - Controller deletes SSL profiles off of Ingress virtual servers if watching multiple namespaces.
+
 v1.4.0
 ------
 

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1266,7 +1266,7 @@ func (appMgr *Manager) handleIngressTls(
 					log.Debugf("No Secret with name '%s': %s. Parsing secretName as path instead.",
 						tls.SecretName, err)
 					profRef := convertStringToProfileRef(
-						tls.SecretName, customProfileClient)
+						tls.SecretName, customProfileClient, ing.ObjectMeta.Namespace)
 					rsCfg.Virtual.AddOrUpdateProfile(profRef)
 					continue
 				}
@@ -1280,11 +1280,13 @@ func (appMgr *Manager) handleIngressTls(
 					Partition: rsCfg.Virtual.Partition,
 					Name:      tls.SecretName,
 					Context:   customProfileClient,
+					Namespace: ing.ObjectMeta.Namespace,
 				}
 				rsCfg.Virtual.AddOrUpdateProfile(profRef)
 			} else {
 				secretName := formatIngressSslProfileName(tls.SecretName)
-				profRef := convertStringToProfileRef(secretName, customProfileClient)
+				profRef := convertStringToProfileRef(
+					secretName, customProfileClient, ing.ObjectMeta.Namespace)
 				rsCfg.Virtual.AddOrUpdateProfile(profRef)
 			}
 		}

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -684,7 +684,11 @@ func compareVirtuals(vs, expected Virtual) {
 	Expect(vs.SourceAddrTranslation).To(Equal(expected.SourceAddrTranslation))
 	Expect(vs.Policies).To(Equal(expected.Policies))
 	Expect(vs.IRules).To(Equal(expected.IRules))
-	Expect(vs.Profiles).To(Equal(expected.Profiles))
+	for i, prof := range vs.Profiles {
+		Expect(prof.Context).To(Equal(expected.Profiles[i].Context))
+		Expect(prof.Name).To(Equal(expected.Profiles[i].Name))
+		Expect(prof.Partition).To(Equal(expected.Profiles[i].Partition))
+	}
 	Expect(vs.Description).To(Equal(expected.Description))
 }
 

--- a/pkg/appmanager/profiles_test.go
+++ b/pkg/appmanager/profiles_test.go
@@ -323,6 +323,7 @@ var _ = Describe("AppManager Profile Tests", func() {
 					Partition: "Common",
 					Name:      "client",
 					Context:   customProfileClient,
+					Namespace: namespace,
 				}))
 			Expect(rs.Virtual.Profiles).ToNot(ContainElement(
 				ProfileRef{
@@ -333,13 +334,15 @@ var _ = Describe("AppManager Profile Tests", func() {
 			pRef := ProfileRef{
 				Name:      "server",
 				Partition: "Common",
-				Context:   "serverside",
+				Context:   customProfileServer,
+				Namespace: namespace,
 			}
 			Expect(rs.Virtual.Profiles).To(ContainElement(pRef))
 			customPRef := ProfileRef{
 				Name:      "openshift_route_default_route-server-ssl",
 				Partition: "velcro",
-				Context:   "serverside",
+				Context:   customProfileServer,
+				Namespace: namespace,
 			}
 			Expect(rs.Virtual.Profiles).ToNot(ContainElement(customPRef))
 
@@ -361,6 +364,7 @@ var _ = Describe("AppManager Profile Tests", func() {
 					Partition: "velcro",
 					Name:      "openshift_route_default_route-client-ssl",
 					Context:   customProfileClient,
+					Namespace: namespace,
 				}))
 			Expect(rs.Virtual.Profiles).ToNot(ContainElement(pRef))
 			Expect(rs.Virtual.Profiles).To(ContainElement(customPRef))
@@ -377,17 +381,20 @@ var _ = Describe("AppManager Profile Tests", func() {
 					Partition: "Common",
 					Name:      "newClient",
 					Context:   customProfileClient,
+					Namespace: namespace,
 				}))
 			Expect(rs.Virtual.Profiles).ToNot(ContainElement(
 				ProfileRef{
 					Partition: "velcro",
 					Name:      "openshift_route_default_route-client-ssl",
 					Context:   customProfileClient,
+					Namespace: namespace,
 				}))
 			pRef = ProfileRef{
 				Name:      "newServer",
 				Partition: "Common",
-				Context:   "serverside",
+				Context:   customProfileServer,
+				Namespace: namespace,
 			}
 			Expect(rs.Virtual.Profiles).To(ContainElement(pRef))
 			Expect(rs.Virtual.Profiles).ToNot(ContainElement(customPRef))

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -317,6 +317,7 @@ func makeRouteClientSSLProfileRef(partition, namespace, name string) ProfileRef 
 		Partition: partition,
 		Name:      fmt.Sprintf("openshift_route_%s_%s-client-ssl", namespace, name),
 		Context:   customProfileClient,
+		Namespace: namespace,
 	}
 }
 
@@ -326,6 +327,7 @@ func makeRouteServerSSLProfileRef(partition, namespace, name string) ProfileRef 
 		Partition: partition,
 		Name:      fmt.Sprintf("openshift_route_%s_%s-server-ssl", namespace, name),
 		Context:   customProfileServer,
+		Namespace: namespace,
 	}
 }
 
@@ -361,10 +363,10 @@ func formatIngressSslProfileName(secret string) string {
 	return profName
 }
 
-func convertStringToProfileRef(profileName, context string) ProfileRef {
+func convertStringToProfileRef(profileName, context, ns string) ProfileRef {
 	profName := strings.TrimSpace(strings.TrimPrefix(profileName, "/"))
 	parts := strings.Split(profName, "/")
-	profRef := ProfileRef{Context: context}
+	profRef := ProfileRef{Context: context, Namespace: ns}
 	switch len(parts) {
 	case 2:
 		profRef.Partition = parts[0]
@@ -765,11 +767,11 @@ func copyConfigMap(virtualName, ns string, cfg *ResourceConfig, cfgMap *ConfigMa
 			if len(cfgMap.VirtualServer.Frontend.SslProfile.F5ProfileName) > 0 {
 				profRef := convertStringToProfileRef(
 					cfgMap.VirtualServer.Frontend.SslProfile.F5ProfileName,
-					customProfileClient)
+					customProfileClient, ns)
 				cfg.Virtual.AddOrUpdateProfile(profRef)
 			} else {
 				for _, profName := range cfgMap.VirtualServer.Frontend.SslProfile.F5ProfileNames {
-					profRef := convertStringToProfileRef(profName, customProfileClient)
+					profRef := convertStringToProfileRef(profName, customProfileClient, ns)
 					cfg.Virtual.AddOrUpdateProfile(profRef)
 				}
 			}

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -62,6 +62,9 @@ type (
 		Name      string `json:"name"`
 		Partition string `json:"partition"`
 		Context   string `json:"context"` // 'clientside', 'serverside', or 'all'
+		// Used as reference to which Namespace/Ingress this profile came from
+		// (for deletion purposes)
+		Namespace string `json:"-"`
 	}
 	ProfileRefs []ProfileRef
 


### PR DESCRIPTION
Problem: When deleting unused profiles, if processing a namespace that did not contain
an Ingress that referenced a profile on a virtual, the controller would delete the profile (even
if the profile was referenced by an Ingress in a different namespace).

Solution: Add a namespace field to the ProfileRef struct, in order to tell which namespace a profile
reference comes from. This way we don't delete a profile uninentionally when processing a namespace that
the profile didn't come from.

Note: This is a temporary fix that can be properly reworked when the fix for bug #471  is in.

Fixes #517