### PR TITLE
Unit test shouldn't look for python driver

### DIFF
--- a/cmd/k8s-bigip-ctlr/main_test.go
+++ b/cmd/k8s-bigip-ctlr/main_test.go
@@ -133,7 +133,10 @@ var _ = Describe("Main Tests", func() {
 			configFile := fmt.Sprintf("/tmp/k8s-bigip-ctlr.config.%d.json",
 				os.Getpid())
 			driverPath, err := exec.LookPath("bigipconfigdriver.py")
-			Expect(err).To(BeNil(), "We should find the driver.")
+			if err != nil {
+				// Set path for local runs
+				driverPath = "bigipconfigdriver.py"
+			}
 
 			args := []string{
 				pyDriver,


### PR DESCRIPTION
Problem: If running locally without the bigipconfigdriver.py installed, one of the unit tests would fail when looking for the existence to this file. This test shouldn't care whether the file exists, as that is not what is being tested.

Solution: Remove the check for the existence of bigipconfigdriver.py, as it is not necessary to the test.

Fixes #623 