### PR TITLE
Don't remove Route annotation profiles

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -24,6 +24,7 @@ Bug Fixes
 * :issues:`608` - Single service Ingresses cannot share virtual servers.
 * :issues:`636` - Controller configures default ssl profiles for Routes when specified via CLI.
 * :issues:`638` - Ingress extended paths no longer break BIG-IP GUI links.
+* :issues:`649` - Route annotation profiles are no longer ignored.
 
 v1.4.2
 ------


### PR DESCRIPTION
Problem: If pre-existing profiles were being supplied via annotation for Routes, the controller was accidentally deleting these profiles.

Solution: When cleaning up unused profiles, be sure to check if the annotation profiles should be kept. The client/server profiles we check will either be in the route OR in the annotation.

Fixes #649 