### PR TITLE
Fix unit tests to use correct Health Monitor parameters

### DIFF
--- a/python/tests/kubernetes_one_svc_two_nodes.json
+++ b/python/tests/kubernetes_one_svc_two_nodes.json
@@ -10,14 +10,14 @@
                     "interval": 30,
                     "name": "default_configmap_0_tcp",
                     "send": "GET /",
-                    "timeout": 20,
+                    "timeout": 40,
                     "type": "tcp"
                 },
                 {
                     "interval": 10,
                     "name": "default_configmap_1_0_http",
                     "send": "GET /",
-                    "timeout": 5,
+                    "timeout": 15,
                     "type": "http"
                 }
             ],

--- a/python/tests/kubernetes_one_svc_two_nodes_expected.json
+++ b/python/tests/kubernetes_one_svc_two_nodes_expected.json
@@ -9,14 +9,14 @@
                 "interval": 30,
                 "name": "default_configmap_0_tcp",
                 "send": "GET /",
-                "timeout": 20,
+                "timeout": 40,
                 "type": "tcp"
             },
             {
                 "interval": 10,
                 "name": "default_configmap_1_0_http",
                 "send": "GET /",
-                "timeout": 5,
+                "timeout": 15,
                 "type": "http"
             }
         ],

--- a/python/tests/kubernetes_one_udp_svc_two_nodes.json
+++ b/python/tests/kubernetes_one_udp_svc_two_nodes.json
@@ -10,7 +10,7 @@
                     "interval": 30,
                     "name": "default_configmap_0_udp",
                     "send": "GET /",
-                    "timeout": 20,
+                    "timeout": 40,
                     "type": "udp"
                 }
             ],

--- a/python/tests/kubernetes_one_udp_svc_two_nodes_expected.json
+++ b/python/tests/kubernetes_one_udp_svc_two_nodes_expected.json
@@ -9,7 +9,7 @@
                 "interval": 30,
                 "name": "default_configmap_0_udp",
                 "send": "GET /",
-                "timeout": 20,
+                "timeout": 40,
                 "type": "udp"
             }
         ],


### PR DESCRIPTION
CCCL now enforces the relationship that the Health Monitor interval must
be less than the timeout