### PR TITLE
Update docs version on version-tag commits

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,15 @@ script:
   - export IMG_TAG="${BASE_PUSH_TARGET}:${TRAVIS_COMMIT}"
   - export BUILD_IMG_TAG="${BASE_PUSH_TARGET}-devel:${TRAVIS_COMMIT}"
   - export BUILD_STAMP=devel-$TRAVIS_BRANCH-n-$TRAVIS_BUILD_NUMBER-id-$TRAVIS_BUILD_ID-$(date +%s)
-  - export CTLR_VERSION=$(echo $TRAVIS_BRANCH | sed s/-stable//g)
+  - |
+    if [[ "$TRAVIS_BRANCH" == *"-stable" ]]; then
+      export CTLR_VERSION=v$(echo $TRAVIS_BRANCH | sed s/-stable//g)
+    elif [[ "$TRAVIS_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]* ]]; then
+      va=( ${TRAVIS_BRANCH//./ } ) # replace decimals and split into array
+      export CTLR_VERSION="${va[0]}.${va[1]}"
+    else
+      export CTLR_VERSION=$TRAVIS_BRANCH
+    fi
   - export CLEAN_BUILD=true
   - export BASE_OS=alpine
   - make verify
@@ -59,7 +67,7 @@ deploy:
     on:
       all_branches: true
       repo: F5Networks/k8s-bigip-ctlr
-      condition: $TRAVIS_BRANCH == *"-stable"
+      condition: $TRAVIS_BRANCH == *"-stable" || "$TRAVIS_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]*
     script:
       - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/k8s-bigip-ctlr v$CTLR_VERSION
 

--- a/build-tools/docker-docs.sh
+++ b/build-tools/docker-docs.sh
@@ -13,7 +13,7 @@ RUN_ARGS=( \
   -e TRAVIS=$TRAVIS
 )
 
-if [[ $TRAVIS_BRANCH == *"-stable" ]]; then
+if [[ $TRAVIS_BRANCH == *"-stable" || "$TRAVIS_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]* ]]; then
   release="$(git describe --tags --abbrev=0)"
   RUN_ARGS+=( -e DOCS_RELEASE=$release )
   va=( ${release//./ } ) # replace decimals and split into array


### PR DESCRIPTION
Problem:
Docs version string not being updated when a new version
tag is pushed. Also, docs are not published when new version
tags are pushed

Solution:
1. Changed the criteria for updating docs version string to include
version-tag expected string.
2. Changed condition in travis which allows docs publish
when new version tags are pushed.