### PR TITLE
Delete rules that no longer exist in Ingress

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -24,6 +24,7 @@ Bug Fixes
 * :issues:`603` - Pool only mode no longer prints excessive logs.
 * :issues:`608` - Single service Ingresses cannot share virtual servers.
 * :issues:`636` - Controller configures default ssl profiles for Routes when specified via CLI.
+* :issues:`635` - Controller cleans up policy rules when an Ingress removes them.
 * :issues:`638` - Ingress extended paths no longer break BIG-IP GUI links.
 * :issues:`649` - Route annotation profiles are no longer ignored.
 

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1050,7 +1050,7 @@ func (appMgr *Manager) syncIngresses(
 				svcs = append(svcs, ing.Spec.Backend.ServiceName)
 			}
 
-			// Remove any left over pools from services no longer used by this Ingress
+			// Remove any dependencies no longer used by this Ingress
 			for _, dep := range depsRemoved {
 				if dep.Kind == "Service" {
 					cfgChanged, svcKey := rsCfg.RemovePool(
@@ -1060,6 +1060,15 @@ func (appMgr *Manager) syncIngresses(
 					}
 					if nil != svcKey {
 						appMgr.resources.DeleteKeyRef(*svcKey, rsName)
+					}
+				}
+				if dep.Kind == "Rule" {
+					for _, pol := range rsCfg.Policies {
+						for _, rl := range pol.Rules {
+							if rl.FullURI == dep.Name {
+								rsCfg.DeleteRuleFromPolicy(pol.Name, rl)
+							}
+						}
 					}
 				}
 			}

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -513,6 +513,12 @@ func NewObjectDependencies(
 					Name:      path.Backend.ServiceName,
 				}
 				deps[dep]++
+				dep = ObjectDependency{
+					Kind:      "Rule",
+					Namespace: ingress.ObjectMeta.Namespace,
+					Name:      rule.Host + path.Path,
+				}
+				deps[dep]++
 			}
 		}
 	default:

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -451,6 +451,10 @@ var _ = Describe("Resource Config Tests", func() {
 				{Kind: "Service", Namespace: "ns2", Name: "bar"},
 				{Kind: "Service", Namespace: "ns2", Name: "baz"},
 				{Kind: "Service", Namespace: "ns2", Name: "foobarbaz"},
+				{Kind: "Rule", Namespace: "ns2", Name: "host1/bar"},
+				{Kind: "Rule", Namespace: "ns2", Name: "host1/baz"},
+				{Kind: "Rule", Namespace: "ns2", Name: "host2/baz"},
+				{Kind: "Rule", Namespace: "ns2", Name: "host2/foobarbaz"},
 			}
 			for _, dep := range ingressDeps {
 				_, found := deps[dep]


### PR DESCRIPTION
Problem: If a rule was deleted in an Ingress, but the pool still remained (pool was referenced multiple times in Ingress or multi-service gets reduced to single-service), the rule would still be configured.

Solution: Track Ingress host/path rules as an object dependency. If an Ingress gets updated and that host/path rule no longer exists, then the rule is deleted from the config.

Fixes #635 