### PR TITLE
Disallow single service Ingress to share VS

### DIFF
--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -2663,11 +2663,23 @@ var _ = Describe("AppManager Tests", func() {
 						f5VsPartitionAnnotation: "velcro",
 					})
 				// Add ingress with same ip (should use shared virtual)
-				ingress5 := test.NewIngress("ingressShared", "3", namespace,
+				ingress5 := test.NewIngress("ingressShared", "4", namespace,
 					v1beta1.IngressSpec{
-						Backend: &v1beta1.IngressBackend{
-							ServiceName: "foobar",
-							ServicePort: intstr.IntOrString{IntVal: 80},
+						Rules: []v1beta1.IngressRule{
+							{Host: "",
+								IngressRuleValue: v1beta1.IngressRuleValue{
+									HTTP: &v1beta1.HTTPIngressRuleValue{
+										Paths: []v1beta1.HTTPIngressPath{
+											{Path: "/foo",
+												Backend: v1beta1.IngressBackend{
+													ServiceName: "foobar",
+													ServicePort: intstr.IntOrString{IntVal: 80},
+												},
+											},
+										},
+									},
+								},
+							},
 						},
 					},
 					map[string]string{
@@ -2684,7 +2696,7 @@ var _ = Describe("AppManager Tests", func() {
 					serviceKey{"foo", 80, "default"}, formatIngressVSName("1.2.3.4", 80))
 				Expect(len(rs.Policies[0].Rules)).To(Equal(2))
 				events = mockMgr.getFakeEvents(namespace)
-				Expect(len(events)).To(Equal(7))
+				Expect(len(events)).To(Equal(8))
 
 				mockMgr.deleteIngress(ingress5)
 				Expect(resources.VirtualCount()).To(Equal(1))

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -1088,6 +1088,7 @@ func (appMgr *Manager) createRSConfigFromIngress(
 		}
 		pools = append(pools, pool)
 		cfg.Virtual.PoolName = joinBigipPath(cfg.Virtual.Partition, pool.Name)
+		cfg.MetaData.ssIngName = ing.ObjectMeta.Name
 	}
 
 	resources.Lock()

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -48,6 +48,9 @@ type (
 		ResourceType string
 		// Only used for Routes (for keeping track of annotated profiles)
 		RouteProfs map[routeKey]string
+		// Only used for single-service Ingress; the name of the Ingress that created
+		// this config
+		ssIngName string
 	}
 
 	// Key used to store annotated profiles for a route


### PR DESCRIPTION
Problem: Single service Ingresses should not be able to share a virtual server with any other Ingress. Single service Ingresses don't create policies (since there is only one pool), so having multiple pools without a policy doesn't make sense.

Solution: When an Ingress update happens, and either the incoming Ingress is single service, or we already have a single service configured on the specified IP:Port, then we reject the incoming Ingress.

Fixes #608 