### PR TITLE
Fix iRule name for 11.6; datagroup record

### DIFF
--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -1228,7 +1228,7 @@ func (appMgr *Manager) handleIngressTls(
 		rsCfg.Virtual.AddIRule(ruleName)
 		if nil != ing.Spec.Backend {
 			svcFwdRulesMap.AddEntry(ing.ObjectMeta.Namespace,
-				ing.Spec.Backend.ServiceName, "*", "/")
+				ing.Spec.Backend.ServiceName, "\\*", "/")
 		}
 		for _, rul := range ing.Spec.Rules {
 			if nil != rul.HTTP {


### PR DESCRIPTION
Problem: The ssl passthrough irule in 11.6 was not validating data fields correctly. Also in 11.6, we
were passing a wildcard to a datagroup record, which needs to be escaped.

Solution: Properly format the iRule variables to be compatible with 11.6. Also, escape the wildcard string
that is passed in the https redirect data group.