### PR TITLE
Improve navigation between doc sets

### DIFF
--- a/docs/_templates/breadcrumb.html
+++ b/docs/_templates/breadcrumb.html
@@ -1,0 +1,6 @@
+      <nav class="site-breadcrumb-nav site-nav">
+          <ul class="site-breadcrumb-list">
+            <li class="breadcrumb-item"><button type="button" id="sidebarCollapse" class="btn btn-info navbar-btn site-hidden"><i class="fa fa-align-justify"></i></button>&#x20 <a href="{{ theme_url_root }}">{{ theme_site_name|striptags|e }}</a> &gt; <a href="http://clouddocs.f5.com/containers/latest/">Container Connectors </a> &gt; <a href="{{ pathto(master_doc) }}">{{ project|striptags|e }} </a> &gt; {{ title|striptags|e }}</li>
+          </ul>
+      </nav>
+      

--- a/docs/_templates/extralinks.html
+++ b/docs/_templates/extralinks.html
@@ -1,0 +1,4 @@
+<hr>
+<span class="nav-sidebartoc">
+<h5>View related articles on <a href="https://devcentral.f5.com/articles?tag=Containers" target="_blank">DevCentral <i class="fa fa-external-link-square"></i></a></h5>
+</span>


### PR DESCRIPTION
I made a few docs-nav updates to improve the user experience:

- Add devcentral link to sidebar (same as in the solution docs)
- Add link to the solution docs to the breadcrumb