### PR TITLE
Replace rule / with underscore

### DIFF
--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -252,7 +252,9 @@ func formatIngressRuleName(host, path, pool string) string {
 	if path == "" {
 		rule = fmt.Sprintf("ingress_%s_%s", host, pool)
 	} else {
+		// Remove the first slash, then replace any subsequent slashes with '_'
 		path = strings.TrimPrefix(path, "/")
+		path = strings.Replace(path, "/", "_", -1)
 		rule = fmt.Sprintf("ingress_%s_%s_%s", host, path, pool)
 	}
 	return rule


### PR DESCRIPTION
Problem: Extended paths that had / characters were causing dead links on the BIG-IP GUI. Traffic would still work, but the GUI would not.

Solution: Changed any / characters to underscores in Ingress rule names.

Fixes #638 