### PR TITLE
Fix version information in documentation

### DIFF
--- a/build-tools/docker-docs.sh
+++ b/build-tools/docker-docs.sh
@@ -13,6 +13,14 @@ RUN_ARGS=( \
   -e TRAVIS=$TRAVIS
 )
 
+if [[ $TRAVIS_BRANCH == *"-stable" ]]; then
+  release="$(git describe --tags --abbrev=0)"
+  RUN_ARGS+=( -e DOCS_RELEASE=$release )
+  va=( ${release//./ } ) # replace decimals and split into array
+  version="${va[0]}.${va[1]}"
+  RUN_ARGS+=( -e DOCS_VERSION=$version )
+fi
+
 # Add -it if caller is a terminal
 if [ -t 0 ]; then
   RUN_ARGS+=( "-it" )

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -10,7 +10,13 @@ BUILDDIR      = _build
 # Internal variables.
 PAPEROPT_a4     = -D latex_paper_size=a4
 PAPEROPT_letter = -D latex_paper_size=letter
-ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
+ALLSPHINXOPTS   = 
+ifdef DOCS_RELEASE
+  ifdef DOCS_VERSION
+    ALLSPHINXOPTS += -D release=$(DOCS_RELEASE) -D version=$(DOCS_VERSION)
+  endif
+endif
+ALLSPHINXOPTS   += -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -19,8 +19,6 @@
 #
 import os
 import sys
-import subprocess
-import re
 
 sys.path.insert(0, os.path.abspath('.'))
 sys.path.insert(0, os.path.abspath('../'))
@@ -80,24 +78,12 @@ author = u'F5 Networks'
 # |version| and |release|, also used in various other places throughout the
 # built documents.
 #
-git_branch = subprocess.check_output(['git', 'rev-parse', '--symbolic-full-name', '--abbrev-ref', 'HEAD']).strip()
-is_stable = re.search(r'^(\d+\.\d+)-stable$', git_branch)
-if is_stable:
-    # For stable branches, use the latest git tag to determine docs version.
-    v = subprocess.check_output(['git', 'describe', '--tags', '--abbrev=0']).strip().split('.')
+with open('../next-version.txt') as verfile:
+    v = verfile.readline().strip().split('.')
     # The short X.Y version.
-    version = u'{}.{}'.format(v[0], v[1])
+    version = u'v{}.{}'.format(v[0], v[1])
     # The full version, including alpha/beta/rc tags.
-    release = u'{}.{}.{}'.format(v[0], v[1], v[2])
-else:
-    # For non-stable branches, use the information in the next-version.txt file to determine docs version.
-    # Note: we don't currently push docs from non-stable versions to clouddocs.
-    with open('../next-version.txt') as verfile:
-        v = verfile.readline().strip().split('.')
-        # The short X.Y version.
-        version = u'v{}.{}'.format(v[0], v[1])
-        # The full version, including alpha/beta/rc tags.
-        release = u'v{}.{}.{}-dev'.format(v[0], v[1], v[2])
+    release = u'v{}.{}.{}-dev'.format(v[0], v[1], v[2])
 
 # def setup(app):
 #    app.add_config_value('versionlevel', '', 'env')


### PR DESCRIPTION
Problem:
The previous fix to extract docs version information relied on
git commands running in the containthedocs environment which
was failing and always going through the non-stable branch
path.

Solution:
Extract the docs version information in the same way as the previous
fix, but prior to running the containthedocs container. In the
docs Makefile, use these release related variables (if set) to
override the ones in the Sphinx config file.

Testing:
Ran the following commands with various values for TRAVIS_BRANCH
to test the functionality:
./build-tools/docker-docs.sh # from dev-machine
./build-tools/make-docs.sh   # from containthedocs shell

Now, browse docs/_build to ensure the generated docs have
the version string to meet the expectation as set by TRAVIS_BRANCH.