### PR TITLE
Fix SSL Secret profile issues

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -893,14 +893,13 @@ func (appMgr *Manager) syncConfigMaps(
 				if profile.Context != customProfileClient {
 					continue
 				}
-				profileName := fmt.Sprintf("%s/%s", profile.Partition, profile.Name)
 				// Check if profile is contained in a Secret
 				secret, err := appMgr.kubeClient.Core().Secrets(cm.ObjectMeta.Namespace).
-					Get(profileName, metav1.GetOptions{})
+					Get(profile.Name, metav1.GetOptions{})
 				if err != nil {
 					// No secret, so we assume the profile is a BIG-IP default
-					log.Debugf("No Secret with name '%s', parsing secretName as path instead.",
-						profileName)
+					log.Debugf("No Secret with name '%s' in namespace '%s', "+
+						"parsing secretName as path instead.", profile.Name, sKey.Namespace)
 					continue
 				}
 				err, updated := appMgr.createSecretSslProfile(rsCfg, secret)

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -684,6 +684,7 @@ func compareVirtuals(vs, expected Virtual) {
 	Expect(vs.SourceAddrTranslation).To(Equal(expected.SourceAddrTranslation))
 	Expect(vs.Policies).To(Equal(expected.Policies))
 	Expect(vs.IRules).To(Equal(expected.IRules))
+	Expect(len(vs.Profiles)).To(Equal(len(expected.Profiles)))
 	for i, prof := range vs.Profiles {
 		Expect(prof.Context).To(Equal(expected.Profiles[i].Context))
 		Expect(prof.Name).To(Equal(expected.Profiles[i].Name))

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -390,9 +390,9 @@ func convertStringToProfileRef(profileName, context, ns string) ProfileRef {
 		profRef.Partition = parts[0]
 		profRef.Name = parts[1]
 	case 1:
-		// This is technically supported on the Big-IP, but will fail in the
-		// python driver. Issue a warning here for better context.
-		log.Warningf("Profile name '%v' does not contain a full path.", profileName)
+		log.Debugf("Partition not provided in profile '%s', using default partition '%s'",
+			profileName, DEFAULT_PARTITION)
+		profRef.Partition = DEFAULT_PARTITION
 		profRef.Name = profileName
 	default:
 		// This is almost certainly an error, but again issue a warning for
@@ -1171,8 +1171,9 @@ func (appMgr *Manager) handleIngressTls(
 					Get(tls.SecretName, metav1.GetOptions{})
 				if err != nil {
 					// No secret, so we assume the profile is a BIG-IP default
-					log.Debugf("No Secret with name '%s': %s. Parsing secretName as path instead.",
-						tls.SecretName, err)
+					log.Debugf("No Secret with name '%s' in namespace '%s', "+
+						"parsing secretName as path instead.",
+						tls.SecretName, ing.ObjectMeta.Namespace)
 					profRef := convertStringToProfileRef(
 						tls.SecretName, customProfileClient, ing.ObjectMeta.Namespace)
 					rsCfg.Virtual.AddOrUpdateProfile(profRef)


### PR DESCRIPTION
Problem: Some logging around using Secret SSL profiles was confusing or vague. Also, the partition was not included if only the profile name was provided (which is the case with Secrets), resulting in a bunch of unnecessary updates to the virtual server. Finally, configmap profiles were not being cleaned up properly when removed.

Solution: Update the logging to be clearer about what is happening, and removed a log that was misleading. Ensured that if a secret profile name was used, then the partition is added to prevent constant updates to the virtual server. Also ensured that profiles are cleaned up in the configmap case.

Fixes #552