### PR TITLE
Fix multi-service to single-service transition

### DIFF
--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -48,9 +48,9 @@ type (
 		ResourceType string
 		// Only used for Routes (for keeping track of annotated profiles)
 		RouteProfs map[routeKey]string
-		// Only used for single-service Ingress; the name of the Ingress that created
-		// this config
-		ssIngName string
+		// Name of the Ingress that created this config
+		// Used to prevent single-service Ingresses from sharing virtuals
+		ingName string
 	}
 
 	// Key used to store annotated profiles for a route

--- a/pkg/appmanager/validateResources.go
+++ b/pkg/appmanager/validateResources.go
@@ -167,7 +167,7 @@ func (appMgr *Manager) checkValidIngress(
 		// It doesn't make sense for single service Ingresses to share a VS
 		if oldCfg, exists := appMgr.resources.GetByName(rsName); exists {
 			if (oldCfg.Virtual.PoolName != "" || ing.Spec.Rules == nil) &&
-				oldCfg.MetaData.ssIngName != ing.ObjectMeta.Name &&
+				oldCfg.MetaData.ingName != ing.ObjectMeta.Name &&
 				oldCfg.Virtual.VirtualAddress.BindAddr != "" {
 				log.Warningf(
 					"Single-service Ingress cannot share the IP and port: '%s:%d'.",


### PR DESCRIPTION
Problem: When updating a multi-service Ingress to a single-service Ingress, there were a few issues. First, the controller would still have the previous multi-service ingress stored, and so when seeing the single-service, would deny the IP address to be shared, and reject the Ingress. Also, if changing from a multi-service to single-service, the default pool was not updated.

Solution: Change the single-service check to verify whether or not the previous config came from an ingress with the same name, rather than of the same type. This allows different type ingresses to be updated properly. If going from a multi-service Ingress to single-service, set the virtual's default pool.