### PR TITLE
Fix: #433 Add Serversslprofile to Ingress integration

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -585,6 +585,8 @@ Supported Ingress Annotations
 | ingress.kubernetes.io/ssl-redirect            | boolean     | Optional  | Tells the Controller to redirect HTTP traffic to the HTTPS port for HTTPS Ingress   | true        | "true", "false"                         |
 |                                               |             |           | resources (see TLS Ingress resources, below).                                       |             |                                         |
 +-----------------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+-----------------------------------------+
+| virtual-server.f5.com/serverssl               | string      | Optional  | The name of a pre-configured server ssl profile on the BIG-IP system.               | N/A         |                                         |
++-----------------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+-----------------------------------------+
 
 Ingress Health Monitors
 ```````````````````````

--- a/pkg/appmanager/profiles.go
+++ b/pkg/appmanager/profiles.go
@@ -493,6 +493,16 @@ func (appMgr *Manager) deleteUnusedProfiles(
 							&referenced,
 						)
 					}
+					if serverProfile, ok :=
+						ing.ObjectMeta.Annotations[f5ServerSslProfileAnnotation]; ok == true {
+						appMgr.checkProfile(
+							prof,
+							&toRemove,
+							ing.ObjectMeta.Namespace,
+							serverProfile,
+							&referenced,
+						)
+					}
 					if referenced {
 						break
 					}
@@ -521,6 +531,8 @@ func (appMgr *Manager) deleteUnusedProfiles(
 				}
 			}
 			if !referenced {
+				log.Debugf("deleteUnusedProfiles Removing profile: %v.",
+					prof)
 				toRemove = append(toRemove, prof)
 			}
 		}

--- a/pkg/appmanager/profiles_test.go
+++ b/pkg/appmanager/profiles_test.go
@@ -178,7 +178,20 @@ var _ = Describe("AppManager Profile Tests", func() {
 			}
 			sort.Strings(clientProfileNames)
 			Expect(clientProfileNames).To(Equal(secretArray))
-
+			// ServerSSL Profile tests
+			fooIng.ObjectMeta.Annotations[f5ServerSslProfileAnnotation] = "Common/server"
+			r = mockMgr.addIngress(fooIng)
+			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
+			httpsCfg, found = resources.Get(svcKey, formatIngressVSName("1.2.3.4", 443))
+			Expect(found).To(BeTrue())
+			Expect(httpsCfg).ToNot(BeNil())
+			Expect(httpsCfg.Virtual.Profiles).To(ContainElement(
+				ProfileRef{
+					Name:      "server",
+					Partition: "Common",
+					Context:   customProfileServer,
+					Namespace: namespace,
+				}))
 			// Now test state 3.
 			fooIng.ObjectMeta.Annotations[ingressSslRedirect] = "false"
 			fooIng.ObjectMeta.Annotations[ingressAllowHttp] = "true"

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -1253,6 +1253,13 @@ func (appMgr *Manager) handleIngressTls(
 				rsCfg.Virtual.AddOrUpdateProfile(profRef)
 			}
 		}
+		if serverProfile, ok :=
+			ing.ObjectMeta.Annotations[f5ServerSslProfileAnnotation]; ok == true {
+			secretName := formatIngressSslProfileName(serverProfile)
+			profRef := convertStringToProfileRef(
+				secretName, customProfileServer, ing.ObjectMeta.Namespace)
+			rsCfg.Virtual.AddOrUpdateProfile(profRef)
+		}
 		return cpUpdated
 	}
 


### PR DESCRIPTION
Problem:
We need to reencrypt from the BigIP to the PODs in Openshift

Solution:
Adding support for a new annotation in Ingress (from the #433 issue)

    virtual-server.f5.com/serverssl: "/Common/serverssl-k8s"

Detailed description of your solution:

Adding handling for serverssl in resourceconfig.go/handleIngressTls to add the profile
and profiles.go/deleteUnusedProfiles to don't accidently delete it. I also added a debug output so it's possible to logg unused profiles

Testing :
We have tested it on 1.4.3 branch in our environment based on Openshift 3.6 and 3.7.