### PR TITLE
Old service pools are not immediately removed

### DIFF
--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -3187,9 +3187,9 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(hostDg[namespace].Records[1].Name).To(Equal(hostName1))
 					Expect(hostDg[namespace].Records[0].Name).To(Equal(hostName2))
 					Expect(hostDg[namespace].Records[1].Data).To(Equal(formatRoutePoolName(
-						route1, getRouteCanonicalServiceName(route1))))
+						route1.ObjectMeta.Namespace, getRouteCanonicalServiceName(route1))))
 					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(
-						route2, getRouteCanonicalServiceName(route2))))
+						route2.ObjectMeta.Namespace, getRouteCanonicalServiceName(route2))))
 
 					rs, ok = resources.Get(
 						serviceKey{svcName2, 443, namespace}, "ose-vserver")
@@ -3208,7 +3208,7 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(len(hostDg[namespace].Records)).To(Equal(1))
 					Expect(hostDg[namespace].Records[0].Name).To(Equal(hostName1))
 					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(
-						route1, getRouteCanonicalServiceName(route1))))
+						route1.ObjectMeta.Namespace, getRouteCanonicalServiceName(route1))))
 				})
 
 				It("configures reencrypt routes", func() {
@@ -3258,7 +3258,7 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(len(hostDg[namespace].Records)).To(Equal(1))
 					Expect(hostDg[namespace].Records[0].Name).To(Equal(hostName))
 					Expect(hostDg[namespace].Records[0].Data).To(Equal(formatRoutePoolName(
-						route, getRouteCanonicalServiceName(route))))
+						route.ObjectMeta.Namespace, getRouteCanonicalServiceName(route))))
 
 					customProfiles := mockMgr.customProfiles()
 					// Should be 2 profiles from Spec, 2 defaults (clientssl and serverssl)

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -2805,6 +2805,14 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(resources.PoolCount()).To(Equal(2))
 				mockMgr.deleteService(fooSvc)
 				Expect(resources.PoolCount()).To(Equal(1))
+				// re-add the service and make sure the pool is re-created
+				mockMgr.addService(fooSvc)
+				Expect(resources.PoolCount()).To(Equal(2))
+				// Rename a service to one that doesn't exist, which should cause
+				// removal of its pool.
+				ingress4.Spec.Rules[0].HTTP.Paths[1].Backend.ServiceName = "not-there"
+				mockMgr.updateIngress(ingress4)
+				Expect(resources.PoolCount()).To(Equal(1))
 			})
 
 			It("properly uses the default Ingress IP", func() {
@@ -3514,6 +3522,11 @@ var _ = Describe("AppManager Tests", func() {
 
 					mockMgr.addService(bazSvc)
 					Expect(resources.PoolCount()).To(Equal(3))
+
+					// Rename a service, expect the pool to be removed
+					route.Spec.To.Name = "not-there"
+					mockMgr.updateRoute(route)
+					Expect(resources.PoolCount()).To(Equal(2))
 				})
 
 				It("manages alternate backends for routes (datagroups)", func() {

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -467,7 +467,7 @@ func updateDataGroupForPassthroughRoute(
 ) {
 	hostName := route.Spec.Host
 	svcName := getRouteCanonicalServiceName(route)
-	poolName := formatRoutePoolName(route, svcName)
+	poolName := formatRoutePoolName(route.ObjectMeta.Namespace, svcName)
 	updateDataGroup(dgMap, passthroughHostsDgName,
 		partition, namespace, hostName, poolName)
 }
@@ -481,7 +481,7 @@ func updateDataGroupForReencryptRoute(
 ) {
 	hostName := route.Spec.Host
 	svcName := getRouteCanonicalServiceName(route)
-	poolName := formatRoutePoolName(route, svcName)
+	poolName := formatRoutePoolName(route.ObjectMeta.Namespace, svcName)
 	updateDataGroup(dgMap, reencryptHostsDgName,
 		partition, namespace, hostName, poolName)
 }
@@ -535,7 +535,7 @@ func updateDataGroupForABRoute(
 			}
 			runningWeightTotal = runningWeightTotal + svc.weight
 			weightedSliceThreshold := float64(runningWeightTotal) / float64(weightTotal)
-			pool := formatRoutePoolName(route, svc.name)
+			pool := formatRoutePoolName(route.ObjectMeta.Namespace, svc.name)
 			entry := fmt.Sprintf("%s,%4.3f", pool, weightedSliceThreshold)
 			entries = append(entries, entry)
 		}


### PR DESCRIPTION
Problem:
When Route resources are updated to reference a different service, the
old pools are not cleaned up until the next full refresh cycle. This is
also applicable to Ingress resources.

Solution:
There was no way before this commit to detect that a Route or Ingress
has been updated to reference different services. Now the Resources
object has the ability to track dependencies for Ingress and Route
objects (currently only Service dependencies are tracked), which allows
changes in dependent services to be identified, and pools updated
accordingly.

This commit also contains a bug fix for deleteUnusedResources, fixing
an issue where a policy that contains only 1 rule is deleted regardless
if it is a rule that should be removed for that invocation. That
function was also not protected by the mutex as it should have been so
I added that and also removed the appInf parameter as it was not being
used.

Fixes #471

affects-branches: master