### PR TITLE
Config example for credentials directory

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -174,6 +174,9 @@ BIG-IP system
      It is important to not project the Secret keys to specific paths, as the controller looks for the "username",
      "password", and "url" files directly within the credentials directory.
 
+     See :fonticon:`fa fa-download` :download:`example-bigip-credentials-directory.yaml </_static/config_examples/example-bigip-credentials-directory.yaml>`
+     for a deployment example.
+
 .. _vxlan configs:
 
 VXLAN
@@ -746,6 +749,7 @@ Example Configuration Files
 
 - :fonticon:`fa fa-download` :download:`sample-k8s-bigip-ctlr-secrets.yaml </_static/config_examples/sample-k8s-bigip-ctlr-secrets.yaml>`
 - :fonticon:`fa fa-download` :download:`sample-bigip-credentials-secret.yaml </_static/config_examples/sample-bigip-credentials-secret.yaml>`
+- :fonticon:`fa fa-download` :download:`example-bigip-credentials-directory.yaml </_static/config_examples/example-bigip-credentials-directory.yaml>`
 - :fonticon:`fa fa-download` :download:`example-vs-resource.configmap.yaml </_static/config_examples/example-vs-resource.configmap.yaml>`
 - :fonticon:`fa fa-download` :download:`example-vs-resource-udp.configmap.yaml </_static/config_examples/example-vs-resource-udp.configmap.yaml>`
 - :fonticon:`fa fa-download` :download:`example-vs-resource.json </_static/config_examples/example-vs-resource.json>`

--- a/docs/_static/config_examples/example-bigip-credentials-directory.yaml
+++ b/docs/_static/config_examples/example-bigip-credentials-directory.yaml
@@ -1,0 +1,43 @@
+# Sample configuration for k8s-bigip-ctlr. BIG-IP configuration is mounted
+# from the secret store into the controller.
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: k8s-bigip-ctlr
+  namespace: kube-system
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: k8s-bigip-ctlr
+      labels:
+        app: k8s-bigip-ctlr
+    spec:
+      serviceAccountName: bigip-ctlr-serviceaccount
+      containers:
+        - name: k8s-bigip-ctlr
+          image: "f5networks/k8s-bigip-ctlr"
+          command: ["/app/bin/k8s-bigip-ctlr"]
+          args: ["--running-in-cluster=true",
+            "--credentials-directory=/tmp/creds",
+            "--bigip-partition=k8s",
+            "--namespace=default",
+          ]
+          volumeMounts:
+          - name: bigip-creds
+            mountPath: "/tmp/creds"
+            readOnly: true
+      volumes:
+      - name: bigip-creds
+        secret:
+          secretName: bigip-credentials
+    imagePullSecrets:
+      - name: f5-docker-images
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: bigip-ctlr-serviceaccount
+  namespace: kube-system

--- a/docs/_static/config_examples/sample-k8s-bigip-ctlr-secrets.yaml
+++ b/docs/_static/config_examples/sample-k8s-bigip-ctlr-secrets.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: k8s-bigip-ctlr
           # Specify the path to your image here
-          image: "docker-registry/username/k8s-bigip-ctlr:v1.4.2"
+          image: "f5networks/k8s-bigip-ctlr"
           env:
             # Get sensitive values from the bigip-credentials secret
             - name: BIGIP_USERNAME


### PR DESCRIPTION
Adding deployment config example for how to mount a secret containing BIG-IP information into the controller.