### PR TITLE
Clarify persistence of iApp limitations

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -61,6 +61,7 @@ Limitations
   - `Download and install the latest iApps templates`_.
   - `Set the service to use the newer iApp template`_.
 
+* Check BIG-IP version compatibility on Application Services (iApps) before deploying. See Application Services Integration iApp `[#16] <https://github.com/F5Networks/f5-application-services-integration-iApp/issues/16>`_ for more information.
 * Cannot delete ARP entries on BIG-IP v11.6.1 when running the Controller in Kubernetes with Flannel VXLAN enabled.
 * The controller will exit at startup if it cannot establish a connection with the BIG-IP.
 


### PR DESCRIPTION
Problem:
Some iApps have limitations that prevent deployment by the controller - e.g. the Application Services Integration iApp is not compatible with BIG-IP > 12.1.1. Nightly regressions skip BIG-IP / Controller combinations that exceed these limitations and the documentation is not explicit.

Solution:
Add a base limitation to the release notes.

See https://github.com/F5Networks/f5-application-services-integration-iApp/issues/16