### PR TITLE
Update k8s-bigip-ctlr deployment

### DIFF
--- a/docs/_static/config_examples/sample-k8s-bigip-ctlr-secrets.yaml
+++ b/docs/_static/config_examples/sample-k8s-bigip-ctlr-secrets.yaml
@@ -1,17 +1,26 @@
 # Sample configuration for k8s-bigip-ctlr. BIG-IP configuration is pulled
 # from the secret store and passed to the controller.
-apiVersion: extensions/v1beta1
+# for Kubernetes 1.9 use apps/v1 see https://kubernetes.io/docs/reference/workloads-18-19
+apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
   name: k8s-bigip-ctlr
   namespace: kube-system
+  labels:
+    app: k8s-bigip-ctlr
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: k8s-bigip-ctlr
   template:
     metadata:
       name: k8s-bigip-ctlr
       labels:
         app: k8s-bigip-ctlr
+      annotations:
+        prometheus.io/scrape: "true"
+        prometheus.io/port: "8080"
     spec:
       serviceAccountName: bigip-ctlr-serviceaccount
       containers:
@@ -22,19 +31,19 @@ spec:
             # Get sensitive values from the bigip-credentials secret
             - name: BIGIP_USERNAME
               valueFrom:
-              secretKeyRef:
-                name: bigip-credentials
-                key: username
+                secretKeyRef:
+                  name: bigip-credentials
+                  key: username
             - name: BIGIP_PASSWORD
               valueFrom:
-              secretKeyRef:
-                name: bigip-credentials
-                key: password
+                secretKeyRef:
+                  name: bigip-credentials
+                  key: password
             - name: BIGIP_URL
               valueFrom:
-              secretKeyRef:
-                name: bigip-credentials
-                key: url
+                secretKeyRef:
+                  name: bigip-credentials
+                  key: url
           command: ["/app/bin/k8s-bigip-ctlr"]
           args: ["--running-in-cluster=true",
             "--bigip-url=$(BIGIP_URL)",
@@ -49,11 +58,11 @@ spec:
             "--pool-member-type=nodeport",
             "--kubeconfig=./config"
           ]
-    imagePullSecrets:
+          ports:
+          - containerPort: 8080
+      imagePullSecrets:
       - name: f5-docker-images
-
 ---
-
 apiVersion: v1
 kind: ServiceAccount
 metadata:


### PR DESCRIPTION
This PR updates the sample-k8s-bigip-ctrlr deployment:

- Use `apps` instead of `extenstions` (see: https://kubernetes.io/docs/reference/workloads-18-19)
- Add `Annotations` for Prometheus scraping 
- Add a `labelSelector` to the Deployment (which is required in `apps`)

I validated the example configuration against a Kubernetes 1.9.3 cluster (should also work for 1.8)