### PR TITLE
Fix performance issues

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -120,7 +120,7 @@ rst_epilog = '''
 .. _Kubernetes Service: https://kubernetes.io/docs/concepts/services-networking/service/
 .. _Kubernetes Annotation: https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/
 .. _Kubernetes clusters: https://kubernetes.io/docs/concepts/cluster-administration/cluster-administration-overview/
-.. _NodePort: https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport
+.. _NodePort: https://kubernetes.io/docs/concepts/services-networking/service/#nodeport
 .. _ClusterIP: https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/
 .. _iApps: https://devcentral.f5.com/iapps
 .. _Kubernetes pods: https://kubernetes.io/docs/user-guide/pods/

--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -148,8 +148,7 @@ func (appMgr *Manager) outputConfigLocked() {
 		}
 	}
 
-	if appMgr.vsQueue.Len() == 0 && appMgr.nsQueue.Len() == 0 ||
-		appMgr.initialState == true {
+	if appMgr.processedItems >= appMgr.queueLen || appMgr.initialState {
 		doneCh, errCh, err := appMgr.ConfigWriter().SendSection("resources", resources)
 		if nil != err {
 			log.Warningf("Failed to write Big-IP config data: %v", err)


### PR DESCRIPTION
Problem: There were a couple of problems causing performance issues. First, using gob encoding to deepcopy configs proved to be inefficient. Secondly, the controller's steady-state check relied upon the queue being empty before writing any configs. With a large number of resources to process, and Kubernetes constantly updating endpoints, the queue would take a long time before being empty, therefore the controller wouldn't write any configs in a reasonable time.

Solution: Switched back to manual deepcopy instead of gob encoding. Saved off the initial queue length on startup, and kept track of the number of processed items before writing out a config, rather than waiting for the queue to be empty.