### PR TITLE
Tight loop in vxlan manager causes high CPU usage

### DIFF
--- a/pkg/vxlan/vxlanMgr.go
+++ b/pkg/vxlan/vxlanMgr.go
@@ -189,7 +189,6 @@ func (vxm *VxlanMgr) ProcessAppmanagerEvents(kubeClient kubernetes.Interface) {
 				} else {
 					log.Errorf("Vxlan Manager could not read Endpoints from appManager channel.")
 				}
-			default:
 			}
 		}
 	}()


### PR DESCRIPTION
Problem:
High CPU usage when controller should be idling with no orchestration
changes

Solution:
The vxlan manager consumer should not use a default select case for the
channel read. This allows the process to tight loop when no reads are
available. It is OK to block on this read.

This should be cherry-picked back to 1.4 branch

Fixes #555