### PR TITLE
Cherrypick 567

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -11,6 +11,7 @@ Bug Fixes
 * :cccl-issue:`211` - Memory leak in f5-cccl submodule
 * :issues:`555` - Controller high CPU usage when inactive
 * :issues:`510` - Change behavior of controller on startup when encountering errors
+* :issues:`567` - Clean up all objects (including iRules and datagroups) when deleting Routes.
 
 v1.4.1
 ------

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -3023,7 +3023,7 @@ var _ = Describe("AppManager Tests", func() {
 				r = mockMgr.addIngress(ing1a)
 				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
 				nsMap, found = mockMgr.appMgr.intDgMap[grpRef]
-				Expect(found).To(BeTrue(), "redirect group not found")
+				Expect(found).To(BeFalse(), "redirect group should be gone")
 				flatDg = nsMap.FlattenNamespaces()
 				Expect(flatDg).To(BeNil(), "should not have data")
 			})
@@ -3449,7 +3449,7 @@ var _ = Describe("AppManager Tests", func() {
 					r = mockMgr.deleteRoute(route1b)
 					Expect(r).To(BeTrue(), "Route resource should be processed.")
 					nsMap, found = mockMgr.appMgr.intDgMap[grpRef]
-					Expect(found).To(BeTrue(), "redirect group not found")
+					Expect(found).To(BeFalse(), "redirect group should be gone")
 					flatDg = nsMap.FlattenNamespaces()
 					Expect(flatDg).To(BeNil(), "should not have data")
 
@@ -3459,7 +3459,7 @@ var _ = Describe("AppManager Tests", func() {
 					r = mockMgr.addRoute(route1a)
 					Expect(r).To(BeTrue(), "Route resource should be processed.")
 					nsMap, found = mockMgr.appMgr.intDgMap[grpRef]
-					Expect(found).To(BeTrue(), "redirect group not found")
+					Expect(found).To(BeFalse(), "redirect group should be gone")
 					flatDg = nsMap.FlattenNamespaces()
 					Expect(flatDg).To(BeNil(), "should not have data")
 				})

--- a/pkg/appmanager/healthMonitors.go
+++ b/pkg/appmanager/healthMonitors.go
@@ -85,7 +85,7 @@ func (appMgr *Manager) assignMonitorToPool(
 				// Also add a monitor index to the name to be consistent with the
 				// marathon-bigip-ctlr. Since the monitor names are already unique here,
 				// appending a '0' is sufficient.
-				Name:      poolName + "_0_http",
+				Name:      formatMonitorName(poolName),
 				Partition: partition,
 				Type:      "http",
 				Interval:  ruleData.healthMon.Interval,
@@ -137,7 +137,7 @@ func (appMgr *Manager) handleSingleServiceHealthMonitors(
 	if nil != err {
 		log.Errorf("%s", err.Error())
 		appMgr.recordIngressEvent(ing, "MonitorError", err.Error())
-		mon := poolName + "_0_http"
+		mon := formatMonitorName(poolName)
 		_, pool := splitBigipPath(poolName, false)
 		cfg.RemoveMonitor(pool, mon)
 		return
@@ -277,7 +277,7 @@ func (appMgr *Manager) handleRouteHealthMonitors(
 	if nil != err {
 		log.Errorf("%s", err.Error())
 		// If this monitor exists already, remove it
-		monitorName := poolPath + "_0_http"
+		monitorName := formatMonitorName(poolPath)
 		if removed := cfg.RemoveMonitor(pool.Name, monitorName); removed {
 			stats.vsUpdated += 1
 		}

--- a/pkg/appmanager/profiles_test.go
+++ b/pkg/appmanager/profiles_test.go
@@ -141,7 +141,7 @@ var _ = Describe("AppManager Profile Tests", func() {
 			// No annotations were specified to control http redirect, check that
 			// we are in the default state 2.
 			Expect(len(httpCfg.Virtual.IRules)).To(Equal(1))
-			expectedIRuleName := fmt.Sprintf("/%s/%s",
+			expectedIRuleName := fmt.Sprintf("/%s/%s_443",
 				DEFAULT_PARTITION, httpRedirectIRuleName)
 			Expect(httpCfg.Virtual.IRules[0]).To(Equal(expectedIRuleName))
 
@@ -154,7 +154,7 @@ var _ = Describe("AppManager Profile Tests", func() {
 			Expect(httpCfg).ToNot(BeNil())
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
 			Expect(len(httpCfg.Virtual.IRules)).To(Equal(1))
-			expectedIRuleName = fmt.Sprintf("/%s/%s",
+			expectedIRuleName = fmt.Sprintf("/%s/%s_443",
 				DEFAULT_PARTITION, httpRedirectIRuleName)
 			Expect(httpCfg.Virtual.IRules[0]).To(Equal(expectedIRuleName))
 

--- a/pkg/appmanager/validateResources.go
+++ b/pkg/appmanager/validateResources.go
@@ -109,7 +109,7 @@ func (appMgr *Manager) checkValidIngress(
 	var keyList []*serviceQueueKey
 	// Depending on the Ingress, we may loop twice here, once for http and once for https
 	for _, portStruct := range appMgr.virtualPorts(ing) {
-		rsCfg := createRSConfigFromIngress(
+		rsCfg := appMgr.createRSConfigFromIngress(
 			ing,
 			appMgr.resources,
 			namespace,


### PR DESCRIPTION
Cleanup for leftover objects (Ingress/Routes)

Problem: iRules and datagroups were being created early and left behind for both Ingresses and Routes.
The ctlr also had issues leaving behind health monitors and profiles for Routes.

Solution: Ensured that iRules and datagroups are only created when necessary, and are cleaned up when done being used. Also added some logic to clean up health monitors and profiles properly for Routes.