### PR TITLE
Docs and log message for bad Route spec

### DIFF
--- a/docs/README.rst
+++ b/docs/README.rst
@@ -740,6 +740,15 @@ Supported Route Annotations
 | virtual-server.f5.com/rewrite-target-url      | string      | Optional  | URL host, path, or host and path to be rewritten.                                 | N/A         |                                         |
 +-----------------------------------------------+-------------+-----------+-----------------------------------------------------------------------------------+-------------+-----------------------------------------+
 
+.. important::
+
+    For edge (client) termination, a Route **must** include **either** the certificate/key literal information
+    in the Route Spec, **or** the clientssl annotation. For re-encrypt (server) termination, a Route **must** include
+    **either** the destinationCaCertificate literal information in the Route Spec, **or** the serverssl annotation, 
+    in addition to the edge rules listed previously. If you want to use the configuration parameters 
+    `default-clientssl` or `default-serverssl` profiles for a Route, then specify those profile names in the
+    Route annotations in addition to the controller configuration.
+
 Please see the example configuration files for more details.
 
 .. _conf examples:

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -9,7 +9,9 @@ v1.6.1
 
 Bug Fixes
 `````````
+* :issues:`486` - User cannot configure the controller to manage the Common partition.
 * :issues:`743` - Controller doesn't temporarily remove entire BIG-IP configs after deleting a single service.
+* :issues:`746` - Log messages and documentation added to ensure Route profile configuration is clear.
 
 v1.6.0
 ------

--- a/pkg/appmanager/profiles.go
+++ b/pkg/appmanager/profiles.go
@@ -127,6 +127,9 @@ func (appMgr *Manager) setClientSslProfile(
 			appMgr.customProfiles.profs[skey] = cp
 			profRef.Partition = cp.Partition
 			profRef.Name = cp.Name
+		} else {
+			log.Warningf("No profile information supplied for Route '%v'", route.ObjectMeta.Name)
+			return
 		}
 		if add := rsCfg.Virtual.AddOrUpdateProfile(profRef); add {
 			// Remove annotation profile if it exists


### PR DESCRIPTION
Problem: The controller requires either literal cert/key info or annotations to be specified for Route profiles. If neither were specified, the controller silently failed.

Solution: Added docs and a log warning to inform the user that one of these fields is required.

Fixes #746 