### PR TITLE
Allow files for BIG-IP parameters

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -153,6 +153,26 @@ BIG-IP system
 | bigip-username        | string  | Required | n/a               | BIG-IP iControl REST username           |                |
 |                       |         |          |                   | [#username]_                            |                |
 +-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| credentials-directory | string  | Optional | n/a               | Directory that contains the BIG-IP      |                |
+|                       |         |          |                   | username, password, or url files        |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+
+.. important::
+
+     The :code:`credentials-directory` option is an alternative to using the :code:`bigip-username`, :code:`bigip-password`, or
+     :code:`bigip-url` arguments.
+
+     When you use this argument, the controller looks for three files in the specified directory:
+
+     - "username", "password", and "url"
+
+     If any of these files do not exist, the controller falls back to using the CLI arguments as parameters.
+
+     Each file should contain **only** the username, password, and url, respectively. You can create and mount
+     the files as `Kubernetes Secrets`_.
+     
+     It is important to not project the Secret keys to specific paths, as the controller looks for the "username",
+     "password", and "url" files directly within the credentials directory.
 
 .. _vxlan configs:
 

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -4,6 +4,18 @@ Release Notes for BIG-IP Controller for Kubernetes
 next-release
 ------------
 
+v1.6.0
+------
+
+Added Functionality
+```````````````````
+* Added ability to provide BIG-IP credentials via mounted Secret files instead of CLI arguments.
+
+Bug Fixes
+`````````
+* Improved controller performance when deep copying configurations.
+* Improved controller performance when starting up and achieving "steady state".
+
 v1.5.1
 ------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -125,6 +125,7 @@ rst_epilog = '''
 .. _iApps: https://devcentral.f5.com/iapps
 .. _Kubernetes pods: https://kubernetes.io/docs/user-guide/pods/
 .. _Kubernetes Ingress: https://kubernetes.io/docs/concepts/services-networking/ingress/
+.. _Kubernetes Secrets: https://kubernetes.io/docs/concepts/configuration/secret/
 .. _iApp table: https://devcentral.f5.com/wiki/iApp.Working-with-Tables.ashx
 .. _Kubernetes Service Type: https://kubernetes.io/docs/concepts/services-networking/service/
 .. _OpenShift: https://www.openshift.com/


### PR DESCRIPTION
Problem: Using the CLI to provide BIG-IP arguments is a security vulnerability, as they are displayed when running 'ps'.

Solution: Allow for users to create and mount files via a Secret, and provide the mount path to the controller. The controller will look in this path for username, password, and url files. If they are not found, it falls back to using the CLI.