### PR TITLE
Fix an issue with vserver getting port 0

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,6 +1,13 @@
 Release Notes for BIG-IP Controller for Kubernetes
 ==================================================
 
+v1.4.2
+------
+
+Bug Fixes
+`````````
+* :issues:`549` - Using IP annotation on ConfigMaps would result in the virtual server getting a port of 0.
+
 v1.4.1
 ------
 

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -2159,6 +2159,14 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(rs.Virtual.VirtualAddress.BindAddr).To(Equal(""))
 				Expect(rs.Virtual.VirtualAddress.Port).To(Equal(int32(10000)))
 
+				// Add ip annotation
+				noBindAddr.ObjectMeta.Annotations[f5VsBindAddrAnnotation] = "1.2.3.4"
+				mockMgr.updateConfigMap(noBindAddr)
+				rs, _ = resources.Get(
+					serviceKey{"foo", 80, namespace}, formatConfigMapVSName(noBindAddr))
+				Expect(rs.Virtual.VirtualAddress.BindAddr).To(Equal("1.2.3.4"))
+				Expect(rs.Virtual.VirtualAddress.Port).To(Equal(int32(10000)))
+
 				mockMgr.deleteConfigMap(noBindAddr)
 			}
 

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -844,7 +844,7 @@ func parseConfigMap(cm *v1.ConfigMap, schemaDBPath string) (*ResourceConfig, err
 					} else if cfg.Virtual.VirtualAddress.BindAddr == "" {
 						// Check for IP annotation provided by IPAM system
 						if addr, ok := cm.ObjectMeta.Annotations[f5VsBindAddrAnnotation]; ok == true {
-							cfg.Virtual.SetVirtualAddress(addr, 0)
+							cfg.Virtual.SetVirtualAddress(addr, cfg.Virtual.VirtualAddress.Port)
 						} else {
 							log.Infof("No virtual IP was specified for the virtual server %s creating pool only.", cm.ObjectMeta.Name)
 						}

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -124,6 +124,7 @@ func NewConfigMap(id, rv, namespace string,
 			Name:            id,
 			ResourceVersion: rv,
 			Namespace:       namespace,
+			Annotations:     make(map[string]string),
 		},
 		Data: keys,
 	}


### PR DESCRIPTION
Problem: When using the IP annotation for a ConfigMap, the virtual server was mistakenly being set
to 0.

Solution: Use the port from the provided ConfigMap, instead of 0.

Fixes #549 