### PR TITLE
Updated f5-ctlr-agent to include whitelist changes

### DIFF
--- a/.f5license
+++ b/.f5license
@@ -1515,3 +1515,63 @@
     THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
     OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The jsonpatch module has a Modified BSD license
+- name: jsonpatch
+  version: 1.16
+  attribution_text: |
+    Copyright (c) 2011 Stefan Kögl <stefan@skoegl.net>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. The name of the author may not be used to endorse or promote products
+       derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+    IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+    OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+    IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+    THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# The jsonpointer module has a Modified BSD license
+- name: jsonpointer
+  version: "2.0"
+  attribution_text: |
+    Copyright (c) 2011 Stefan Kögl <stefan@skoegl.net>
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions
+    are met:
+
+    1. Redistributions of source code must retain the above copyright
+       notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+       notice, this list of conditions and the following disclaimer in the
+       documentation and/or other materials provided with the distribution.
+    3. The name of the author may not be used to endorse or promote products
+       derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+    IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+    OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+    IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+    INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+    NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+    DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+    THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+    THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -66,6 +66,8 @@ Within the cluster, the allocated NodePort load balances traffic to all pods.
 
    F5 does not recommend making configuration changes to objects in any partition managed by the |kctlr| via any other means (for example, the configuration utility, TMOS, or by syncing configuration with another device or service group). Doing so may result in disruption of service or unexpected behavior.
 
+   The Controller allows one exception to this recommendation.  When using named virtual servers for :ref:`Openshift routes <openshift route configs>`, you can set the Controller to merge its desired settings with a pre-existing virtual server(s). See `Manage OpenShift Routes`_ for more information.
+
 .. _configuration parameters:
 
 Controller Configuration Parameters

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -15,6 +15,7 @@ Added Functionality
 * Support for virtual server source address translation configuration.
 * Added controller name and version to the metadata of certain BIG-IP LTM resources managed by the controller.
 * :issues:`433` - Support for pre-existing server ssl profiles for Ingresses.
+* Added support for attaching OpenShift Routes to existing BIG-IP virtual servers.
 
 Bug Fixes
 `````````

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -133,6 +133,7 @@ rst_epilog = '''
 .. _Overview of SNAT features: https://support.f5.com/csp/article/K7820
 .. _route domain: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-0-0/9.html
 .. _`F5 Controller Agent`: https://github.com/f5devcentral/f5-ctlr-agent
+.. _Manage OpenShift Routes:  %(base_url)s/containers/latest/openshift/kctlr-openshift-routes.html
 ''' % {
     'url_version': version,
     'base_url': 'http://clouddocs.f5.com'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/f5devcentral/f5-ctlr-agent.git@348a178b0e8ab364715c70ab374d6a3412257e0a#egg=f5-ctlr-agent
+-e git+https://github.com/f5devcentral/f5-ctlr-agent.git@f10e7cf021f6f2c02ce18d78afe1a63b0ae26596#egg=f5-ctlr-agent


### PR DESCRIPTION
Problem:  Need to support externally defined virtual servers in
the controller partition.  This is needed to bring parity to the
Openshift F5 Router.

Solution: The CCCL library has been updated to perform a merge
instead of a replace if the resource has a cccl-whitelist
metadata flag set to true/1.  The change here is simply to include
new CCCL change by updating the f5-ctlr-agent.  In addition, the
product docs, the release notes, and license information required
by the whitelist feature have been updated.