### PR TITLE
Fix url-rewrite rule naming add limitations to release notes.

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -37,6 +37,10 @@ Bug Fixes
 * :issues:`649` - Route annotation profiles are no longer ignored.
 * :cccl-issue:`214` - Keys and certificates are now installed onto the managed partition.
 
+Limitations
+```````````
+* Cannot apply app-root and url-rewrite annotations to the same resource; see: :issues:`675`
+
 v1.4.2
 ------
 

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -1078,7 +1078,7 @@ func processURLRewrite(target, value string, rsType int) *Rule {
 		return nil
 	}
 
-	nameEnd := target + value
+	nameEnd := target + "-" + value
 	nameEnd = strings.Replace(nameEnd, "/", "_", -1)
 	return &Rule{
 		Name:       fmt.Sprintf("url-rewrite-rule-%s", nameEnd),


### PR DESCRIPTION
Problem:
 url-rewrite rule names were targetvalue instead of target-value making
 them difficult to read. The release notes were missing the limitation
 comment for the url-rewrite feature.

Solution:
 Add - to url-rewrite names so they are target-value. Add limitation
 note to release notes.