### PR TITLE
Clean up Route rules if Spec changes

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1224,6 +1224,15 @@ func (appMgr *Manager) syncRoutes(
 						appMgr.resources.DeleteKeyRef(*svcKey, rsName)
 					}
 				}
+				if dep.Kind == "Rule" {
+					for _, pol := range rsCfg.Policies {
+						for _, rl := range pol.Rules {
+							if rl.FullURI == dep.Name {
+								rsCfg.DeleteRuleFromPolicy(pol.Name, rl, appMgr.mergedRulesMap)
+							}
+						}
+					}
+				}
 			}
 
 			_, found, updated := appMgr.handleConfigForType(

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -492,6 +492,12 @@ func NewObjectDependencies(
 			dep.Name = backend.Name
 			deps[dep]++
 		}
+		dep = ObjectDependency{
+			Kind:      "Rule",
+			Namespace: route.ObjectMeta.Namespace,
+			Name:      route.Spec.Host + route.Spec.Path,
+		}
+		deps[dep]++
 	case *v1beta1.Ingress:
 		ingress := obj.(*v1beta1.Ingress)
 		key.Kind = "Ingress"

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -350,6 +350,7 @@ var _ = Describe("Resource Config Tests", func() {
 				{Kind: "Service", Namespace: "ns1", Name: "foo"},
 				{Kind: "Service", Namespace: "ns1", Name: "bar"},
 				{Kind: "Service", Namespace: "ns1", Name: "baz"},
+				{Kind: "Rule", Namespace: "ns1", Name: "host.com/foo"},
 			}
 			for _, dep := range routeDeps {
 				_, found := deps[dep]


### PR DESCRIPTION
Problem: Similar to a previous Ingress problem we had, if a Route's host/path spec changes, the controller doesn't clean up the original rule.

Solution: Track the route host/path rule as an object dependency, and clean up the original rule if the host/path changes.