### PR TITLE
Enable 'go vet' checking during verify step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ prod: prod-build
 
 debug: dbg-build
 
-verify: fmt
+verify: fmt vet
 
 docs: _docs
 
@@ -89,6 +89,10 @@ dbg-build: pre-build
 fmt:
 	@echo "Enforcing code formatting using 'go fmt'..."
 	$(CURDIR)/build-tools/fmt.sh
+
+vet:
+	@echo "Running 'go vet'..."
+	$(CURDIR)/build-tools/vet.sh
 
 devel-image:
 	BASE_OS=$(BASE_OS) ./build-tools/build-devel-image.sh

--- a/build-tools/vet.sh
+++ b/build-tools/vet.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -x
+set -e
+
+go tool vet -all -shadow ./cmd ./pkg
+
+exit $?

--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -560,7 +560,8 @@ func main() {
 	subPid := <-subPidCh
 	defer func(pid int) {
 		if 0 != pid {
-			proc, err := os.FindProcess(pid)
+			var proc *os.Process
+			proc, err = os.FindProcess(pid)
 			if nil != err {
 				log.Warningf("Failed to find sub-process on exit: %v", err)
 			}

--- a/cmd/k8s-bigip-ctlr/main_test.go
+++ b/cmd/k8s-bigip-ctlr/main_test.go
@@ -440,8 +440,8 @@ var _ = Describe("Main Tests", func() {
 		err := verifyArgs()
 		Expect(err).To(BeNil())
 
-		fake := fake.NewSimpleClientset()
-		Expect(fake).ToNot(BeNil(), "Mock client cannot be nil.")
+		fakeClient := fake.NewSimpleClientset()
+		Expect(fakeClient).ToNot(BeNil(), "Mock client cannot be nil.")
 
 		configWriter := &test.MockWriter{
 			FailStyle: test.Success,
@@ -455,7 +455,7 @@ var _ = Describe("Main Tests", func() {
 		Expect(nodePoller).ToNot(BeNil(), "Mock poller cannot be nil.")
 
 		vsm := appmanager.NewManager(&appmanager.Params{
-			KubeClient:   fake,
+			KubeClient:   fakeClient,
 			ConfigWriter: configWriter,
 		})
 		err = setupNodePolling(vsm, nodePoller, nil, nil)

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -344,7 +344,7 @@ func (m *mockAppManager) startLabelMode(nsLabel string) error {
 	nsSelector, err := labels.Parse(m.nsLabel)
 	if nil != err {
 		return fmt.Errorf(
-			"Failed to create namespace selector for label %v", nsLabel, err)
+			"Failed to create namespace selector for label %v: %v", nsLabel, err)
 	}
 	err = m.appMgr.AddNamespaceLabelInformer(nsSelector, 0)
 	if nil != err {
@@ -843,9 +843,9 @@ var _ = Describe("AppManager Tests", func() {
 
 			expectedNodes := []*v1.Node{
 				test.NewNode("node0", "0", true, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.0"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
 				test.NewNode("node1", "1", false, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.1"}},
+					{Type: "ExternalIP", Address: "127.0.0.1"}},
 					[]v1.Taint{
 						{
 							Key:    "node-role.kubernetes.io/worker",
@@ -853,7 +853,7 @@ var _ = Describe("AppManager Tests", func() {
 						},
 					}),
 				test.NewNode("node2", "2", false, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.2"}},
+					{Type: "ExternalIP", Address: "127.0.0.2"}},
 					[]v1.Taint{
 						{
 							Key:    "node-role.kubernetes.io/worker",
@@ -861,7 +861,7 @@ var _ = Describe("AppManager Tests", func() {
 						},
 					}),
 				test.NewNode("node3", "3", false, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.3"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}),
 			}
 
 			expectedReturn := []string{
@@ -891,9 +891,9 @@ var _ = Describe("AppManager Tests", func() {
 			// Existing Node data
 			expectedNodes := []*v1.Node{
 				test.NewNode("node0", "0", true, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.0"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
 				test.NewNode("node1", "1", false, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.1"}},
+					{Type: "ExternalIP", Address: "127.0.0.1"}},
 					[]v1.Taint{
 						{
 							Key:    "node-role.kubernetes.io/worker",
@@ -901,15 +901,15 @@ var _ = Describe("AppManager Tests", func() {
 						},
 					}),
 				test.NewNode("node2", "2", false, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.2"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
 				test.NewNode("node3", "3", false, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.3"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}),
 				test.NewNode("node4", "4", false, []v1.NodeAddress{
-					{"InternalIP", "127.0.0.4"}}, []v1.Taint{}),
+					{Type: "InternalIP", Address: "127.0.0.4"}}, []v1.Taint{}),
 				test.NewNode("node5", "5", false, []v1.NodeAddress{
-					{"Hostname", "127.0.0.5"}}, []v1.Taint{}),
+					{Type: "Hostname", Address: "127.0.0.5"}}, []v1.Taint{}),
 				test.NewNode("node6", "6", false, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.6"}},
+					{Type: "ExternalIP", Address: "127.0.0.6"}},
 					[]v1.Taint{
 						{
 							Key:    "node-role.kubernetes.io/worker",
@@ -951,7 +951,7 @@ var _ = Describe("AppManager Tests", func() {
 			Expect(addresses).To(Equal(expectedInternal))
 
 			for _, node := range expectedNodes {
-				err := fakeClient.Core().Nodes().Delete(node.ObjectMeta.Name,
+				err = fakeClient.Core().Nodes().Delete(node.ObjectMeta.Name,
 					&metav1.DeleteOptions{})
 				Expect(err).To(BeNil(), "Should not fail deleting node.")
 			}
@@ -968,19 +968,19 @@ var _ = Describe("AppManager Tests", func() {
 		It("should process node updates", func() {
 			originalSet := []v1.Node{
 				*test.NewNode("node0", "0", true, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.0"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
 				*test.NewNode("node1", "1", false, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.1"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
 				*test.NewNode("node2", "2", false, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.2"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
 				*test.NewNode("node3", "3", false, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.3"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}),
 				*test.NewNode("node4", "4", false, []v1.NodeAddress{
-					{"InternalIP", "127.0.0.4"}}, []v1.Taint{}),
+					{Type: "InternalIP", Address: "127.0.0.4"}}, []v1.Taint{}),
 				*test.NewNode("node5", "5", false, []v1.NodeAddress{
-					{"Hostname", "127.0.0.5"}}, []v1.Taint{}),
+					{Type: "Hostname", Address: "127.0.0.5"}}, []v1.Taint{}),
 				*test.NewNode("node6", "6", false, []v1.NodeAddress{
-					{"ExternalIP", "127.0.0.6"}},
+					{Type: "ExternalIP", Address: "127.0.0.6"}},
 					[]v1.Taint{
 						{
 							Key:    "node-role.kubernetes.io/worker",
@@ -1025,11 +1025,11 @@ var _ = Describe("AppManager Tests", func() {
 
 			// add some nodes
 			_, err = fakeClient.Core().Nodes().Create(test.NewNode("nodeAdd", "nodeAdd", false,
-				[]v1.NodeAddress{{"ExternalIP", "127.0.0.6"}}, []v1.Taint{}))
+				[]v1.NodeAddress{{Type: "ExternalIP", Address: "127.0.0.6"}}, []v1.Taint{}))
 			Expect(err).To(BeNil(), "Create should not return err.")
 
 			_, err = fakeClient.Core().Nodes().Create(test.NewNode("nodeExclude", "nodeExclude",
-				true, []v1.NodeAddress{{"InternalIP", "127.0.0.7"}}, []v1.Taint{}))
+				true, []v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.7"}}, []v1.Taint{}))
 
 			appMgr.useNodeInternal = false
 			nodes, err = fakeClient.Core().Nodes().List(metav1.ListOptions{})
@@ -1206,11 +1206,11 @@ var _ = Describe("AppManager Tests", func() {
 
 				nodeSet := []v1.Node{
 					*test.NewNode("node0", "0", false, []v1.NodeAddress{
-						{"InternalIP", "127.0.0.0"}}, []v1.Taint{}),
+						{Type: "InternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
 					*test.NewNode("node1", "1", false, []v1.NodeAddress{
-						{"InternalIP", "127.0.0.1"}}, []v1.Taint{}),
+						{Type: "InternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
 					*test.NewNode("node2", "2", false, []v1.NodeAddress{
-						{"InternalIP", "127.0.0.2"}}, []v1.Taint{}),
+						{Type: "InternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
 				}
 
 				mockMgr.processNodeUpdate(nodeSet, nil)
@@ -1322,14 +1322,14 @@ var _ = Describe("AppManager Tests", func() {
 					[]v1.ServicePort{{Port: 80, NodePort: 37001}})
 				nodes := []*v1.Node{
 					test.NewNode("node0", "0", true, []v1.NodeAddress{
-						{"ExternalIP", "127.0.0.0"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
 					test.NewNode("node1", "1", false, []v1.NodeAddress{
-						{"ExternalIP", "127.0.0.1"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
 					test.NewNode("node2", "2", false, []v1.NodeAddress{
-						{"ExternalIP", "127.0.0.2"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
 				}
 				extraNode := test.NewNode("node3", "3", false,
-					[]v1.NodeAddress{{"ExternalIP", "127.0.0.3"}}, []v1.Taint{})
+					[]v1.NodeAddress{{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
 
 				nodeCh := make(chan struct{})
 				mapCh := make(chan struct{})
@@ -1586,14 +1586,14 @@ var _ = Describe("AppManager Tests", func() {
 					[]v1.ServicePort{{Port: 80, NodePort: 37001}})
 				nodes := []v1.Node{
 					*test.NewNode("node0", "0", true, []v1.NodeAddress{
-						{"ExternalIP", "127.0.0.0"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
 					*test.NewNode("node1", "1", false, []v1.NodeAddress{
-						{"ExternalIP", "127.0.0.1"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
 					*test.NewNode("node2", "2", false, []v1.NodeAddress{
-						{"ExternalIP", "127.0.0.2"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
 				}
 				extraNode := test.NewNode("node3", "3", false,
-					[]v1.NodeAddress{{"ExternalIP", "127.0.0.3"}}, []v1.Taint{})
+					[]v1.NodeAddress{{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
 
 				addrs := []string{"127.0.0.1", "127.0.0.2"}
 
@@ -1889,7 +1889,7 @@ var _ = Describe("AppManager Tests", func() {
 				wrongNamespace := "wrongnamespace"
 
 				node := test.NewNode("node3", "3", false,
-					[]v1.NodeAddress{{"InternalIP", "127.0.0.3"}}, []v1.Taint{})
+					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
 				_, err := mockMgr.appMgr.kubeClient.Core().Nodes().Create(node)
 				Expect(err).To(BeNil())
 				n, err := mockMgr.appMgr.kubeClient.Core().Nodes().List(metav1.ListOptions{})
@@ -1991,16 +1991,16 @@ var _ = Describe("AppManager Tests", func() {
 					[]v1.ServicePort{{Port: 80, NodePort: 20202}})
 				nodes := []v1.Node{
 					*test.NewNode("node0", "0", true, []v1.NodeAddress{
-						{"InternalIP", "192.168.0.0"}}, []v1.Taint{}),
+						{Type: "InternalIP", Address: "192.168.0.0"}}, []v1.Taint{}),
 					*test.NewNode("node1", "1", false, []v1.NodeAddress{
-						{"InternalIP", "192.168.0.1"}}, []v1.Taint{}),
+						{Type: "InternalIP", Address: "192.168.0.1"}}, []v1.Taint{}),
 					*test.NewNode("node2", "2", false, []v1.NodeAddress{
-						{"InternalIP", "192.168.0.2"}}, []v1.Taint{}),
+						{Type: "InternalIP", Address: "192.168.0.2"}}, []v1.Taint{}),
 					*test.NewNode("node3", "3", false, []v1.NodeAddress{
-						{"ExternalIP", "192.168.0.3"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "192.168.0.3"}}, []v1.Taint{}),
 				}
-				extraNode := test.NewNode("node4", "4", false, []v1.NodeAddress{{"InternalIP",
-					"192.168.0.4"}}, []v1.Taint{})
+				extraNode := test.NewNode("node4", "4", false, []v1.NodeAddress{
+					{Type: "InternalIP", Address: "192.168.0.4"}}, []v1.Taint{})
 
 				addrs := []string{"192.168.0.1", "192.168.0.2"}
 
@@ -3813,7 +3813,7 @@ var _ = Describe("AppManager Tests", func() {
 				err := mockMgr.startNonLabelMode([]string{ns1, ns2})
 				Expect(err).To(BeNil())
 				node := test.NewNode("node1", "1", false,
-					[]v1.NodeAddress{{"InternalIP", "127.0.0.3"}}, []v1.Taint{})
+					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
 				_, err = mockMgr.appMgr.kubeClient.Core().Nodes().Create(node)
 				Expect(err).To(BeNil())
 				n, err := mockMgr.appMgr.kubeClient.Core().Nodes().List(metav1.ListOptions{})
@@ -3943,7 +3943,7 @@ var _ = Describe("AppManager Tests", func() {
 				ns3 := test.NewNamespace("ns3", "1", map[string]string{nsLabel: "yes"})
 
 				node := test.NewNode("node1", "1", false,
-					[]v1.NodeAddress{{"InternalIP", "127.0.0.3"}}, []v1.Taint{})
+					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
 				_, err = mockMgr.appMgr.kubeClient.Core().Nodes().Create(node)
 				Expect(err).To(BeNil())
 				n, err := mockMgr.appMgr.kubeClient.Core().Nodes().List(metav1.ListOptions{})
@@ -4087,7 +4087,7 @@ var _ = Describe("AppManager Tests", func() {
 				mockMgr.appMgr.useNodeInternal = true
 				nodeSet := []v1.Node{
 					*test.NewNode("node0", "0", false, []v1.NodeAddress{
-						{"InternalIP", "127.0.0.0"}}, []v1.Taint{}),
+						{Type: "InternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
 				}
 				mockMgr.processNodeUpdate(nodeSet, nil)
 

--- a/pkg/appmanager/profiles.go
+++ b/pkg/appmanager/profiles.go
@@ -243,7 +243,7 @@ func (appMgr *Manager) handleServerSslProfileAnnotation(
 		Namespace: sKey.Namespace,
 	}
 	updated := false
-	if updated := rsCfg.Virtual.AddOrUpdateProfile(profile); updated {
+	if updated = rsCfg.Virtual.AddOrUpdateProfile(profile); updated {
 		// Store this annotated profile in the metadata for future reference
 		// if it gets deleted.
 		rKey := routeKey{

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -388,10 +388,10 @@ type CustomProfileStore struct {
 }
 
 // Contructor for CustomProfiles
-func NewCustomProfiles() CustomProfileStore {
+func NewCustomProfiles() *CustomProfileStore {
 	var cps CustomProfileStore
 	cps.profs = make(map[secretKey]CustomProfile)
-	return cps
+	return &cps
 }
 
 // Key is resource name, value is unused (since go doesn't have set objects).
@@ -1118,12 +1118,12 @@ func createRSConfigFromIngress(
 func createRSConfigFromRoute(
 	route *routeapi.Route,
 	svcName string,
-	resources Resources,
+	resources *Resources,
 	routeConfig RouteConfig,
 	pStruct portStruct,
 	svcIndexer cache.Indexer,
 	svcFwdRulesMap ServiceFwdRuleMap,
-) (ResourceConfig, error, Pool) {
+) (*ResourceConfig, error, Pool) {
 	var rsCfg ResourceConfig
 	rsCfg.MetaData.RouteProfs = make(map[routeKey]string)
 	var policyName, rsName string
@@ -1174,7 +1174,7 @@ func createRSConfigFromRoute(
 	rule, err := createRule(uri, pool.Name, pool.Partition, formatRouteRuleName(route))
 	if nil != err {
 		err = fmt.Errorf("Error configuring rule for Route %s: %v", route.ObjectMeta.Name, err)
-		return rsCfg, err, Pool{}
+		return &rsCfg, err, Pool{}
 	}
 
 	resources.Lock()
@@ -1217,7 +1217,7 @@ func createRSConfigFromRoute(
 	rsCfg.HandleRouteTls(route, pStruct.protocol, policyName, rule,
 		svcFwdRulesMap, abDeployment)
 
-	return rsCfg, nil, pool
+	return &rsCfg, nil, pool
 }
 
 // Copies from an existing config into our new config

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -227,7 +227,7 @@ var _ = Describe("Resource Config Tests", func() {
 
 		It("creates new resources", func() {
 			// Test that we can create a new/empty resources object.
-			rs := NewResources()
+			rs = NewResources()
 			Expect(rs).ToNot(BeNil())
 			Expect(rs.rm).ToNot(BeNil())
 		})
@@ -678,7 +678,7 @@ var _ = Describe("Resource Config Tests", func() {
 			}
 			svcFwdRulesMap := NewServiceFwdRuleMap()
 			cfg, _, _ := createRSConfigFromRoute(route, getRouteCanonicalServiceName(route),
-				Resources{}, rc, ps, nil, svcFwdRulesMap)
+				&Resources{}, rc, ps, nil, svcFwdRulesMap)
 			Expect(cfg.Virtual.Name).To(Equal("https-ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_foo"))
 			Expect(cfg.Pools[0].ServiceName).To(Equal("foo"))
@@ -703,7 +703,7 @@ var _ = Describe("Resource Config Tests", func() {
 				port:     80,
 			}
 			cfg, _, _ = createRSConfigFromRoute(route2, getRouteCanonicalServiceName(route2),
-				Resources{}, rc, ps, nil, svcFwdRulesMap)
+				&Resources{}, rc, ps, nil, svcFwdRulesMap)
 			Expect(cfg.Virtual.Name).To(Equal("ose-vserver"))
 			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_bar"))
 			Expect(cfg.Pools[0].ServiceName).To(Equal("bar"))

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -72,7 +72,7 @@ type (
 	Virtual struct {
 		Name                  string                `json:"name"`
 		PoolName              string                `json:"pool,omitempty"`
-		Partition             string                `-"`
+		Partition             string                `json:"-"`
 		Destination           string                `json:"destination"`
 		Enabled               bool                  `json:"enabled"`
 		IpProtocol            string                `json:"ipProtocol,omitempty"`
@@ -158,7 +158,7 @@ type (
 	// action config for a Rule
 	action struct {
 		Name      string `json:"name"`
-		Pool      string `json:"pool",omitempty"`
+		Pool      string `json:"pool,omitempty"`
 		HttpReply bool   `json:"httpReply,omitempty"`
 		Forward   bool   `json:"forward,omitempty"`
 		Location  string `json:"location,omitempty"`

--- a/pkg/pollers/nodePoller_test.go
+++ b/pkg/pollers/nodePoller_test.go
@@ -184,10 +184,10 @@ var _ = Describe("Node Poller Tests", func() {
 	}
 
 	It("starts and stops", func() {
-		fake := fake.NewSimpleClientset()
-		Expect(fake).ToNot(BeNil(), "Mock client cannot be nil.")
+		fakeClient := fake.NewSimpleClientset()
+		Expect(fakeClient).ToNot(BeNil(), "Mock client cannot be nil.")
 
-		np := NewNodePoller(fake, 1*time.Millisecond, "")
+		np := NewNodePoller(fakeClient, 1*time.Millisecond, "")
 		Expect(np).ToNot(BeNil(), "Node poller cannot be nil.")
 
 		err := np.Run()
@@ -284,10 +284,10 @@ var _ = Describe("Node Poller Tests", func() {
 	})
 
 	It("registers properly while stopped", func() {
-		fake := fake.NewSimpleClientset()
-		Expect(fake).ToNot(BeNil(), "Mock client cannot be nil.")
+		fakeClient := fake.NewSimpleClientset()
+		Expect(fakeClient).ToNot(BeNil(), "Mock client cannot be nil.")
 
-		np := NewNodePoller(fake, 1*time.Millisecond, "")
+		np := NewNodePoller(fakeClient, 1*time.Millisecond, "")
 		Expect(np).ToNot(BeNil(), "Node poller cannot be nil.")
 
 		calls := []bool{false, false, false, false, false}

--- a/pkg/pollers/nodePoller_test.go
+++ b/pkg/pollers/nodePoller_test.go
@@ -82,25 +82,25 @@ var _ = Describe("Node Poller Tests", func() {
 	initTestData := func(nodeLabelSelector string) (Poller, []nodeData) {
 		addressList := [][]v1.NodeAddress{
 			{
-				{"ExternalIP", "127.0.0.0"},
+				{Type: "ExternalIP", Address: "127.0.0.0"},
 			},
 			{
-				{"ExternalIP", "127.0.0.1"},
-				{"InternalIP", "127.1.0.1"},
+				{Type: "ExternalIP", Address: "127.0.0.1"},
+				{Type: "InternalIP", Address: "127.1.0.1"},
 			},
 			{
-				{"ExternalIP", "127.0.0.2"},
-				{"InternalIP", "127.1.0.2"},
+				{Type: "ExternalIP", Address: "127.0.0.2"},
+				{Type: "InternalIP", Address: "127.1.0.2"},
 			},
 			{
-				{"ExternalIP", "127.0.0.3"},
-				{"InternalIP", "127.1.0.3"},
+				{Type: "ExternalIP", Address: "127.0.0.3"},
+				{Type: "InternalIP", Address: "127.1.0.3"},
 			},
 			{
-				{"InternalIP", "127.0.0.4"},
+				{Type: "InternalIP", Address: "127.0.0.4"},
 			},
 			{
-				{"Hostname", "127.0.0.5"},
+				{Type: "Hostname", Address: "127.0.0.5"},
 			},
 		}
 
@@ -330,7 +330,7 @@ var _ = Describe("Node Poller Tests", func() {
 		}
 
 		for i := range calls[5:] {
-			err := np.RegisterListener(func(index int) PollListener {
+			err = np.RegisterListener(func(index int) PollListener {
 				var p PollListener = func(obj interface{}, err error) {
 					if false == calls[index] {
 						calls[index] = true

--- a/pkg/vxlan/vxlanMgr.go
+++ b/pkg/vxlan/vxlanMgr.go
@@ -124,7 +124,8 @@ func (vxm *VxlanMgr) ProcessNodeUpdate(obj interface{}, err error) {
 		}
 		// Will only exist in Flannel/Kubernetes
 		if atn, ok := node.ObjectMeta.Annotations["flannel.alpha.coreos.com/backend-data"]; ok {
-			mac, err := parseVtepMac(atn, node.ObjectMeta.Name)
+			var mac string
+			mac, err = parseVtepMac(atn, node.ObjectMeta.Name)
 			if nil != err {
 				log.Errorf("%v", err)
 			} else if rec.Endpoint != "" {
@@ -208,7 +209,8 @@ func (vxm *VxlanMgr) addArpForPods(pods interface{}, kubeClient kubernetes.Inter
 		return
 	}
 	for _, pod := range pods.([]appmanager.Member) {
-		mac, err := getVtepMac(pod, kubePods, kubeNodes)
+		var mac string
+		mac, err = getVtepMac(pod, kubePods, kubeNodes)
 		if nil != err {
 			log.Errorf("%v", err)
 			return

--- a/pkg/vxlan/vxlanMgr_test.go
+++ b/pkg/vxlan/vxlanMgr_test.go
@@ -59,25 +59,25 @@ func newNode(
 func getNodeList() []v1.Node {
 	nodes := []v1.Node{
 		*newNode("node0", "0", true, []v1.NodeAddress{
-			{"ExternalIP", "127.0.0.0"}}, nil),
+			{Type: "ExternalIP", Address: "127.0.0.0"}}, nil),
 		*newNode("node1", "1", false, []v1.NodeAddress{
-			{"ExternalIP", "127.0.0.1"}}, nil),
+			{Type: "ExternalIP", Address: "127.0.0.1"}}, nil),
 		*newNode("node2", "2", false, []v1.NodeAddress{
-			{"ExternalIP", "127.0.0.2"},
-			{"InternalIP", "127.1.1.2"}}, nil),
+			{Type: "ExternalIP", Address: "127.0.0.2"},
+			{Type: "InternalIP", Address: "127.1.1.2"}}, nil),
 		*newNode("node3", "3", false, []v1.NodeAddress{
-			{"ExternalIP", "127.0.0.3"}}, nil),
+			{Type: "ExternalIP", Address: "127.0.0.3"}}, nil),
 		*newNode("node4", "4", false, []v1.NodeAddress{
-			{"InternalIP", "127.0.0.4"}}, nil),
+			{Type: "InternalIP", Address: "127.0.0.4"}}, nil),
 		*newNode("node5", "5", false, []v1.NodeAddress{
-			{"Hostname", "127.0.0.5"},
-			{"InternalIP", "127.1.1.5"}}, nil),
+			{Type: "Hostname", Address: "127.0.0.5"},
+			{Type: "InternalIP", Address: "127.1.1.5"}}, nil),
 		*newNode("node6", "6", true, []v1.NodeAddress{
-			{"ExternalIP", "127.0.0.6"}}, nil),
+			{Type: "ExternalIP", Address: "127.0.0.6"}}, nil),
 		*newNode("node7", "7", false, []v1.NodeAddress{
-			{"InternalIP", "127.0.0.7"}}, nil),
+			{Type: "InternalIP", Address: "127.0.0.7"}}, nil),
 		*newNode("node8", "8", false, []v1.NodeAddress{
-			{"Hostname", "127.0.0.8"}}, nil),
+			{Type: "Hostname", Address: "127.0.0.8"}}, nil),
 	}
 
 	return nodes
@@ -236,7 +236,7 @@ var _ = Describe("VxlanMgr Tests", func() {
 			"flannel.alpha.coreos.com/backend-data": "{\"VtepMAC\":\"12:ab:34:cd:56:ef\"}",
 		}
 		flannelNode := *newNode("flannelNode", "9", false,
-			[]v1.NodeAddress{{"InternalIP", "127.0.0.10"}}, annotations)
+			[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.10"}}, annotations)
 
 		expected = fdbSection{
 			TunnelName: "vxlan500",
@@ -325,7 +325,7 @@ var _ = Describe("VxlanMgr Tests", func() {
 			"flannel.alpha.coreos.com/public-ip":    "127.0.0.10",
 		}
 		flannelNode := *newNode("flannelNode", "9", false,
-			[]v1.NodeAddress{{"InternalIP", "127.0.0.10"}}, annotations)
+			[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.10"}}, annotations)
 		flannelPod := &v1.Pod{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "Pod",

--- a/pkg/writer/configWriter_test.go
+++ b/pkg/writer/configWriter_test.go
@@ -190,7 +190,7 @@ var _ = Describe("Config Writer Tests", func() {
 
 		AfterEach(func() {
 			cw.Stop()
-			_, err := os.Stat(f)
+			_, err = os.Stat(f)
 			Expect(os.IsExist(err)).To(BeFalse())
 		})
 


### PR DESCRIPTION
Problem:
Improve code verifications with 'go vet'

Solution:
Added a new make file step (make vet) and added the 'vet' target to the
existing verify step. Also fixed all of the current problems identified.

"go vet" has all standard checks enabled (using the -all flag), as well
as the experimental flag -shadow which is very useful to help find
problems due to shadowed variables.

Fixes VEL-1291

affects-branches: master