### PR TITLE
Cleanup for leftover objects (Ingress/Routes)

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -191,28 +191,6 @@ func NewManager(params *Params) *Manager {
 	return &manager
 }
 
-func (appMgr *Manager) addIRule(name, partition, rule string) {
-	appMgr.irulesMutex.Lock()
-	defer appMgr.irulesMutex.Unlock()
-
-	key := nameRef{
-		Name:      name,
-		Partition: partition,
-	}
-	appMgr.irulesMap[key] = NewIRule(name, partition, rule)
-}
-
-func (appMgr *Manager) addInternalDataGroup(name, partition string) {
-	appMgr.intDgMutex.Lock()
-	defer appMgr.intDgMutex.Unlock()
-
-	key := nameRef{
-		Name:      name,
-		Partition: partition,
-	}
-	appMgr.intDgMap[key] = make(DataGroupNamespaceMap)
-}
-
 func (appMgr *Manager) watchingAllNamespacesLocked() bool {
 	if 0 == len(appMgr.appInformers) {
 		// Not watching any namespaces.
@@ -694,21 +672,6 @@ func (appMgr *Manager) runImpl(stopCh <-chan struct{}) {
 	defer appMgr.vsQueue.ShutDown()
 	defer appMgr.nsQueue.ShutDown()
 
-	appMgr.addIRule(httpRedirectIRuleName, DEFAULT_PARTITION,
-		httpRedirectIRule(DEFAULT_HTTPS_PORT))
-	appMgr.addInternalDataGroup(httpsRedirectDgName, DEFAULT_PARTITION)
-
-	if nil != appMgr.routeClientV1 {
-		appMgr.addIRule(
-			sslPassthroughIRuleName, DEFAULT_PARTITION, sslPassthroughIRule())
-		appMgr.addInternalDataGroup(passthroughHostsDgName, DEFAULT_PARTITION)
-		appMgr.addInternalDataGroup(reencryptHostsDgName, DEFAULT_PARTITION)
-		appMgr.addInternalDataGroup(reencryptServerSslDgName, DEFAULT_PARTITION)
-		appMgr.addIRule(
-			abDeploymentPathIRuleName, DEFAULT_PARTITION, abDeploymentPathIRule())
-		appMgr.addInternalDataGroup(abDeploymentDgName, DEFAULT_PARTITION)
-	}
-
 	if nil != appMgr.nsInformer {
 		// Using one worker for namespace label changes.
 		appMgr.startAndSyncNamespaceInformer(stopCh)
@@ -857,9 +820,10 @@ func (appMgr *Manager) syncVirtualServer(sKey serviceQueueKey) error {
 			return err
 		}
 	}
-
 	// Update internal data groups if changed
-	appMgr.updateRouteDataGroups(&stats, dgMap, sKey.Namespace)
+	appMgr.syncDataGroups(&stats, dgMap, sKey.Namespace)
+	// Delete IRules if necessary
+	appMgr.syncIRules()
 
 	if len(rsMap) > 0 {
 		// We get here when there are ports defined in the service that don't
@@ -1024,7 +988,7 @@ func (appMgr *Manager) syncIngresses(
 			objKey, objDeps, svcDepKey, ingressLookupFunc)
 
 		for _, portStruct := range appMgr.virtualPorts(ing) {
-			rsCfg := createRSConfigFromIngress(
+			rsCfg := appMgr.createRSConfigFromIngress(
 				ing,
 				appMgr.resources,
 				sKey.Namespace,
@@ -1184,27 +1148,11 @@ func (appMgr *Manager) syncRoutes(
 		_, depsRemoved := appMgr.resources.UpdateDependencies(
 			objKey, objDeps, svcDepKey, routeLookupFunc)
 
-		if nil != route.Spec.TLS {
-			// We need this even for A/B so the irule can determine if we are
-			// doing passthrough or reencrypt (otherwise we need to add more
-			// info to the A/B data group).
-			switch route.Spec.TLS.Termination {
-			case routeapi.TLSTerminationPassthrough:
-				updateDataGroupForPassthroughRoute(route, DEFAULT_PARTITION,
-					sKey.Namespace, dgMap)
-			case routeapi.TLSTerminationReencrypt:
-				updateDataGroupForReencryptRoute(route, DEFAULT_PARTITION,
-					sKey.Namespace, dgMap)
-			}
-		}
-
-		updateDataGroupForABRoute(route, svcName, DEFAULT_PARTITION, sKey.Namespace, dgMap)
-
 		pStructs := []portStruct{{protocol: "http", port: DEFAULT_HTTP_PORT},
 			{protocol: "https", port: DEFAULT_HTTPS_PORT}}
 		for _, ps := range pStructs {
-			rsCfg, err, pool := createRSConfigFromRoute(route, svcName,
-				appMgr.resources, appMgr.routeConfig, ps,
+			rsCfg, err, pool := appMgr.createRSConfigFromRoute(
+				route, svcName, appMgr.resources, appMgr.routeConfig, ps,
 				appInf.svcInformer.GetIndexer(), svcFwdRulesMap)
 			if err != nil {
 				// We return err if there was an error creating a rule
@@ -1264,6 +1212,20 @@ func (appMgr *Manager) syncRoutes(
 			stats.vsFound += found
 			stats.vsUpdated += updated
 		}
+		if nil != route.Spec.TLS {
+			// We need this even for A/B so the irule can determine if we are
+			// doing passthrough or reencrypt (otherwise we need to add more
+			// info to the A/B data group).
+			switch route.Spec.TLS.Termination {
+			case routeapi.TLSTerminationPassthrough:
+				updateDataGroupForPassthroughRoute(route, DEFAULT_PARTITION,
+					sKey.Namespace, dgMap)
+			case routeapi.TLSTerminationReencrypt:
+				updateDataGroupForReencryptRoute(route, DEFAULT_PARTITION,
+					sKey.Namespace, dgMap)
+			}
+		}
+		updateDataGroupForABRoute(route, svcName, DEFAULT_PARTITION, sKey.Namespace, dgMap)
 	}
 
 	if len(svcFwdRulesMap) > 0 {
@@ -1276,7 +1238,6 @@ func (appMgr *Manager) syncRoutes(
 		}
 		svcFwdRulesMap.AddToDataGroup(dgMap[httpsRedirectDg])
 	}
-
 	return nil
 }
 
@@ -1295,122 +1256,6 @@ func getBooleanAnnotation(
 		return defaultValue
 	}
 	return bVal
-}
-
-type secretKey struct {
-	Name         string
-	ResourceName string
-}
-
-// Return value is whether or not a custom profile was updated
-func (appMgr *Manager) handleIngressTls(
-	rsCfg *ResourceConfig,
-	ing *v1beta1.Ingress,
-	svcFwdRulesMap ServiceFwdRuleMap,
-) bool {
-	if 0 == len(ing.Spec.TLS) {
-		// Nothing to do if no TLS section
-		return false
-	}
-	if nil == rsCfg.Virtual.VirtualAddress ||
-		rsCfg.Virtual.VirtualAddress.BindAddr == "" {
-		// Nothing to do for pool-only mode
-		return false
-	}
-
-	var httpsPort int32
-	if port, ok :=
-		ing.ObjectMeta.Annotations[f5VsHttpsPortAnnotation]; ok == true {
-		p, _ := strconv.ParseInt(port, 10, 32)
-		httpsPort = int32(p)
-	} else {
-		httpsPort = DEFAULT_HTTPS_PORT
-	}
-	// If we are processing the HTTPS server,
-	// then we don't need a redirect policy, only profiles
-	if rsCfg.Virtual.VirtualAddress.Port == httpsPort {
-		var cpUpdated, updateState bool
-		for _, tls := range ing.Spec.TLS {
-			// Check if profile is contained in a Secret
-			if appMgr.useSecrets {
-				secret, err := appMgr.kubeClient.Core().Secrets(ing.ObjectMeta.Namespace).
-					Get(tls.SecretName, metav1.GetOptions{})
-				if err != nil {
-					// No secret, so we assume the profile is a BIG-IP default
-					log.Debugf("No Secret with name '%s': %s. Parsing secretName as path instead.",
-						tls.SecretName, err)
-					profRef := convertStringToProfileRef(
-						tls.SecretName, customProfileClient, ing.ObjectMeta.Namespace)
-					rsCfg.Virtual.AddOrUpdateProfile(profRef)
-					continue
-				}
-				err, cpUpdated = appMgr.createSecretSslProfile(rsCfg, secret)
-				if err != nil {
-					log.Warningf("%v", err)
-					continue
-				}
-				updateState = updateState || cpUpdated
-				profRef := ProfileRef{
-					Partition: rsCfg.Virtual.Partition,
-					Name:      tls.SecretName,
-					Context:   customProfileClient,
-					Namespace: ing.ObjectMeta.Namespace,
-				}
-				rsCfg.Virtual.AddOrUpdateProfile(profRef)
-			} else {
-				secretName := formatIngressSslProfileName(tls.SecretName)
-				profRef := convertStringToProfileRef(
-					secretName, customProfileClient, ing.ObjectMeta.Namespace)
-				rsCfg.Virtual.AddOrUpdateProfile(profRef)
-			}
-		}
-		return cpUpdated
-	}
-
-	// sslRedirect defaults to true, allowHttp defaults to false.
-	sslRedirect := getBooleanAnnotation(ing.ObjectMeta.Annotations,
-		ingressSslRedirect, true)
-	allowHttp := getBooleanAnnotation(ing.ObjectMeta.Annotations,
-		ingressAllowHttp, false)
-	// -----------------------------------------------------------------
-	// | State | sslRedirect | allowHttp | Description                 |
-	// -----------------------------------------------------------------
-	// |   1   |     F       |    F      | Just HTTPS, nothing on HTTP |
-	// -----------------------------------------------------------------
-	// |   2   |     T       |    F      | HTTP redirects to HTTPS     |
-	// -----------------------------------------------------------------
-	// |   2   |     T       |    T      | Honor sslRedirect == true   |
-	// -----------------------------------------------------------------
-	// |   3   |     F       |    T      | Both HTTP and HTTPS         |
-	// -----------------------------------------------------------------
-	if sslRedirect {
-		// State 2, set HTTP redirect iRule
-		log.Debugf("TLS: Applying HTTP redirect iRule.")
-		ruleName := joinBigipPath(DEFAULT_PARTITION, httpRedirectIRuleName)
-		if httpsPort != DEFAULT_HTTPS_PORT {
-			ruleName = fmt.Sprintf("%s_%d", ruleName, httpsPort)
-			appMgr.addIRule(ruleName, DEFAULT_PARTITION,
-				httpRedirectIRule(httpsPort))
-		}
-		rsCfg.Virtual.AddIRule(ruleName)
-		if nil != ing.Spec.Backend {
-			svcFwdRulesMap.AddEntry(ing.ObjectMeta.Namespace,
-				ing.Spec.Backend.ServiceName, "*", "/")
-		}
-		for _, rul := range ing.Spec.Rules {
-			if nil != rul.HTTP {
-				host := rul.Host
-				for _, path := range rul.HTTP.Paths {
-					svcFwdRulesMap.AddEntry(ing.ObjectMeta.Namespace,
-						path.Backend.ServiceName, host, path.Path)
-				}
-			}
-		}
-	} else if allowHttp {
-		// State 3, do not apply any policy
-		log.Debugf("TLS: Not applying any policies.")
-	}
-	return false
 }
 
 type portStruct struct {
@@ -1794,22 +1639,17 @@ func (appMgr *Manager) deleteUnusedResources(
 	sKey serviceQueueKey,
 	svcFound bool,
 ) int {
-	// FIXME: This function is mostly obsolete for Ingress and Routes due to
-	// the new object dependency code, but is still needed when the Ingress
-	// or route resource is deleted to handle the profiles, and is still
-	// needed for ConfigMaps
 	appMgr.resources.Lock()
 	defer appMgr.resources.Unlock()
 	rsUpdated := 0
 	namespace := sKey.Namespace
 	svcName := sKey.ServiceName
-	var resourceName string
 	for _, cfg := range appMgr.resources.GetAllResources() {
 		if cfg.MetaData.ResourceType == "configmap" ||
 			cfg.MetaData.ResourceType == "iapp" {
 			continue
 		}
-		for i, pool := range cfg.Pools {
+		for _, pool := range cfg.Pools {
 			// Make sure we aren't processing empty pool
 			if pool.Name != "" {
 				key := serviceKey{
@@ -1820,42 +1660,10 @@ func (appMgr *Manager) deleteUnusedResources(
 				poolNS := strings.Split(pool.Name, "_")[1]
 				_, ok := appMgr.resources.Get(key, cfg.GetName())
 				if pool.ServiceName == svcName && poolNS == namespace && (!ok || !svcFound) {
-					poolName := joinBigipPath(cfg.Virtual.Partition, pool.Name)
-					// Delete rule
-					for _, pol := range cfg.Policies {
-						// Loop through rules to find which one to remove
-						ruleOffsets := []int{}
-						for i, rule := range pol.Rules {
-							if len(rule.Actions) > 0 && rule.Actions[0].Pool == poolName {
-								if cfg.MetaData.ResourceType == "route" {
-									resourceName = strings.Split(rule.Name, "_")[3]
-								}
-								ruleOffsets = append(ruleOffsets, i)
-							}
-						}
-						polChanged := pol.RemoveRules(ruleOffsets)
-						// Update or remove the policy
-						if 0 == len(pol.Rules) {
-							cfg.RemovePolicy(pol)
-						} else if polChanged {
-							cfg.SetPolicy(pol)
-						}
+					if updated, svcKey := cfg.RemovePool(namespace, pool.Name); updated {
+						appMgr.resources.deleteKeyRefLocked(*svcKey, cfg.GetName())
+						rsUpdated += 1
 					}
-					// Delete pool
-					cfg.RemovePoolAt(i)
-					appMgr.resources.deleteKeyRefLocked(key, cfg.GetName())
-					if resourceName != "" {
-						// Delete profileRef (Route)
-						if cfg.MetaData.ResourceType == "route" {
-							profRef := makeRouteClientSSLProfileRef(
-								cfg.Virtual.Partition, namespace, resourceName)
-							cfg.Virtual.RemoveProfile(profRef)
-							serverProfile := makeRouteServerSSLProfileRef(
-								cfg.Virtual.Partition, namespace, resourceName)
-							cfg.Virtual.RemoveProfile(serverProfile)
-						}
-					}
-					rsUpdated += 1
 				}
 			}
 		}

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -3023,7 +3023,7 @@ var _ = Describe("AppManager Tests", func() {
 				r = mockMgr.addIngress(ing1a)
 				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
 				nsMap, found = mockMgr.appMgr.intDgMap[grpRef]
-				Expect(found).To(BeTrue(), "redirect group not found")
+				Expect(found).To(BeFalse(), "redirect group should be gone")
 				flatDg = nsMap.FlattenNamespaces()
 				Expect(flatDg).To(BeNil(), "should not have data")
 			})
@@ -3449,7 +3449,7 @@ var _ = Describe("AppManager Tests", func() {
 					r = mockMgr.deleteRoute(route1b)
 					Expect(r).To(BeTrue(), "Route resource should be processed.")
 					nsMap, found = mockMgr.appMgr.intDgMap[grpRef]
-					Expect(found).To(BeTrue(), "redirect group not found")
+					Expect(found).To(BeFalse(), "redirect group should be gone")
 					flatDg = nsMap.FlattenNamespaces()
 					Expect(flatDg).To(BeNil(), "should not have data")
 
@@ -3459,7 +3459,7 @@ var _ = Describe("AppManager Tests", func() {
 					r = mockMgr.addRoute(route1a)
 					Expect(r).To(BeTrue(), "Route resource should be processed.")
 					nsMap, found = mockMgr.appMgr.intDgMap[grpRef]
-					Expect(found).To(BeTrue(), "redirect group not found")
+					Expect(found).To(BeFalse(), "redirect group should be gone")
 					flatDg = nsMap.FlattenNamespaces()
 					Expect(flatDg).To(BeNil(), "should not have data")
 				})

--- a/pkg/appmanager/healthMonitors.go
+++ b/pkg/appmanager/healthMonitors.go
@@ -85,7 +85,7 @@ func (appMgr *Manager) assignMonitorToPool(
 				// Also add a monitor index to the name to be consistent with the
 				// marathon-bigip-ctlr. Since the monitor names are already unique here,
 				// appending a '0' is sufficient.
-				Name:      poolName + "_0_http",
+				Name:      formatMonitorName(poolName),
 				Partition: partition,
 				Type:      "http",
 				Interval:  ruleData.healthMon.Interval,
@@ -137,7 +137,7 @@ func (appMgr *Manager) handleSingleServiceHealthMonitors(
 	if nil != err {
 		log.Errorf("%s", err.Error())
 		appMgr.recordIngressEvent(ing, "MonitorError", err.Error())
-		mon := poolName + "_0_http"
+		mon := formatMonitorName(poolName)
 		_, pool := splitBigipPath(poolName, false)
 		cfg.RemoveMonitor(pool, mon)
 		return
@@ -277,7 +277,7 @@ func (appMgr *Manager) handleRouteHealthMonitors(
 	if nil != err {
 		log.Errorf("%s", err.Error())
 		// If this monitor exists already, remove it
-		monitorName := poolPath + "_0_http"
+		monitorName := formatMonitorName(poolPath)
 		if removed := cfg.RemoveMonitor(pool.Name, monitorName); removed {
 			stats.vsUpdated += 1
 		}

--- a/pkg/appmanager/profiles_test.go
+++ b/pkg/appmanager/profiles_test.go
@@ -141,7 +141,7 @@ var _ = Describe("AppManager Profile Tests", func() {
 			// No annotations were specified to control http redirect, check that
 			// we are in the default state 2.
 			Expect(len(httpCfg.Virtual.IRules)).To(Equal(1))
-			expectedIRuleName := fmt.Sprintf("/%s/%s",
+			expectedIRuleName := fmt.Sprintf("/%s/%s_443",
 				DEFAULT_PARTITION, httpRedirectIRuleName)
 			Expect(httpCfg.Virtual.IRules[0]).To(Equal(expectedIRuleName))
 
@@ -154,7 +154,7 @@ var _ = Describe("AppManager Profile Tests", func() {
 			Expect(httpCfg).ToNot(BeNil())
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
 			Expect(len(httpCfg.Virtual.IRules)).To(Equal(1))
-			expectedIRuleName = fmt.Sprintf("/%s/%s",
+			expectedIRuleName = fmt.Sprintf("/%s/%s_443",
 				DEFAULT_PARTITION, httpRedirectIRuleName)
 			Expect(httpCfg.Virtual.IRules[0]).To(Equal(expectedIRuleName))
 

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -23,6 +23,7 @@ import (
 	"net"
 	"reflect"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -31,6 +32,7 @@ import (
 
 	routeapi "github.com/openshift/origin/pkg/route/api"
 	"github.com/xeipuuv/gojsonschema"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
@@ -90,6 +92,7 @@ func (v *Virtual) ReferencesProfile(profile CustomProfile) bool {
 	return false
 }
 
+// Adds an IRule reference to a Virtual object
 func (v *Virtual) AddIRule(ruleName string) bool {
 	for _, irule := range v.IRules {
 		if irule == ruleName {
@@ -98,6 +101,19 @@ func (v *Virtual) AddIRule(ruleName string) bool {
 	}
 	v.IRules = append(v.IRules, ruleName)
 	return true
+}
+
+// Removes an IRule reference from a Virtual object
+func (v *Virtual) RemoveIRule(ruleName string) bool {
+	for i, irule := range v.IRules {
+		if irule == ruleName {
+			copy(v.IRules[i:], v.IRules[i+1:])
+			v.IRules[len(v.IRules)-1] = ""
+			v.IRules = v.IRules[:len(v.IRules)-1]
+			return true
+		}
+	}
+	return false
 }
 
 func (v *Virtual) ToString() string {
@@ -205,6 +221,11 @@ func formatConfigMapVSName(cm *v1.ConfigMap) string {
 // format the pool name for a ConfigMap
 func formatConfigMapPoolName(namespace, cmName, svc string) string {
 	return fmt.Sprintf("cfgmap_%s_%s_%s", namespace, cmName, svc)
+}
+
+// formats a health monitor name
+func formatMonitorName(poolName string) string {
+	return poolName + "_0_http"
 }
 
 // format the virtual server name for an Ingress
@@ -962,7 +983,7 @@ func copyConfigMap(virtualName, ns string, cfg *ResourceConfig, cfgMap *ConfigMa
 }
 
 // Create a ResourceConfig based on an Ingress resource config
-func createRSConfigFromIngress(
+func (appMgr *Manager) createRSConfigFromIngress(
 	ing *v1beta1.Ingress,
 	resources *Resources,
 	ns string,
@@ -1115,7 +1136,117 @@ func createRSConfigFromIngress(
 	return &cfg
 }
 
-func createRSConfigFromRoute(
+// Return value is whether or not a custom profile was updated
+func (appMgr *Manager) handleIngressTls(
+	rsCfg *ResourceConfig,
+	ing *v1beta1.Ingress,
+	svcFwdRulesMap ServiceFwdRuleMap,
+) bool {
+	if 0 == len(ing.Spec.TLS) {
+		// Nothing to do if no TLS section
+		return false
+	}
+	if nil == rsCfg.Virtual.VirtualAddress ||
+		rsCfg.Virtual.VirtualAddress.BindAddr == "" {
+		// Nothing to do for pool-only mode
+		return false
+	}
+
+	var httpsPort int32
+	if port, ok :=
+		ing.ObjectMeta.Annotations[f5VsHttpsPortAnnotation]; ok == true {
+		p, _ := strconv.ParseInt(port, 10, 32)
+		httpsPort = int32(p)
+	} else {
+		httpsPort = DEFAULT_HTTPS_PORT
+	}
+	// If we are processing the HTTPS server,
+	// then we don't need a redirect policy, only profiles
+	if rsCfg.Virtual.VirtualAddress.Port == httpsPort {
+		var cpUpdated, updateState bool
+		for _, tls := range ing.Spec.TLS {
+			// Check if profile is contained in a Secret
+			if appMgr.useSecrets {
+				secret, err := appMgr.kubeClient.Core().Secrets(ing.ObjectMeta.Namespace).
+					Get(tls.SecretName, metav1.GetOptions{})
+				if err != nil {
+					// No secret, so we assume the profile is a BIG-IP default
+					log.Debugf("No Secret with name '%s': %s. Parsing secretName as path instead.",
+						tls.SecretName, err)
+					profRef := convertStringToProfileRef(
+						tls.SecretName, customProfileClient, ing.ObjectMeta.Namespace)
+					rsCfg.Virtual.AddOrUpdateProfile(profRef)
+					continue
+				}
+				err, cpUpdated = appMgr.createSecretSslProfile(rsCfg, secret)
+				if err != nil {
+					log.Warningf("%v", err)
+					continue
+				}
+				updateState = updateState || cpUpdated
+				profRef := ProfileRef{
+					Partition: rsCfg.Virtual.Partition,
+					Name:      tls.SecretName,
+					Context:   customProfileClient,
+					Namespace: ing.ObjectMeta.Namespace,
+				}
+				rsCfg.Virtual.AddOrUpdateProfile(profRef)
+			} else {
+				secretName := formatIngressSslProfileName(tls.SecretName)
+				profRef := convertStringToProfileRef(
+					secretName, customProfileClient, ing.ObjectMeta.Namespace)
+				rsCfg.Virtual.AddOrUpdateProfile(profRef)
+			}
+		}
+		return cpUpdated
+	}
+
+	// sslRedirect defaults to true, allowHttp defaults to false.
+	sslRedirect := getBooleanAnnotation(ing.ObjectMeta.Annotations,
+		ingressSslRedirect, true)
+	allowHttp := getBooleanAnnotation(ing.ObjectMeta.Annotations,
+		ingressAllowHttp, false)
+	// -----------------------------------------------------------------
+	// | State | sslRedirect | allowHttp | Description                 |
+	// -----------------------------------------------------------------
+	// |   1   |     F       |    F      | Just HTTPS, nothing on HTTP |
+	// -----------------------------------------------------------------
+	// |   2   |     T       |    F      | HTTP redirects to HTTPS     |
+	// -----------------------------------------------------------------
+	// |   2   |     T       |    T      | Honor sslRedirect == true   |
+	// -----------------------------------------------------------------
+	// |   3   |     F       |    T      | Both HTTP and HTTPS         |
+	// -----------------------------------------------------------------
+	if sslRedirect {
+		// State 2, set HTTP redirect iRule
+		log.Debugf("TLS: Applying HTTP redirect iRule.")
+		ruleName := fmt.Sprintf("%s_%d", httpRedirectIRuleName, httpsPort)
+		appMgr.addIRule(ruleName, DEFAULT_PARTITION,
+			httpRedirectIRule(httpsPort))
+		appMgr.addInternalDataGroup(httpsRedirectDgName, DEFAULT_PARTITION)
+		ruleName = joinBigipPath(DEFAULT_PARTITION, ruleName)
+		rsCfg.Virtual.AddIRule(ruleName)
+		if nil != ing.Spec.Backend {
+			svcFwdRulesMap.AddEntry(ing.ObjectMeta.Namespace,
+				ing.Spec.Backend.ServiceName, "*", "/")
+		}
+		for _, rul := range ing.Spec.Rules {
+			if nil != rul.HTTP {
+				host := rul.Host
+				for _, path := range rul.HTTP.Paths {
+					svcFwdRulesMap.AddEntry(ing.ObjectMeta.Namespace,
+						path.Backend.ServiceName, host, path.Path)
+				}
+			}
+		}
+	} else if allowHttp {
+		// State 3, do not apply any policy
+		log.Debugf("TLS: Not applying any policies.")
+	}
+	return false
+}
+
+func (appMgr *Manager) createRSConfigFromRoute(
 	route *routeapi.Route,
 	svcName string,
 	resources *Resources,
@@ -1214,8 +1345,13 @@ func createRSConfigFromRoute(
 	}
 
 	abDeployment := isRouteABDeployment(route)
-	rsCfg.HandleRouteTls(route, pStruct.protocol, policyName, rule,
-		svcFwdRulesMap, abDeployment)
+	appMgr.handleRouteTls(&rsCfg,
+		route,
+		pStruct.protocol,
+		policyName,
+		rule,
+		svcFwdRulesMap,
+		abDeployment)
 
 	return &rsCfg, nil, pool
 }
@@ -1250,7 +1386,8 @@ func (rc *ResourceConfig) copyConfig(cfg *ResourceConfig) {
 	}
 }
 
-func (rc *ResourceConfig) HandleRouteTls(
+func (appMgr *Manager) handleRouteTls(
+	rc *ResourceConfig,
 	route *routeapi.Route,
 	protocol string,
 	policyName string,
@@ -1268,6 +1405,9 @@ func (rc *ResourceConfig) HandleRouteTls(
 	if protocol == "http" {
 		if nil == tls || len(tls.Termination) == 0 {
 			if abDeployment {
+				appMgr.addIRule(
+					abDeploymentPathIRuleName, DEFAULT_PARTITION, abDeploymentPathIRule())
+				appMgr.addInternalDataGroup(abDeploymentDgName, DEFAULT_PARTITION)
 				rc.Virtual.AddIRule(abPathIRuleName)
 			} else {
 				rc.AddRuleToPolicy(policyName, rule)
@@ -1287,6 +1427,9 @@ func (rc *ResourceConfig) HandleRouteTls(
 				case routeapi.InsecureEdgeTerminationPolicyRedirect:
 					redirectIRuleName := joinBigipPath(DEFAULT_PARTITION,
 						httpRedirectIRuleName)
+					appMgr.addIRule(httpRedirectIRuleName, DEFAULT_PARTITION,
+						httpRedirectIRule(DEFAULT_HTTPS_PORT))
+					appMgr.addInternalDataGroup(httpsRedirectDgName, DEFAULT_PARTITION)
 					rc.Virtual.AddIRule(redirectIRuleName)
 					// TLS config indicates to forward http to https.
 					path := "/"
@@ -1306,13 +1449,23 @@ func (rc *ResourceConfig) HandleRouteTls(
 			switch tls.Termination {
 			case routeapi.TLSTerminationEdge:
 				if abDeployment {
+					appMgr.addIRule(
+						abDeploymentPathIRuleName, DEFAULT_PARTITION, abDeploymentPathIRule())
+					appMgr.addInternalDataGroup(abDeploymentDgName, DEFAULT_PARTITION)
 					rc.Virtual.AddIRule(abPathIRuleName)
 				} else {
 					rc.AddRuleToPolicy(policyName, rule)
 				}
 			case routeapi.TLSTerminationPassthrough:
+				appMgr.addIRule(
+					sslPassthroughIRuleName, DEFAULT_PARTITION, sslPassthroughIRule())
+				appMgr.addInternalDataGroup(passthroughHostsDgName, DEFAULT_PARTITION)
 				rc.Virtual.AddIRule(passThroughIRuleName)
 			case routeapi.TLSTerminationReencrypt:
+				appMgr.addIRule(
+					sslPassthroughIRuleName, DEFAULT_PARTITION, sslPassthroughIRule())
+				appMgr.addInternalDataGroup(reencryptHostsDgName, DEFAULT_PARTITION)
+				appMgr.addInternalDataGroup(reencryptServerSslDgName, DEFAULT_PARTITION)
 				rc.Virtual.AddIRule(passThroughIRuleName)
 				if !abDeployment {
 					rc.AddRuleToPolicy(policyName, rule)
@@ -1507,6 +1660,7 @@ func (rc *ResourceConfig) RemovePool(
 ) (bool, *serviceKey) {
 	var cfgChanged bool
 	var svcKey *serviceKey
+	var fullPoolName, resourceName string
 
 	// Delete pool
 	for i, pool := range rc.Pools {
@@ -1521,15 +1675,18 @@ func (rc *ResourceConfig) RemovePool(
 		cfgChanged = rc.RemovePoolAt(i)
 		break
 	}
+	fullPoolName = joinBigipPath(DEFAULT_PARTITION, poolName)
 
 	// Delete forwarding rule for the pool
 	policy := rc.FindPolicy("forwarding")
 	if nil != policy {
 		// Loop through rules to find which one to remove
-		fullPoolName := joinBigipPath(DEFAULT_PARTITION, poolName)
 		ruleOffsets := []int{}
 		for i, rule := range policy.Rules {
 			if len(rule.Actions) > 0 && rule.Actions[0].Pool == fullPoolName {
+				if rc.MetaData.ResourceType == "route" {
+					resourceName = strings.Split(rule.Name, "_")[3]
+				}
 				ruleOffsets = append(ruleOffsets, i)
 			}
 		}
@@ -1541,6 +1698,21 @@ func (rc *ResourceConfig) RemovePool(
 		} else if polChanged {
 			rc.SetPolicy(*policy)
 			cfgChanged = true
+		}
+	}
+	// Delete health monitor for the pool
+	monitorName := formatMonitorName(fullPoolName)
+	rc.RemoveMonitor(poolName, monitorName)
+
+	// Delete profile (route only)
+	if resourceName != "" {
+		if rc.MetaData.ResourceType == "route" {
+			profRef := makeRouteClientSSLProfileRef(
+				rc.Virtual.Partition, namespace, resourceName)
+			rc.Virtual.RemoveProfile(profRef)
+			serverProfile := makeRouteServerSSLProfileRef(
+				rc.Virtual.Partition, namespace, resourceName)
+			rc.Virtual.RemoveProfile(serverProfile)
 		}
 	}
 
@@ -1686,6 +1858,34 @@ func NewInternalDataGroup(name, partition string) *InternalDataGroup {
 		Name:      name,
 		Partition: partition,
 		Records:   []InternalDataGroupRecord{},
+	}
+}
+
+// Creates an IRule if it doesn't already exist
+func (appMgr *Manager) addIRule(name, partition, rule string) {
+	appMgr.irulesMutex.Lock()
+	defer appMgr.irulesMutex.Unlock()
+
+	key := nameRef{
+		Name:      name,
+		Partition: partition,
+	}
+	if _, found := appMgr.irulesMap[key]; !found {
+		appMgr.irulesMap[key] = NewIRule(name, partition, rule)
+	}
+}
+
+// Creates an InternalDataGroup if it doesn't already exist
+func (appMgr *Manager) addInternalDataGroup(name, partition string) {
+	appMgr.intDgMutex.Lock()
+	defer appMgr.intDgMutex.Unlock()
+
+	key := nameRef{
+		Name:      name,
+		Partition: partition,
+	}
+	if _, found := appMgr.intDgMap[key]; !found {
+		appMgr.intDgMap[key] = make(DataGroupNamespaceMap)
 	}
 }
 

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -593,123 +593,136 @@ var _ = Describe("Resource Config Tests", func() {
 			lenValidate(0)
 		})
 
-		It("properly configures ingress resources", func() {
-			namespace := "default"
-			ingressConfig := v1beta1.IngressSpec{
-				Backend: &v1beta1.IngressBackend{
-					ServiceName: "foo",
-					ServicePort: intstr.IntOrString{IntVal: 80},
-				},
-			}
-			ingress := test.NewIngress("ingress", "1", namespace, ingressConfig,
-				map[string]string{
-					f5VsBindAddrAnnotation:  "1.2.3.4",
-					f5VsPartitionAnnotation: "velcro",
-				})
-			ps := portStruct{
-				protocol: "http",
-				port:     80,
-			}
-			cfg := createRSConfigFromIngress(ingress, &Resources{}, namespace, nil, ps, "")
-			Expect(cfg.Pools[0].Balance).To(Equal("round-robin"))
-			Expect(cfg.Virtual.Partition).To(Equal("velcro"))
-			Expect(cfg.Virtual.VirtualAddress.BindAddr).To(Equal("1.2.3.4"))
-			Expect(cfg.Virtual.VirtualAddress.Port).To(Equal(int32(80)))
+		Context("resource configuration", func() {
+			var mockMgr *mockAppManager
+			BeforeEach(func() {
+				mockMgr = newMockAppManager(&Params{})
+			})
 
-			ingress = test.NewIngress("ingress", "1", namespace, ingressConfig,
-				map[string]string{
-					f5VsBindAddrAnnotation:  "1.2.3.4",
-					f5VsPartitionAnnotation: "velcro",
-					f5VsHttpPortAnnotation:  "100",
-					f5VsBalanceAnnotation:   "foobar",
-					k8sIngressClass:         "f5",
-				})
-			ps = portStruct{
-				protocol: "http",
-				port:     100,
-			}
-			cfg = createRSConfigFromIngress(ingress, &Resources{}, namespace, nil, ps, "")
-			Expect(cfg.Pools[0].Balance).To(Equal("foobar"))
-			Expect(cfg.Virtual.VirtualAddress.Port).To(Equal(int32(100)))
+			It("properly configures ingress resources", func() {
+				namespace := "default"
+				ingressConfig := v1beta1.IngressSpec{
+					Backend: &v1beta1.IngressBackend{
+						ServiceName: "foo",
+						ServicePort: intstr.IntOrString{IntVal: 80},
+					},
+				}
+				ingress := test.NewIngress("ingress", "1", namespace, ingressConfig,
+					map[string]string{
+						f5VsBindAddrAnnotation:  "1.2.3.4",
+						f5VsPartitionAnnotation: "velcro",
+					})
+				ps := portStruct{
+					protocol: "http",
+					port:     80,
+				}
+				cfg := mockMgr.appMgr.createRSConfigFromIngress(
+					ingress, &Resources{}, namespace, nil, ps, "")
+				Expect(cfg.Pools[0].Balance).To(Equal("round-robin"))
+				Expect(cfg.Virtual.Partition).To(Equal("velcro"))
+				Expect(cfg.Virtual.VirtualAddress.BindAddr).To(Equal("1.2.3.4"))
+				Expect(cfg.Virtual.VirtualAddress.Port).To(Equal(int32(80)))
 
-			ingress = test.NewIngress("ingress", "1", namespace, ingressConfig,
-				map[string]string{
-					k8sIngressClass: "notf5",
-				})
-			cfg = createRSConfigFromIngress(ingress, &Resources{}, namespace, nil, ps, "")
-			Expect(cfg).To(BeNil())
+				ingress = test.NewIngress("ingress", "1", namespace, ingressConfig,
+					map[string]string{
+						f5VsBindAddrAnnotation:  "1.2.3.4",
+						f5VsPartitionAnnotation: "velcro",
+						f5VsHttpPortAnnotation:  "100",
+						f5VsBalanceAnnotation:   "foobar",
+						k8sIngressClass:         "f5",
+					})
+				ps = portStruct{
+					protocol: "http",
+					port:     100,
+				}
+				cfg = mockMgr.appMgr.createRSConfigFromIngress(
+					ingress, &Resources{}, namespace, nil, ps, "")
+				Expect(cfg.Pools[0].Balance).To(Equal("foobar"))
+				Expect(cfg.Virtual.VirtualAddress.Port).To(Equal(int32(100)))
 
-			// Use controller default IP
-			defaultIng := test.NewIngress("ingress", "1", namespace, ingressConfig,
-				map[string]string{
-					f5VsBindAddrAnnotation:  "controller-default",
-					f5VsPartitionAnnotation: "velcro",
-				})
-			cfg = createRSConfigFromIngress(defaultIng, &Resources{}, namespace, nil, ps, "5.6.7.8")
-			Expect(cfg.Virtual.VirtualAddress.BindAddr).To(Equal("5.6.7.8"))
-		})
+				ingress = test.NewIngress("ingress", "1", namespace, ingressConfig,
+					map[string]string{
+						k8sIngressClass: "notf5",
+					})
+				cfg = mockMgr.appMgr.createRSConfigFromIngress(
+					ingress, &Resources{}, namespace, nil, ps, "")
+				Expect(cfg).To(BeNil())
 
-		It("properly configures route resources", func() {
-			namespace := "default"
-			spec := routeapi.RouteSpec{
-				Host: "foobar.com",
-				Path: "/foo",
-				To: routeapi.RouteTargetReference{
-					Kind: "Service",
-					Name: "foo",
-				},
-				Port: &routeapi.RoutePort{
-					TargetPort: intstr.FromInt(80),
-				},
-				TLS: &routeapi.TLSConfig{
-					Termination: "edge",
-					Certificate: "cert",
-					Key:         "key",
-				},
-			}
-			route := test.NewRoute("route", "1", namespace, spec, nil)
-			ps := portStruct{
-				protocol: "https",
-				port:     443,
-			}
-			rc := RouteConfig{
-				HttpVs:  "ose-vserver",
-				HttpsVs: "https-ose-vserver",
-			}
-			svcFwdRulesMap := NewServiceFwdRuleMap()
-			cfg, _, _ := createRSConfigFromRoute(route, getRouteCanonicalServiceName(route),
-				&Resources{}, rc, ps, nil, svcFwdRulesMap)
-			Expect(cfg.Virtual.Name).To(Equal("https-ose-vserver"))
-			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_foo"))
-			Expect(cfg.Pools[0].ServiceName).To(Equal("foo"))
-			Expect(cfg.Pools[0].ServicePort).To(Equal(int32(80)))
-			Expect(cfg.Policies[0].Name).To(Equal("openshift_secure_routes"))
-			Expect(cfg.Policies[0].Rules[0].Name).To(Equal("openshift_route_default_route"))
+				// Use controller default IP
+				defaultIng := test.NewIngress("ingress", "1", namespace, ingressConfig,
+					map[string]string{
+						f5VsBindAddrAnnotation:  "controller-default",
+						f5VsPartitionAnnotation: "velcro",
+					})
+				cfg = mockMgr.appMgr.createRSConfigFromIngress(
+					defaultIng, &Resources{}, namespace, nil, ps, "5.6.7.8")
+				Expect(cfg.Virtual.VirtualAddress.BindAddr).To(Equal("5.6.7.8"))
+			})
 
-			spec = routeapi.RouteSpec{
-				Host: "foobar.com",
-				Path: "/foo",
-				To: routeapi.RouteTargetReference{
-					Kind: "Service",
-					Name: "bar",
-				},
-				Port: &routeapi.RoutePort{
-					TargetPort: intstr.FromInt(80),
-				},
-			}
-			route2 := test.NewRoute("route2", "1", namespace, spec, nil)
-			ps = portStruct{
-				protocol: "http",
-				port:     80,
-			}
-			cfg, _, _ = createRSConfigFromRoute(route2, getRouteCanonicalServiceName(route2),
-				&Resources{}, rc, ps, nil, svcFwdRulesMap)
-			Expect(cfg.Virtual.Name).To(Equal("ose-vserver"))
-			Expect(cfg.Pools[0].Name).To(Equal("openshift_default_bar"))
-			Expect(cfg.Pools[0].ServiceName).To(Equal("bar"))
-			Expect(cfg.Pools[0].ServicePort).To(Equal(int32(80)))
-			Expect(cfg.Policies[0].Name).To(Equal("openshift_insecure_routes"))
-			Expect(cfg.Policies[0].Rules[0].Name).To(Equal("openshift_route_default_route2"))
+			It("properly configures route resources", func() {
+				namespace := "default"
+				spec := routeapi.RouteSpec{
+					Host: "foobar.com",
+					Path: "/foo",
+					To: routeapi.RouteTargetReference{
+						Kind: "Service",
+						Name: "foo",
+					},
+					Port: &routeapi.RoutePort{
+						TargetPort: intstr.FromInt(80),
+					},
+					TLS: &routeapi.TLSConfig{
+						Termination: "edge",
+						Certificate: "cert",
+						Key:         "key",
+					},
+				}
+				route := test.NewRoute("route", "1", namespace, spec, nil)
+				ps := portStruct{
+					protocol: "https",
+					port:     443,
+				}
+				rc := RouteConfig{
+					HttpVs:  "ose-vserver",
+					HttpsVs: "https-ose-vserver",
+				}
+				svcFwdRulesMap := NewServiceFwdRuleMap()
+				cfg, _, _ := mockMgr.appMgr.createRSConfigFromRoute(
+					route, getRouteCanonicalServiceName(route),
+					&Resources{}, rc, ps, nil, svcFwdRulesMap)
+				Expect(cfg.Virtual.Name).To(Equal("https-ose-vserver"))
+				Expect(cfg.Pools[0].Name).To(Equal("openshift_default_foo"))
+				Expect(cfg.Pools[0].ServiceName).To(Equal("foo"))
+				Expect(cfg.Pools[0].ServicePort).To(Equal(int32(80)))
+				Expect(cfg.Policies[0].Name).To(Equal("openshift_secure_routes"))
+				Expect(cfg.Policies[0].Rules[0].Name).To(Equal("openshift_route_default_route"))
+
+				spec = routeapi.RouteSpec{
+					Host: "foobar.com",
+					Path: "/foo",
+					To: routeapi.RouteTargetReference{
+						Kind: "Service",
+						Name: "bar",
+					},
+					Port: &routeapi.RoutePort{
+						TargetPort: intstr.FromInt(80),
+					},
+				}
+				route2 := test.NewRoute("route2", "1", namespace, spec, nil)
+				ps = portStruct{
+					protocol: "http",
+					port:     80,
+				}
+				cfg, _, _ = mockMgr.appMgr.createRSConfigFromRoute(
+					route2, getRouteCanonicalServiceName(route2),
+					&Resources{}, rc, ps, nil, svcFwdRulesMap)
+				Expect(cfg.Virtual.Name).To(Equal("ose-vserver"))
+				Expect(cfg.Pools[0].Name).To(Equal("openshift_default_bar"))
+				Expect(cfg.Pools[0].ServiceName).To(Equal("bar"))
+				Expect(cfg.Pools[0].ServicePort).To(Equal(int32(80)))
+				Expect(cfg.Policies[0].Name).To(Equal("openshift_insecure_routes"))
+				Expect(cfg.Policies[0].Rules[0].Name).To(Equal("openshift_route_default_route2"))
+			})
 		})
 
 		It("sets and removes internal data group records", func() {

--- a/pkg/appmanager/validateResources.go
+++ b/pkg/appmanager/validateResources.go
@@ -109,7 +109,7 @@ func (appMgr *Manager) checkValidIngress(
 	var keyList []*serviceQueueKey
 	// Depending on the Ingress, we may loop twice here, once for http and once for https
 	for _, portStruct := range appMgr.virtualPorts(ing) {
-		rsCfg := createRSConfigFromIngress(
+		rsCfg := appMgr.createRSConfigFromIngress(
 			ing,
 			appMgr.resources,
 			namespace,


### PR DESCRIPTION
Problem: iRules and datagroups were being created early and left behind for both Ingresses and Routes.
The ctlr also had issues leaving behind health monitors and profiles for Routes.

Solution: Ensured that iRules and datagroups are only created when necessary, and are cleaned up when done being used. Also added some logic to clean up health monitors and profiles properly for Routes.

Fixes #567 