### PR TITLE
Add retry backoff for recoverable start up errors.

### DIFF
--- a/python/tests/test_bigipconfigdriver.py
+++ b/python/tests/test_bigipconfigdriver.py
@@ -486,9 +486,6 @@ def test_parse_config(request):
 
         handler = bigipconfigdriver.ConfigHandler(config_file, [mgr], 30)
 
-        r = bigipconfigdriver._parse_config(config_file)
-        assert r is None
-
         obj = {}
         obj['field1'] = 'one'
         obj['field_string'] = 'string'


### PR DESCRIPTION
Problem:
 The bigipconfigdriver could encounter errors on start up that are
 recoverable but are currently fatal if encountered.

Solution:
 If the bigipconfigdriver encounters BIG-IP connection erros or missing
 config file errors (since these are written out by the controllers) it
 will now log these errors and enter a retry backoff loop until
 recovered.

Fixes: #510