### PR TITLE
Fixed repeating INFO logs when a pool only config map or ingress is d…

### DIFF
--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -881,8 +881,6 @@ func parseConfigMap(cm *v1.ConfigMap, schemaDBPath, snatPoolName string) (*Resou
 						// Check for IP annotation provided by IPAM system
 						if addr, ok := cm.ObjectMeta.Annotations[f5VsBindAddrAnnotation]; ok == true {
 							cfg.Virtual.SetVirtualAddress(addr, cfg.Virtual.VirtualAddress.Port)
-						} else {
-							log.Infof("No virtual IP was specified for the virtual server %s creating pool only.", cm.ObjectMeta.Name)
 						}
 					}
 				}
@@ -1034,9 +1032,6 @@ func (appMgr *Manager) createRSConfigFromIngress(
 		} else {
 			bindAddr = addr
 		}
-	} else {
-		log.Infof("No virtual IP was specified for the virtual server %s, creating pool only.",
-			ing.ObjectMeta.Name)
 	}
 	cfg.Virtual.Name = formatIngressVSName(bindAddr, pStruct.port)
 


### PR DESCRIPTION
…eployed. (fixes #603)

Problem:
When a pool only config map or ingress was deployed, the INFO log message
stating "No virtual IP was specified for the virtual server" would get
logged multiple times.

Solution:
This log message is now located in the validResources.go file within the
checkValidIngress and checkValidConfigMap methods rather than in the
resourceConfig.go file. There is now an additional check to guarantee that
the log message is only logged the first time a config is seen.

affects-branch: master