### PR TITLE
Added cccl-issue for certificates and keys to the Release Notes.

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -26,6 +26,7 @@ Bug Fixes
 * :issues:`636` - Controller configures default ssl profiles for Routes when specified via CLI.
 * :issues:`638` - Ingress extended paths no longer break BIG-IP GUI links.
 * :issues:`649` - Route annotation profiles are no longer ignored.
+* :cccl-issue:`214` - Keys and certificates are now installed onto the managed partition.
 
 v1.4.2
 ------


### PR DESCRIPTION
Problem:
The cccl-issue for installing the certificates and keys to the
managed partition was not included in the Release Notes.

Solution:
Added this issue to the Release Notes under Bug Fixes.

affects-branches: master