### PR TITLE
Fix node watching; update CCCL pointer

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -4,8 +4,13 @@ Release Notes for BIG-IP Controller for Kubernetes
 next-release
 ------------
 
+v1.5.1
+------
+
 Bug Fixes
 `````````
+* :issues:`683` - Controller upgrades properly with new metadata field.
+* :issues:`686` - Controller in cluster mode does not rely on vxlan name to configure pool members.
 
 v1.5.0
 ------
@@ -40,6 +45,9 @@ Bug Fixes
 Limitations
 ```````````
 * Cannot apply app-root and url-rewrite annotations to the same resource; see: :issues:`675`
+* If an older controller created resources, upgrading to the new version could
+  result in a python exception when adding metadata to virtuals: :issues:`683`
+* If running the controller in cluster mode without a vxlan name, pool members are not created: :issues:`686`
 
 v1.4.2
 ------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/f5devcentral/f5-ctlr-agent.git@ffe7c22288502ca45f14bcf2b6d93295ca58a593#egg=f5-ctlr-agent
+-e git+https://github.com/f5devcentral/f5-ctlr-agent.git@435f049bf1a36c56293e57686d88a0bcd03e4cf6#egg=f5-ctlr-agent


### PR DESCRIPTION
Problem: Node watching was only enabled for nodeport mode, and cluster mode w/ vxlan specified. This breaks when cluster mode is being run without vxlan. Pool members were not being configured.

Solution: Removed the stipulation that a vxlan name had to be specified in order to watch nodes. Also, updated the CCCL pointer to pull in the list length bug fix.

Fixes #682 
Fixes #683
Fixes #686