### PR TITLE
Ignore versions of pip packages already on rhel host while building

### DIFF
--- a/build-tools/Dockerfile.rhel7.builder
+++ b/build-tools/Dockerfile.rhel7.builder
@@ -56,7 +56,7 @@ COPY requirements.docs.txt /tmp/requirements.docs.txt
 RUN source scl_source enable python27 && \
 	pip install --no-cache-dir --upgrade pip && \
 	pip install --no-cache-dir setuptools flake8 && \
-	pip install --no-cache-dir --process-dependency-links -r /tmp/requirements.txt && \
+	pip install --no-cache-dir --process-dependency-links --ignore-installed -r /tmp/requirements.txt && \
 	pip install --no-cache-dir -r /tmp/requirements.docs.txt && \
 	go get github.com/wadey/gocovmerge && \
 	go get golang.org/x/tools/cmd/cover && \


### PR DESCRIPTION
Problem:
If the RHEL host has pip packages that are part of the distribution,
and they conflict with the versions required by the pip install
commands in the Dockerfile, the install fails.

Solution:
Ignore any installed versions of pip packages on the RHEL host
and install the ones specified in the requirements file.