### PR TITLE
Remove extra 'v' prefix in docs version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,7 +72,7 @@ deploy:
       repo: F5Networks/k8s-bigip-ctlr
       condition: $TRAVIS_BRANCH == *"-stable" || "$TRAVIS_BRANCH" =~ ^v[0-9]+\.[0-9]+\.[0-9]*
     script:
-      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/k8s-bigip-ctlr v$CTLR_VERSION
+      - ./build-tools/deploy-docs.sh publish-product-docs-to-prod connectors/k8s-bigip-ctlr $CTLR_VERSION
 
 notifications:
   slack:


### PR DESCRIPTION
Problem:
The docs deploy script is deploying changes into 'vvX.Y' instead
of 'vX.Y'.

Solution:
Fixed the travis script to remove the extra 'v' prefix.