### PR TITLE
Fix node label selector in cluster mode

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -398,9 +398,16 @@ func setupNodePolling(
 			return fmt.Errorf("error creating vxlan manager: %v", err)
 		}
 
+		// Register vxMgr to watch for node updates to process fdb records
 		err = np.RegisterListener(vxMgr.ProcessNodeUpdate)
 		if nil != err {
 			return fmt.Errorf("error registering node update listener for vxlan mode: %v",
+				err)
+		}
+		// Register appMgr to watch for node updates to keep track of watched nodes
+		err = np.RegisterListener(appMgr.ProcessNodeUpdate)
+		if nil != err {
+			return fmt.Errorf("error registering node update listener for appManager: %v",
 				err)
 		}
 		if eventChan != nil {

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -651,11 +651,11 @@ var _ = Describe("AppManager Tests", func() {
 					{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}),
 			}
 
-			expectedReturn := []string{
-				"127.0.0.0",
-				"127.0.0.1",
-				"127.0.0.2",
-				"127.0.0.3",
+			expectedReturn := []Node{
+				{Name: "node0", Addr: "127.0.0.0"},
+				{Name: "node1", Addr: "127.0.0.1"},
+				{Name: "node2", Addr: "127.0.0.2"},
+				{Name: "node3", Addr: "127.0.0.3"},
 			}
 
 			fakeClient := fake.NewSimpleClientset()
@@ -669,7 +669,7 @@ var _ = Describe("AppManager Tests", func() {
 
 			nodes, err := fakeClient.Core().Nodes().List(metav1.ListOptions{})
 			Expect(err).To(BeNil(), "Should not fail listing nodes.")
-			addresses, err := appMgr.getNodeAddresses(nodes.Items)
+			addresses, err := appMgr.getNodes(nodes.Items)
 			Expect(err).To(BeNil(), "Should not fail getting addresses.")
 			Expect(addresses).To(Equal(expectedReturn))
 		})
@@ -705,10 +705,10 @@ var _ = Describe("AppManager Tests", func() {
 					}),
 			}
 
-			expectedReturn := []string{
-				"127.0.0.1",
-				"127.0.0.2",
-				"127.0.0.3",
+			expectedReturn := []Node{
+				{Name: "node1", Addr: "127.0.0.1"},
+				{Name: "node2", Addr: "127.0.0.2"},
+				{Name: "node3", Addr: "127.0.0.3"},
 			}
 
 			fakeClient := fake.NewSimpleClientset()
@@ -723,17 +723,17 @@ var _ = Describe("AppManager Tests", func() {
 			appMgr.useNodeInternal = false
 			nodes, err := fakeClient.Core().Nodes().List(metav1.ListOptions{})
 			Expect(err).To(BeNil(), "Should not fail listing nodes.")
-			addresses, err := appMgr.getNodeAddresses(nodes.Items)
+			addresses, err := appMgr.getNodes(nodes.Items)
 			Expect(err).To(BeNil(), "Should not fail getting addresses.")
 			Expect(addresses).To(Equal(expectedReturn))
 
 			// test filtering
-			expectedInternal := []string{
-				"127.0.0.4",
+			expectedInternal := []Node{
+				{Name: "node4", Addr: "127.0.0.4"},
 			}
 
 			appMgr.useNodeInternal = true
-			addresses, err = appMgr.getNodeAddresses(nodes.Items)
+			addresses, err = appMgr.getNodes(nodes.Items)
 			Expect(err).To(BeNil(), "Should not fail getting internal addresses.")
 			Expect(addresses).To(Equal(expectedInternal))
 
@@ -743,11 +743,11 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(err).To(BeNil(), "Should not fail deleting node.")
 			}
 
-			expectedReturn = []string{}
+			expectedReturn = []Node{}
 			appMgr.useNodeInternal = false
 			nodes, err = fakeClient.Core().Nodes().List(metav1.ListOptions{})
 			Expect(err).To(BeNil(), "Should not fail listing nodes.")
-			addresses, err = appMgr.getNodeAddresses(nodes.Items)
+			addresses, err = appMgr.getNodes(nodes.Items)
 			Expect(err).To(BeNil(), "Should not fail getting empty addresses.")
 			Expect(addresses).To(Equal(expectedReturn), "Should get no addresses.")
 		})
@@ -776,10 +776,10 @@ var _ = Describe("AppManager Tests", func() {
 					}),
 			}
 
-			expectedOgSet := []string{
-				"127.0.0.1",
-				"127.0.0.2",
-				"127.0.0.3",
+			expectedOgSet := []Node{
+				{Name: "node1", Addr: "127.0.0.1"},
+				{Name: "node2", Addr: "127.0.0.2"},
+				{Name: "node3", Addr: "127.0.0.3"},
 			}
 
 			fakeClient := fake.NewSimpleClientset(&v1.NodeList{Items: originalSet})
@@ -796,8 +796,8 @@ var _ = Describe("AppManager Tests", func() {
 			Expect(cachedNodes).To(Equal(expectedOgSet))
 
 			// test filtering
-			expectedInternal := []string{
-				"127.0.0.4",
+			expectedInternal := []Node{
+				{Name: "node4", Addr: "127.0.0.4"},
 			}
 
 			appMgr.useNodeInternal = true
@@ -822,7 +822,7 @@ var _ = Describe("AppManager Tests", func() {
 			nodes, err = fakeClient.Core().Nodes().List(metav1.ListOptions{})
 			Expect(err).To(BeNil(), "Should not fail listing nodes.")
 			appMgr.ProcessNodeUpdate(nodes.Items, err)
-			expectedAddSet := append(expectedOgSet, "127.0.0.6")
+			expectedAddSet := append(expectedOgSet, Node{Name: "nodeAdd", Addr: "127.0.0.6"})
 
 			Expect(appMgr.oldNodes).To(Equal(expectedAddSet))
 
@@ -835,7 +835,7 @@ var _ = Describe("AppManager Tests", func() {
 			nodes, err = fakeClient.Core().Nodes().List(metav1.ListOptions{})
 			Expect(err).To(BeNil(), "Should not fail listing nodes.")
 			appMgr.ProcessNodeUpdate(nodes.Items, err)
-			expectedAddSet = append(expectedOgSet, "127.0.0.6")
+			expectedAddSet = append(expectedOgSet, Node{Name: "nodeAdd", Addr: "127.0.0.6"})
 
 			Expect(appMgr.oldNodes).To(Equal(expectedAddSet))
 
@@ -851,7 +851,9 @@ var _ = Describe("AppManager Tests", func() {
 			fakeClient.Core().Nodes().Delete("node3", &metav1.DeleteOptions{})
 			Expect(err).To(BeNil())
 
-			expectedDelSet := []string{"127.0.0.6"}
+			expectedDelSet := []Node{
+				{Name: "nodeAdd", Addr: "127.0.0.6"},
+			}
 
 			appMgr.useNodeInternal = false
 			nodes, err = fakeClient.Core().Nodes().List(metav1.ListOptions{})
@@ -994,10 +996,6 @@ var _ = Describe("AppManager Tests", func() {
 				nodeSet := []v1.Node{
 					*test.NewNode("node0", "0", false, []v1.NodeAddress{
 						{Type: "InternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
-					*test.NewNode("node1", "1", false, []v1.NodeAddress{
-						{Type: "InternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
-					*test.NewNode("node2", "2", false, []v1.NodeAddress{
-						{Type: "InternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
 				}
 
 				mockMgr.processNodeUpdate(nodeSet, nil)
@@ -1012,12 +1010,19 @@ var _ = Describe("AppManager Tests", func() {
 					"schema": schemaUrl,
 					"data":   configmapFoo9090})
 
-				foo := test.NewService("foo", "1", namespace, "NodePort",
-					[]v1.ServicePort{{Port: 80, NodePort: 30001},
-						{Port: 8080, NodePort: 38001},
-						{Port: 9090, NodePort: 39001}})
+				fooPorts := []v1.ServicePort{{Port: 80, NodePort: 30001},
+					{Port: 8080, NodePort: 38001},
+					{Port: 9090, NodePort: 39001}}
+				foo := test.NewService("foo", "1", namespace, "NodePort", fooPorts)
 				r := mockMgr.addService(foo)
 				Expect(r).To(BeTrue(), "Service should be processed.")
+
+				fooIps := []string{"10.1.1.1"}
+				fooEndpts := test.NewEndpoints(
+					"foo", "1", "node0", namespace, fooIps, []string{},
+					convertSvcPortsToEndpointPorts(fooPorts))
+				r = mockMgr.addEndpoints(fooEndpts)
+				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 
 				r = mockMgr.addConfigMap(cfgFoo)
 				Expect(r).To(BeTrue(), "ConfigMap should be processed.")
@@ -1046,11 +1051,7 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(resources.CountOf(serviceKey{"foo", 8080, namespace})).To(Equal(1))
 				Expect(resources.CountOf(serviceKey{"foo", 9090, namespace})).To(Equal(1))
 
-				addrs := []string{
-					"127.0.0.0",
-					"127.0.0.1",
-					"127.0.0.2",
-				}
+				addrs := []string{"127.0.0.0"}
 				rs, ok := resources.Get(
 					serviceKey{"foo", 80, namespace}, formatConfigMapVSName(cfgFoo))
 				Expect(ok).To(BeTrue())
@@ -1236,6 +1237,21 @@ var _ = Describe("AppManager Tests", func() {
 				barIps := []string{"10.2.96.0", "10.2.96.3"}
 				barPorts := []v1.ServicePort{newServicePort("port1", 80)}
 
+				nodes := []*v1.Node{
+					test.NewNode("node0", "0", false, []v1.NodeAddress{
+						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
+					test.NewNode("node1", "1", false, []v1.NodeAddress{
+						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
+				}
+				for _, node := range nodes {
+					n, err := mockMgr.appMgr.kubeClient.Core().Nodes().Create(node)
+					Expect(err).To(BeNil(), "Should not fail creating node.")
+					Expect(n).To(Equal(node))
+				}
+				n, err := mockMgr.appMgr.kubeClient.Core().Nodes().List(metav1.ListOptions{})
+				Expect(err).To(BeNil())
+				mockMgr.processNodeUpdate(n.Items, nil)
+
 				cfgFoo := test.NewConfigMap("foomap", "1", namespace, map[string]string{
 					"schema": schemaUrl,
 					"data":   configmapFoo8080})
@@ -1246,9 +1262,9 @@ var _ = Describe("AppManager Tests", func() {
 				foo := test.NewService("foo", "1", namespace, v1.ServiceTypeClusterIP, fooPorts)
 				bar := test.NewService("bar", "1", namespace, v1.ServiceTypeClusterIP, barPorts)
 
-				fooEndpts := test.NewEndpoints("foo", "1", namespace, fooIps, barIps,
+				fooEndpts := test.NewEndpoints("foo", "1", "node0", namespace, fooIps, barIps,
 					convertSvcPortsToEndpointPorts(fooPorts))
-				barEndpts := test.NewEndpoints("bar", "1", namespace, barIps, fooIps,
+				barEndpts := test.NewEndpoints("bar", "1", "node1", namespace, barIps, fooIps,
 					convertSvcPortsToEndpointPorts(barPorts))
 				cfgCh := make(chan struct{})
 				endptCh := make(chan struct{})
@@ -2032,15 +2048,34 @@ var _ = Describe("AppManager Tests", func() {
 
 				foo := test.NewService(svcName, "1", namespace, v1.ServiceTypeClusterIP, svcPorts)
 
+				nodes := []*v1.Node{
+					test.NewNode("node0", "0", false, []v1.NodeAddress{
+						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
+					test.NewNode("node1", "1", false, []v1.NodeAddress{
+						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
+					test.NewNode("node2", "2", false, []v1.NodeAddress{
+						{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
+					test.NewNode("node3", "3", false, []v1.NodeAddress{
+						{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}),
+				}
+				for _, node := range nodes {
+					n, err := mockMgr.appMgr.kubeClient.Core().Nodes().Create(node)
+					Expect(err).To(BeNil(), "Should not fail creating node.")
+					Expect(n).To(Equal(node))
+				}
+				n, err := mockMgr.appMgr.kubeClient.Core().Nodes().List(metav1.ListOptions{})
+				Expect(err).To(BeNil())
+				mockMgr.processNodeUpdate(n.Items, nil)
+
 				endptPorts := convertSvcPortsToEndpointPorts(svcPorts)
-				goodEndpts := test.NewEndpoints(svcName, "1", namespace, emptyIps, emptyIps,
-					endptPorts)
+				goodEndpts := test.NewEndpoints(svcName, "1", "node0", namespace,
+					emptyIps, emptyIps, endptPorts)
 
 				r := mockMgr.addEndpoints(goodEndpts)
 				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 				// this is for another service
-				badEndpts := test.NewEndpoints("wrongSvc", "1", namespace, []string{"10.2.96.7"},
-					[]string{}, endptPorts)
+				badEndpts := test.NewEndpoints("wrongSvc", "1", "node1", namespace,
+					[]string{"10.2.96.7"}, []string{}, endptPorts)
 				r = mockMgr.addEndpoints(badEndpts)
 				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 
@@ -2063,19 +2098,19 @@ var _ = Describe("AppManager Tests", func() {
 
 				// Move it back to ready from not ready and make sure it is re-added
 				r = mockMgr.updateEndpoints(test.NewEndpoints(
-					svcName, "2", namespace, readyIps, notReadyIps, endptPorts))
+					svcName, "2", "node1", namespace, readyIps, notReadyIps, endptPorts))
 				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 				validateServiceIps(svcName, namespace, svcPorts, readyIps, resources)
 
 				// Remove all endpoints make sure they are removed but virtual server exists
-				r = mockMgr.updateEndpoints(test.NewEndpoints(svcName, "3", namespace, emptyIps,
-					emptyIps, endptPorts))
+				r = mockMgr.updateEndpoints(test.NewEndpoints(svcName, "3", "node2", namespace,
+					emptyIps, emptyIps, endptPorts))
 				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 				validateServiceIps(svcName, namespace, svcPorts, nil, resources)
 
 				// Move it back to ready from not ready and make sure it is re-added
-				r = mockMgr.updateEndpoints(test.NewEndpoints(svcName, "4", namespace, readyIps,
-					notReadyIps, endptPorts))
+				r = mockMgr.updateEndpoints(test.NewEndpoints(svcName, "4", "node3", namespace,
+					readyIps, notReadyIps, endptPorts))
 				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 				validateServiceIps(svcName, namespace, svcPorts, readyIps, resources)
 			})
@@ -2102,6 +2137,29 @@ var _ = Describe("AppManager Tests", func() {
 					"schema": schemaUrl,
 					"data":   configmapFoo9090})
 
+				nodes := []*v1.Node{
+					test.NewNode("node0", "0", false, []v1.NodeAddress{
+						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
+					test.NewNode("node1", "1", false, []v1.NodeAddress{
+						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
+					test.NewNode("node2", "2", false, []v1.NodeAddress{
+						{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
+					test.NewNode("node3", "3", false, []v1.NodeAddress{
+						{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}),
+					test.NewNode("node4", "4", false, []v1.NodeAddress{
+						{Type: "ExternalIP", Address: "127.0.0.4"}}, []v1.Taint{}),
+					test.NewNode("node5", "5", false, []v1.NodeAddress{
+						{Type: "ExternalIP", Address: "127.0.0.5"}}, []v1.Taint{}),
+				}
+				for _, node := range nodes {
+					n, err := mockMgr.appMgr.kubeClient.Core().Nodes().Create(node)
+					Expect(err).To(BeNil(), "Should not fail creating node.")
+					Expect(n).To(Equal(node))
+				}
+				n, err := mockMgr.appMgr.kubeClient.Core().Nodes().List(metav1.ListOptions{})
+				Expect(err).To(BeNil())
+				mockMgr.processNodeUpdate(n.Items, nil)
+
 				foo := test.NewService(svcName, "1", namespace, v1.ServiceTypeClusterIP, svcPorts)
 
 				r := mockMgr.addConfigMap(cfgFoo)
@@ -2123,13 +2181,13 @@ var _ = Describe("AppManager Tests", func() {
 				}
 
 				endptPorts := convertSvcPortsToEndpointPorts(svcPorts)
-				goodEndpts := test.NewEndpoints(svcName, "1", namespace, readyIps, notReadyIps,
-					endptPorts)
+				goodEndpts := test.NewEndpoints(svcName, "1", "node0", namespace,
+					readyIps, notReadyIps, endptPorts)
 				r = mockMgr.addEndpoints(goodEndpts)
 				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 				// this is for another service
-				badEndpts := test.NewEndpoints("wrongSvc", "1", namespace, []string{"10.2.96.7"},
-					[]string{}, endptPorts)
+				badEndpts := test.NewEndpoints("wrongSvc", "1", "node1", namespace,
+					[]string{"10.2.96.7"}, []string{}, endptPorts)
 				r = mockMgr.addEndpoints(badEndpts)
 				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 
@@ -2139,28 +2197,28 @@ var _ = Describe("AppManager Tests", func() {
 				// goes away from virtual servers
 				notReadyIps = append(notReadyIps, readyIps[len(readyIps)-1])
 				readyIps = readyIps[:len(readyIps)-1]
-				r = mockMgr.updateEndpoints(test.NewEndpoints(svcName, "2", namespace, readyIps,
-					notReadyIps, endptPorts))
+				r = mockMgr.updateEndpoints(test.NewEndpoints(svcName, "2", "node2", namespace,
+					readyIps, notReadyIps, endptPorts))
 				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 				validateServiceIps(svcName, namespace, svcPorts, readyIps, resources)
 
 				// Move it back to ready from not ready and make sure it is re-added
 				readyIps = append(readyIps, notReadyIps[len(notReadyIps)-1])
 				notReadyIps = notReadyIps[:len(notReadyIps)-1]
-				r = mockMgr.updateEndpoints(test.NewEndpoints(svcName, "3", namespace, readyIps,
-					notReadyIps, endptPorts))
+				r = mockMgr.updateEndpoints(test.NewEndpoints(svcName, "3", "node3", namespace,
+					readyIps, notReadyIps, endptPorts))
 				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 				validateServiceIps(svcName, namespace, svcPorts, readyIps, resources)
 
 				// Remove all endpoints make sure they are removed but virtual server exists
-				r = mockMgr.updateEndpoints(test.NewEndpoints(svcName, "4", namespace, emptyIps,
-					emptyIps, endptPorts))
+				r = mockMgr.updateEndpoints(test.NewEndpoints(svcName, "4", "node4", namespace,
+					emptyIps, emptyIps, endptPorts))
 				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 				validateServiceIps(svcName, namespace, svcPorts, nil, resources)
 
 				// Move it back to ready from not ready and make sure it is re-added
-				r = mockMgr.updateEndpoints(test.NewEndpoints(svcName, "5", namespace, readyIps,
-					notReadyIps, endptPorts))
+				r = mockMgr.updateEndpoints(test.NewEndpoints(svcName, "5", "node5", namespace,
+					readyIps, notReadyIps, endptPorts))
 				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 				validateServiceIps(svcName, namespace, svcPorts, readyIps, resources)
 			})
@@ -2175,11 +2233,21 @@ var _ = Describe("AppManager Tests", func() {
 				}
 				svcPodIps := []string{"10.2.96.0", "10.2.96.1", "10.2.96.2"}
 
+				node := test.NewNode("node0", "0", false, []v1.NodeAddress{
+					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{})
+				n, err := mockMgr.appMgr.kubeClient.Core().Nodes().Create(node)
+				Expect(err).To(BeNil(), "Should not fail creating node.")
+				Expect(n).To(Equal(node))
+
+				nodes, err := mockMgr.appMgr.kubeClient.Core().Nodes().List(metav1.ListOptions{})
+				Expect(err).To(BeNil())
+				mockMgr.processNodeUpdate(nodes.Items, nil)
+
 				foo := test.NewService(svcName, "1", namespace, v1.ServiceTypeClusterIP, svcPorts)
 
 				endptPorts := convertSvcPortsToEndpointPorts(svcPorts)
-				r := mockMgr.addEndpoints(test.NewEndpoints(svcName, "1", namespace, svcPodIps,
-					[]string{}, endptPorts))
+				r := mockMgr.addEndpoints(test.NewEndpoints(svcName, "1", "node0", namespace,
+					svcPodIps, []string{}, endptPorts))
 				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 
 				r = mockMgr.addService(foo)
@@ -2232,6 +2300,16 @@ var _ = Describe("AppManager Tests", func() {
 				}
 				svcPodIps := []string{"10.2.96.0", "10.2.96.1", "10.2.96.2"}
 
+				node := test.NewNode("node0", "0", false, []v1.NodeAddress{
+					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{})
+				n, err := mockMgr.appMgr.kubeClient.Core().Nodes().Create(node)
+				Expect(err).To(BeNil(), "Should not fail creating node.")
+				Expect(n).To(Equal(node))
+
+				nodes, err := mockMgr.appMgr.kubeClient.Core().Nodes().List(metav1.ListOptions{})
+				Expect(err).To(BeNil())
+				mockMgr.processNodeUpdate(nodes.Items, nil)
+
 				foo := test.NewService(svcName, "1", namespace, v1.ServiceTypeClusterIP, svcPorts)
 
 				endptPorts := convertSvcPortsToEndpointPorts(svcPorts)
@@ -2239,8 +2317,8 @@ var _ = Describe("AppManager Tests", func() {
 				r := mockMgr.addService(foo)
 				Expect(r).To(BeTrue(), "Service should be processed.")
 
-				r = mockMgr.addEndpoints(test.NewEndpoints(svcName, "1", namespace, svcPodIps,
-					[]string{}, endptPorts))
+				r = mockMgr.addEndpoints(test.NewEndpoints(svcName, "1", "node0", namespace,
+					svcPodIps, []string{}, endptPorts))
 				Expect(r).To(BeTrue(), "Endpoints should be processed.")
 
 				// no virtual servers yet

--- a/pkg/appmanager/eventNotifier_test.go
+++ b/pkg/appmanager/eventNotifier_test.go
@@ -161,8 +161,8 @@ var _ = Describe("Event Notifier Tests", func() {
 
 			emptyIps := []string{}
 			readyIps := []string{fmt.Sprintf("10.2.96.%d", ingNbr)}
-			endpts := test.NewEndpoints(svcName, "1", namespaces[ingNbr], readyIps,
-				emptyIps, convertSvcPortsToEndpointPorts(svcPorts))
+			endpts := test.NewEndpoints(svcName, "1", "node0", namespaces[ingNbr],
+				readyIps, emptyIps, convertSvcPortsToEndpointPorts(svcPorts))
 			r = mockMgr.addEndpoints(endpts)
 			Expect(r).To(BeTrue(), "Endpoints should be processed.")
 

--- a/pkg/appmanager/healthMonitors_test.go
+++ b/pkg/appmanager/healthMonitors_test.go
@@ -194,8 +194,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			fooSvc := test.NewService(svcName, "1", namespace, v1.ServiceTypeClusterIP,
 				svcPorts)
 			readyIps := []string{"10.2.96.0", "10.2.96.1", "10.2.96.2"}
-			endpts := test.NewEndpoints(svcName, "1", namespace, readyIps, emptyIps,
-				convertSvcPortsToEndpointPorts(svcPorts))
+			endpts := test.NewEndpoints(svcName, "1", "node0", namespace,
+				readyIps, emptyIps, convertSvcPortsToEndpointPorts(svcPorts))
 
 			r := mockMgr.addIngress(ing)
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
@@ -411,8 +411,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			fooSvc := test.NewService(svc1Name, "1", namespace, v1.ServiceTypeClusterIP,
 				svc1Ports)
 			ready1Ips := []string{"10.2.96.0", "10.2.96.1", "10.2.96.2"}
-			endpts1 := test.NewEndpoints(svc1Name, "1", namespace, ready1Ips, emptyIps,
-				convertSvcPortsToEndpointPorts(svc1Ports))
+			endpts1 := test.NewEndpoints(svc1Name, "1", "node0", namespace,
+				ready1Ips, emptyIps, convertSvcPortsToEndpointPorts(svc1Ports))
 
 			r := mockMgr.addIngress(ing)
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
@@ -438,8 +438,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			barSvc := test.NewService(svc2Name, "1", namespace, v1.ServiceTypeClusterIP,
 				svc2Ports)
 			ready2Ips := []string{"10.2.96.3", "10.2.96.4", "10.2.96.5"}
-			endpts2 := test.NewEndpoints(svc2Name, "1", namespace, ready2Ips, emptyIps,
-				convertSvcPortsToEndpointPorts(svc2Ports))
+			endpts2 := test.NewEndpoints(svc2Name, "1", "node1", namespace,
+				ready2Ips, emptyIps, convertSvcPortsToEndpointPorts(svc2Ports))
 
 			r = mockMgr.addService(barSvc)
 			Expect(r).To(BeTrue(), "Service should be processed.")
@@ -461,8 +461,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			bazSvc := test.NewService(svc3Name, "1", namespace, v1.ServiceTypeClusterIP,
 				svc3Ports)
 			ready3Ips := []string{"10.2.96.6", "10.2.96.7", "10.2.96.8"}
-			endpts3 := test.NewEndpoints(svc3Name, "1", namespace, ready3Ips, emptyIps,
-				convertSvcPortsToEndpointPorts(svc3Ports))
+			endpts3 := test.NewEndpoints(svc3Name, "1", "node2", namespace,
+				ready3Ips, emptyIps, convertSvcPortsToEndpointPorts(svc3Ports))
 
 			r = mockMgr.addService(bazSvc)
 			Expect(r).To(BeTrue(), "Service should be processed.")
@@ -565,8 +565,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			fooSvc := test.NewService(svc1aName, "1", namespace, v1.ServiceTypeClusterIP,
 				svc1aPorts)
 			ready1aIps := []string{"10.2.96.0", "10.2.96.1", "10.2.96.2"}
-			endpts1a := test.NewEndpoints(svc1aName, "1", namespace, ready1aIps, emptyIps,
-				convertSvcPortsToEndpointPorts(svc1aPorts))
+			endpts1a := test.NewEndpoints(svc1aName, "1", "node0", namespace,
+				ready1aIps, emptyIps, convertSvcPortsToEndpointPorts(svc1aPorts))
 
 			r := mockMgr.addService(fooSvc)
 			Expect(r).To(BeTrue(), "Service should be processed.")
@@ -577,8 +577,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			barSvc := test.NewService(svc1bName, "1", namespace, v1.ServiceTypeClusterIP,
 				svc1bPorts)
 			ready1bIps := []string{"10.2.96.3", "10.2.96.4", "10.2.96.5"}
-			endpts1b := test.NewEndpoints(svc1bName, "1", namespace, ready1bIps, emptyIps,
-				convertSvcPortsToEndpointPorts(svc1bPorts))
+			endpts1b := test.NewEndpoints(svc1bName, "1", "node1", namespace,
+				ready1bIps, emptyIps, convertSvcPortsToEndpointPorts(svc1bPorts))
 
 			r = mockMgr.addService(barSvc)
 			Expect(r).To(BeTrue(), "Service should be processed.")
@@ -589,8 +589,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			bazSvc := test.NewService(svc2Name, "1", namespace, v1.ServiceTypeClusterIP,
 				svc2Ports)
 			ready2Ips := []string{"10.2.96.6", "10.2.96.7", "10.2.96.8"}
-			endpts2 := test.NewEndpoints(svc2Name, "1", namespace, ready2Ips, emptyIps,
-				convertSvcPortsToEndpointPorts(svc2Ports))
+			endpts2 := test.NewEndpoints(svc2Name, "1", "node2", namespace,
+				ready2Ips, emptyIps, convertSvcPortsToEndpointPorts(svc2Ports))
 
 			r = mockMgr.addService(bazSvc)
 			Expect(r).To(BeTrue(), "Service should be processed.")
@@ -710,8 +710,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			fooSvc := test.NewService(svc1aName, "1", namespace, v1.ServiceTypeClusterIP,
 				svc1aPorts)
 			ready1aIps := []string{"10.2.96.0", "10.2.96.1", "10.2.96.2"}
-			endpts1a := test.NewEndpoints(svc1aName, "1", namespace, ready1aIps, emptyIps,
-				convertSvcPortsToEndpointPorts(svc1aPorts))
+			endpts1a := test.NewEndpoints(svc1aName, "1", "node0", namespace,
+				ready1aIps, emptyIps, convertSvcPortsToEndpointPorts(svc1aPorts))
 
 			r := mockMgr.addIngress(ing)
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
@@ -737,8 +737,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			barSvc := test.NewService(svc1bName, "1", namespace, v1.ServiceTypeClusterIP,
 				svc1bPorts)
 			ready1bIps := []string{"10.2.96.3", "10.2.96.4", "10.2.96.5"}
-			endpts1b := test.NewEndpoints(svc1bName, "1", namespace, ready1bIps, emptyIps,
-				convertSvcPortsToEndpointPorts(svc1bPorts))
+			endpts1b := test.NewEndpoints(svc1bName, "1", "node1", namespace,
+				ready1bIps, emptyIps, convertSvcPortsToEndpointPorts(svc1bPorts))
 
 			r = mockMgr.addService(barSvc)
 			Expect(r).To(BeTrue(), "Service should be processed.")
@@ -760,8 +760,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			bazSvc := test.NewService(svc2Name, "1", namespace, v1.ServiceTypeClusterIP,
 				svc2Ports)
 			ready2Ips := []string{"10.2.96.6", "10.2.96.7", "10.2.96.8"}
-			endpts2 := test.NewEndpoints(svc2Name, "1", namespace, ready2Ips, emptyIps,
-				convertSvcPortsToEndpointPorts(svc2Ports))
+			endpts2 := test.NewEndpoints(svc2Name, "1", "node0", namespace,
+				ready2Ips, emptyIps, convertSvcPortsToEndpointPorts(svc2Ports))
 
 			r = mockMgr.addService(bazSvc)
 			Expect(r).To(BeTrue(), "Service should be processed.")
@@ -856,8 +856,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			fooSvc := test.NewService(svc1Name, "1", namespace, v1.ServiceTypeClusterIP,
 				svc1Ports)
 			ready1Ips := []string{"10.2.96.0", "10.2.96.1", "10.2.96.2"}
-			endpts1 := test.NewEndpoints(svc1Name, "1", namespace, ready1Ips, emptyIps,
-				convertSvcPortsToEndpointPorts(svc1Ports))
+			endpts1 := test.NewEndpoints(svc1Name, "1", "node0", namespace,
+				ready1Ips, emptyIps, convertSvcPortsToEndpointPorts(svc1Ports))
 
 			r := mockMgr.addIngress(ing)
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
@@ -883,8 +883,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			barSvc := test.NewService(svc2Name, "1", namespace, v1.ServiceTypeClusterIP,
 				svc2Ports)
 			ready2Ips := []string{"10.2.96.3", "10.2.96.4", "10.2.96.5"}
-			endpts2 := test.NewEndpoints(svc2Name, "1", namespace, ready2Ips, emptyIps,
-				convertSvcPortsToEndpointPorts(svc2Ports))
+			endpts2 := test.NewEndpoints(svc2Name, "1", "node1", namespace,
+				ready2Ips, emptyIps, convertSvcPortsToEndpointPorts(svc2Ports))
 
 			r = mockMgr.addService(barSvc)
 			Expect(r).To(BeTrue(), "Service should be processed.")
@@ -906,8 +906,8 @@ var _ = Describe("Health Monitor Tests", func() {
 			bazSvc := test.NewService(svc3Name, "1", namespace, v1.ServiceTypeClusterIP,
 				svc3Ports)
 			ready3Ips := []string{"10.2.96.6", "10.2.96.7", "10.2.96.8"}
-			endpts3 := test.NewEndpoints(svc3Name, "1", namespace, ready3Ips, emptyIps,
-				convertSvcPortsToEndpointPorts(svc3Ports))
+			endpts3 := test.NewEndpoints(svc3Name, "1", "node2", namespace,
+				ready3Ips, emptyIps, convertSvcPortsToEndpointPorts(svc3Ports))
 
 			r = mockMgr.addService(bazSvc)
 			Expect(r).To(BeTrue(), "Service should be processed.")

--- a/pkg/appmanager/profiles_test.go
+++ b/pkg/appmanager/profiles_test.go
@@ -102,8 +102,8 @@ var _ = Describe("AppManager Profile Tests", func() {
 				svcPorts)
 			emptyIps := []string{}
 			readyIps := []string{"10.2.96.0", "10.2.96.1", "10.2.96.2"}
-			endpts := test.NewEndpoints(svcName, "1", namespace, readyIps, emptyIps,
-				convertSvcPortsToEndpointPorts(svcPorts))
+			endpts := test.NewEndpoints(svcName, "1", "node0", namespace,
+				readyIps, emptyIps, convertSvcPortsToEndpointPorts(svcPorts))
 
 			// Add ingress, service, and endpoints objects and make sure the
 			// ssl-profile set in the ingress object shows up in the virtual server.

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -226,8 +226,15 @@ func NewService(id, rv, namespace string, serviceType v1.ServiceType,
 }
 
 //NewEndpoints returns an endpoints objects
-func NewEndpoints(svcName, rv, namespace string,
-	readyIps, notReadyIps []string, ports []v1.EndpointPort) *v1.Endpoints {
+func NewEndpoints(
+	svcName,
+	rv,
+	node,
+	namespace string,
+	readyIps,
+	notReadyIps []string,
+	ports []v1.EndpointPort,
+) *v1.Endpoints {
 	ep := &v1.Endpoints{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Endpoints",
@@ -245,8 +252,8 @@ func NewEndpoints(svcName, rv, namespace string,
 		ep.Subsets = append(
 			ep.Subsets,
 			v1.EndpointSubset{
-				Addresses:         newEndpointAddress(readyIps),
-				NotReadyAddresses: newEndpointAddress(notReadyIps),
+				Addresses:         newEndpointAddress(readyIps, node),
+				NotReadyAddresses: newEndpointAddress(notReadyIps, node),
 				Ports:             ports,
 			},
 		)
@@ -255,10 +262,11 @@ func NewEndpoints(svcName, rv, namespace string,
 	return ep
 }
 
-func newEndpointAddress(ips []string) []v1.EndpointAddress {
+func newEndpointAddress(ips []string, node string) []v1.EndpointAddress {
 	eps := make([]v1.EndpointAddress, len(ips))
 	for i, v := range ips {
 		eps[i].IP = v
+		eps[i].NodeName = &node
 	}
 	return eps
 }


### PR DESCRIPTION
Problem: The node label selector was ignored in cluster mode due to the endpoints being acquired without caring which node they came from.

Solution: When getting the endpoints for cluster mode, the controller will now check which node they came from. This will ensure that if a node is not being watched, the controller will not use endpoints on that node.

Fixes #592