### PR TITLE
Adds switch to disable ConfigMap processing

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -92,6 +92,7 @@ var (
 	kubeConfig        *string
 	namespaceLabel    *string
 	manageRoutes      *bool
+	manageConfigMaps  *bool
 	nodeLabelSelector *string
 	resolveIngNames   *string
 	defaultIngIP      *string
@@ -196,6 +197,8 @@ func _init() {
 		"Optional, used to watch for namespaces with this label")
 	manageRoutes = kubeFlags.Bool("manage-routes", false,
 		"Optional, specify whether or not to manage Route resources")
+	manageConfigMaps = kubeFlags.Bool("manage-configmaps", true,
+		"Optional, specify whether or not to manage ConfigMap resources")
 	nodeLabelSelector = kubeFlags.String("node-label-selector", "",
 		"Optional, used to watch only for nodes with this label")
 	resolveIngNames = kubeFlags.String("resolve-ingress-names", "",
@@ -520,6 +523,8 @@ func setupWatchers(appMgr *appmanager.Manager, resyncPeriod time.Duration) {
 				err = appMgr.AddNamespace(namespace, ls, resyncPeriod)
 				if nil != err {
 					log.Warningf("Failed to add informers for namespace %v: %v", namespace, err)
+				} else {
+					log.Debugf("Added informers for namespace %v: %v", namespace, err)
 				}
 			}
 		}
@@ -597,6 +602,7 @@ func main() {
 		DefaultIngIP:      *defaultIngIP,
 		VsSnatPoolName:    *vsSnatPoolName,
 		UseSecrets:        *useSecrets,
+		ManageConfigMaps:  *manageConfigMaps,
 		SchemaLocal:       *schemaLocal,
 	}
 

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -882,12 +882,13 @@ var _ = Describe("AppManager Tests", func() {
 			Expect(fakeClient).ToNot(BeNil())
 
 			mockMgr = newMockAppManager(&Params{
-				KubeClient:      fakeClient,
-				ConfigWriter:    mw,
-				restClient:      test.CreateFakeHTTPClient(),
-				RouteClientV1:   test.CreateFakeHTTPClient(),
-				IsNodePort:      true,
-				broadcasterFunc: NewFakeEventBroadcaster,
+				KubeClient:       fakeClient,
+				ConfigWriter:     mw,
+				restClient:       test.CreateFakeHTTPClient(),
+				RouteClientV1:    test.CreateFakeHTTPClient(),
+				IsNodePort:       true,
+				broadcasterFunc:  NewFakeEventBroadcaster,
+				ManageConfigMaps: true,
 			})
 		})
 		AfterEach(func() {

--- a/pkg/appmanager/profiles_test.go
+++ b/pkg/appmanager/profiles_test.go
@@ -48,12 +48,13 @@ var _ = Describe("AppManager Profile Tests", func() {
 			Expect(fakeClient).ToNot(BeNil())
 
 			mockMgr = newMockAppManager(&Params{
-				KubeClient:      fakeClient,
-				ConfigWriter:    mw,
-				restClient:      test.CreateFakeHTTPClient(),
-				RouteClientV1:   test.CreateFakeHTTPClient(),
-				IsNodePort:      true,
-				broadcasterFunc: NewFakeEventBroadcaster,
+				KubeClient:       fakeClient,
+				ConfigWriter:     mw,
+				restClient:       test.CreateFakeHTTPClient(),
+				RouteClientV1:    test.CreateFakeHTTPClient(),
+				IsNodePort:       true,
+				broadcasterFunc:  NewFakeEventBroadcaster,
+				ManageConfigMaps: true,
 			})
 			namespace = "default"
 			mockMgr.appMgr.routeConfig = RouteConfig{


### PR DESCRIPTION
This patch adds a switch to the creation args to instruct CC to
either watch, or not watch, ConfigMap events. The default value
of this switch is `true`; as-in "watch ConfigMaps". This was
the default behavior before this switch was added.