### PR TITLE
Fixes bug causing periodic failure of the 'Mock driver subprocess' un…

### DIFF
--- a/cmd/k8s-bigip-ctlr/test/bigipconfigdriver.py
+++ b/cmd/k8s-bigip-ctlr/test/bigipconfigdriver.py
@@ -1,21 +1,41 @@
 #!/usr/bin/env python
 
+import argparse
+import os
 import signal
 import socket
 import sys
 
+# Parses the command line arguments
+parser = argparse.ArgumentParser(description='Writes to a temporary file.')
+# This argument is required by this file. It provides name for the tmp file.
+parser.add_argument('--config-file', type=str, required=True)
+parser.add_argument('--ctlr-prefix', type=str)
+args = parser.parse_args()
+
+# Establishes signal handler for the kill -2 command
 def signal_handler(signal, frame):
     sys.stderr.write("WARNING: Received signal"+ str(signal))
     sys.exit(0)
 
 signal.signal(signal.SIGINT, signal_handler)
 
+# Opens a socket to stall in the while loop
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 s.bind(("", 0))
 s.listen(5)
+
+# Creates the tmp file
+scriptDir = os.path.dirname(__file__)
+filePath = os.path.join(scriptDir, args.config_file)
+f = open(filePath,"w+")
+
+# Infinite loop waiting for SIGINT
 while 1:
     try:
-        sys.stderr.write("DEBUG: Python Driver listening")
+        sys.stderr.write("DEBUG: Python Driver listening\n")
+        f.write("Ready for KeyboardInterrupt")
+        f.close()
         client, address = s.accept()
     except KeyboardInterrupt:
         sys.exit(0)

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -48,11 +48,17 @@ type MockWriter struct {
 	FailStyle    int
 	WrittenTimes int
 	Sections     map[string]interface{}
+	File         string
 	sync.Mutex
 }
 
 func (mw *MockWriter) GetOutputFilename() string {
-	return "mock-file"
+	// Returns the File field if one exists, otherwise returns "mock-file"
+	if len(mw.File) > 0 {
+		return mw.File
+	} else {
+		return "mock-file"
+	}
 }
 
 func (mw *MockWriter) Stop() {


### PR DESCRIPTION
…it test (fixes #602)

Problem:
The 'Mock driver subprocess' unit test in main_test.go periodically
fails due to the AfterEach() section attempting to kill the
bigipconfigdriver.py process before both python and this subprocess have
completed starting up. This would cause an unexpected value to return
from the subprocess.

Solution:
The test now waits for the python subprocess to create a temporary file
and for this file to be written to by the subprocess before attemping
to kill the subprocess.

affects-branches: master