### PR TITLE
Support LoadBalancer Service types in addition to NodePort.

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1527,7 +1527,7 @@ func (appMgr *Manager) updatePoolMembersForNodePort(
 	rsCfg *ResourceConfig,
 	index int,
 ) (bool, string, string) {
-	if svc.Spec.Type == v1.ServiceTypeNodePort {
+	if svc.Spec.Type == v1.ServiceTypeNodePort || svc.Spec.Type == v1.ServiceTypeLoadBalancer {
 		for _, portSpec := range svc.Spec.Ports {
 			if portSpec.Port == svcKey.ServicePort {
 				log.Debugf("Service backend matched %+v: using node port %v",
@@ -1539,7 +1539,7 @@ func (appMgr *Manager) updatePoolMembersForNodePort(
 		}
 		return true, "", ""
 	} else {
-		msg := fmt.Sprintf("Requested service backend '%+v' not of NodePort type",
+		msg := fmt.Sprintf("Requested service backend '%+v' not of NodePort or LoadBalancer type",
 			svcKey.ServiceName)
 		log.Debug(msg)
 		return false, "IncorrectBackendServiceType", msg


### PR DESCRIPTION
LoadBalancer and NodePort services behave the same way in the sense that they use a port on the node for traffic ingress. The controller should be able to treat them the same way.

I've tested that this works for NodePort and LoadBalancer service types.