### PR TITLE
Don't remove all resources when deleting service

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -4,6 +4,13 @@ Release Notes for BIG-IP Controller for Kubernetes
 next-release
 ------------
 
+v1.6.1
+------
+
+Bug Fixes
+`````````
+* :issues:`743` - Controller doesn't temporarily remove entire BIG-IP configs after deleting a single service.
+
 v1.6.0
 ------
 

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1202,7 +1202,6 @@ func (appMgr *Manager) syncRoutes(
 				route, svcName, appMgr.resources, appMgr.routeConfig, ps,
 				appInf.svcInformer.GetIndexer(), svcFwdRulesMap, appMgr.vsSnatPoolName)
 			if err != nil {
-				// We return err if there was an error creating a rule
 				log.Warningf("%v", err)
 				continue
 			}
@@ -1601,11 +1600,29 @@ func (appMgr *Manager) deactivateVirtualServer(
 	appMgr.resources.Lock()
 	defer appMgr.resources.Unlock()
 	if rs, ok := appMgr.resources.Get(sKey, rsName); ok {
-		rsCfg.MetaData.Active = false
-		rsCfg.Pools[index].Members = nil
-		if !reflect.DeepEqual(rs, rsCfg) {
-			log.Debugf("Service delete matching backend %v %v deactivating config",
+		if len(rsCfg.Pools) > 1 {
+			// Only deactivate if all other pools for this config are nil as well
+			var valid bool
+			for i, pool := range rsCfg.Pools {
+				if i != index && pool.Members != nil {
+					valid = true
+					break
+				}
+			}
+			if !valid {
+				rsCfg.MetaData.Active = false
+				rsCfg.Pools[index].Members = nil
+			}
+		} else {
+			rsCfg.MetaData.Active = false
+			rsCfg.Pools[index].Members = nil
+		}
+		if !rsCfg.MetaData.Active {
+			log.Debugf("Service delete matching backend '%v', deactivating config '%v'",
 				sKey, rsName)
+		}
+
+		if !reflect.DeepEqual(rs, rsCfg) {
 			updateConfig = true
 		}
 	} else {

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -2714,6 +2714,114 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(resources.PoolCount()).To(Equal(1))
 			})
 
+			It("doesn't deactivate a multi-service config unnecessarily", func() {
+				mockMgr.appMgr.useNodeInternal = true
+				// Ingress first
+				ingressConfig := v1beta1.IngressSpec{
+					Rules: []v1beta1.IngressRule{
+						{Host: "host1",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{
+										{Path: "/foo",
+											Backend: v1beta1.IngressBackend{
+												ServiceName: "foo",
+												ServicePort: intstr.IntOrString{IntVal: 80},
+											},
+										},
+										{Path: "/bar",
+											Backend: v1beta1.IngressBackend{
+												ServiceName: "bar",
+												ServicePort: intstr.IntOrString{IntVal: 80},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				// Create Node so we get endpoints
+				node := test.NewNode("node1", "1", false,
+					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.1"}}, []v1.Taint{})
+				_, err := mockMgr.appMgr.kubeClient.Core().Nodes().Create(node)
+				Expect(err).To(BeNil())
+				n, err := mockMgr.appMgr.kubeClient.Core().Nodes().List(metav1.ListOptions{})
+				Expect(err).To(BeNil(), "Should not fail listing nodes.")
+				mockMgr.processNodeUpdate(n.Items, err)
+
+				// Create the services
+				fooSvc := test.NewService("foo", "1", namespace, "NodePort",
+					[]v1.ServicePort{{Port: 80, NodePort: 37001}})
+				r := mockMgr.addService(fooSvc)
+				Expect(r).To(BeTrue(), "Service should be processed.")
+				barSvc := test.NewService("bar", "2", namespace, "NodePort",
+					[]v1.ServicePort{{Port: 80, NodePort: 37002}})
+				r = mockMgr.addService(barSvc)
+				Expect(r).To(BeTrue(), "Service should be processed.")
+
+				// Create the Ingress
+				ing := test.NewIngress("ingress", "1", namespace, ingressConfig,
+					map[string]string{
+						f5VsBindAddrAnnotation:  "1.2.3.4",
+						f5VsPartitionAnnotation: "velcro",
+					})
+				r = mockMgr.addIngress(ing)
+				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
+
+				resources := mockMgr.resources()
+
+				deleteServices := func() {
+					rs, ok := resources.Get(
+						serviceKey{"foo", 80, "default"}, formatIngressVSName("1.2.3.4", 80))
+					Expect(ok).To(BeTrue())
+					Expect(rs.MetaData.Active).To(BeTrue())
+
+					// Delete one service, config should still be active
+					mockMgr.deleteService(fooSvc)
+					rs, ok = resources.Get(
+						serviceKey{"bar", 80, "default"}, formatIngressVSName("1.2.3.4", 80))
+					Expect(ok).To(BeTrue())
+					Expect(rs.MetaData.Active).To(BeTrue())
+
+					// Delete final service, config should go inactive
+					mockMgr.deleteService(barSvc)
+					rs, ok = resources.Get(
+						serviceKey{"bar", 80, "default"}, formatIngressVSName("1.2.3.4", 80))
+					Expect(ok).To(BeFalse())
+				}
+				deleteServices()
+
+				// Now try routes
+				mockMgr.addService(fooSvc)
+				mockMgr.addService(barSvc)
+				spec1 := routeapi.RouteSpec{
+					Host: "foo.com",
+					Path: "/foo",
+					To: routeapi.RouteTargetReference{
+						Kind: "Service",
+						Name: "foo",
+					},
+				}
+				route1 := test.NewRoute("route1", "1", namespace, spec1, nil)
+				r = mockMgr.addRoute(route1)
+				Expect(r).To(BeTrue(), "Route resource should be processed.")
+
+				spec2 := routeapi.RouteSpec{
+					Host: "bar.com",
+					Path: "/bar",
+					To: routeapi.RouteTargetReference{
+						Kind: "Service",
+						Name: "bar",
+					},
+				}
+				route2 := test.NewRoute("route2", "1", namespace, spec2, nil)
+				r = mockMgr.addRoute(route2)
+				Expect(r).To(BeTrue(), "Route resource should be processed.")
+
+				deleteServices()
+			})
+
 			It("properly uses the default Ingress IP", func() {
 				mockMgr.appMgr.defaultIngIP = "10.1.2.3"
 

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -1625,13 +1625,13 @@ func (appMgr *Manager) createRSConfigFromRoute(
 		} else {
 			backendPort, err = getServicePort(route, svcName, svcIndexer, strVal)
 			if nil != err {
-				log.Warningf("%v", err)
+				return &rsCfg, err, Pool{}
 			}
 		}
 	} else {
 		backendPort, err = getServicePort(route, svcName, svcIndexer, "")
 		if nil != err {
-			log.Warningf("%v", err)
+			return &rsCfg, err, Pool{}
 		}
 	}
 	var balance string


### PR DESCRIPTION
Problem: A bug existed for both Routes and Ingresses where all BIG-IP resources would temporarily be deleted when a single service was deleted. This was due to some bad logic that would deactivate an entire config if a service for that config wasn't found.

Solution: The logic now considers if there are multiple services for a config, and some are still active, then don't deactivate the config if a single service goes away. Only when all services are gone will the config be removed.

Fixes #743 