### PR TITLE
Adds whitelist annotation support to CC

### DIFF
--- a/.approvals.json
+++ b/.approvals.json
@@ -379,7 +379,7 @@
  },
  {
    "name": "urllib3",
-   "version": " ",
+   "version": "1.23",
    "license": "MIT",
    "category": 3,
    "status": "approved"
@@ -448,7 +448,7 @@
    "status": "approved"
  },
  {
-   "name": "-e git+https://github.com/f5devcentral/f5-cccl.git@5aaa584f9fc77742eb9d976954e6dad805e6f4ff#egg=f5_cccl",
+   "name": "-e git+https://github.com/f5devcentral/f5-cccl.git@c97f6918e69137822466cc2185979e1923bbebb6#egg=f5_cccl",
    "version": "0.1.0",
    "license": "Apache 2.0",
    "category": 3,
@@ -463,7 +463,7 @@
  },
  {
    "name": "f5-sdk",
-   "version": "3.0.1",
+   "version": "3.0.20",
    "license": "Apache 2.0",
    "category": 3,
    "status": "approved"
@@ -715,7 +715,7 @@
  },
  {
    "name": "f5-icontrol-rest",
-   "version": "1.3.4",
+   "version": "1.3.11",
    "license": "Apache 2.0",
    "category": 3,
    "status": "approved"

--- a/Makefile
+++ b/Makefile
@@ -87,7 +87,15 @@ pre-build:
 prod-build: pre-build
 	@echo "Building with minimal instrumentation..."
 	BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-devel-image.sh
-	BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-release-artifacts.sh
+	RUN_TESTS=1 BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-release-artifacts.sh
+	BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-release-images.sh
+
+prod-quick: prod-build-quick
+
+prod-build-quick: pre-build
+	@echo "Building with running tests..."
+	BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-devel-image.sh
+	RUN_TESTS=0 BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-release-artifacts.sh
 	BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-release-images.sh
 
 dbg-build: pre-build

--- a/build-tools/rel-build.sh
+++ b/build-tools/rel-build.sh
@@ -4,6 +4,7 @@
 set -ex
 
 CURDIR="$(dirname $BASH_SOURCE)"
+RUN_TESTS=${RUN_TESTS:-1}
 
 . $CURDIR/_build-lib.sh
 BUILDDIR=$(get_builddir)
@@ -12,16 +13,20 @@ export BUILDDIR=$BUILDDIR
 
 go_install $(all_cmds)
 
-echo "Gathering unit test code coverage for 'release' build..."
-ginkgo_test_with_coverage
+if [ $RUN_TESTS -eq 1 ]; then
+    echo "Gathering unit test code coverage for 'release' build..."
+    ginkgo_test_with_coverage
+fi
 
 # reset GOPATH after using temp directories
 export GOPATH=/build
 
-# push coverage data to coveralls if F5 repo or if configured for fork.
-if [ "$COVERALLS_TOKEN" ]; then
-  cat $BUILDDIR/coverage/coverage.out >> $BUILDDIR/coverage.out
-  goveralls \
-    -coverprofile=$BUILDDIR/coverage.out \
-    -service=travis-ci
+if [ $RUN_TESTS -eq 1 ]; then
+    # push coverage data to coveralls if F5 repo or if configured for fork.
+    if [ "$COVERALLS_TOKEN" ]; then
+      cat $BUILDDIR/coverage/coverage.out >> $BUILDDIR/coverage.out
+      goveralls \
+        -coverprofile=$BUILDDIR/coverage.out \
+        -service=travis-ci
+    fi
 fi

--- a/build-tools/run-in-docker.sh
+++ b/build-tools/run-in-docker.sh
@@ -26,14 +26,15 @@ RUN_ARGS=( \
   -v $PWD:/build/$srcdir:ro,Z
   --workdir  /build/$srcdir
   -e GOPATH=/build
-  -e CLEAN_BUILD
-  -e IMG_TAG
-  -e BUILD_IMG_TAG
-  -e BUILD_VERSION
-  -e BUILD_INFO
+  -e CLEAN_BUILD=$CLEAN_BUILD
+  -e IMG_TAG=$IMG_TAG
+  -e BUILD_IMG_TAG=$BUILD_IMG_TAG
+  -e BUILD_VERSION=$BUILD_VERSION
+  -e BUILD_INFO=$BUILD_INFO
   -e LOCAL_USER_ID=$(id -u)
   -e TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG
   -e COVERALLS_TOKEN=$COVERALLS_REPO_TOKEN
+  -e RUN_TESTS=$RUN_TESTS
 )
 
 # Add -it if caller is a terminal

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -213,6 +213,12 @@ Kubernetes
 +-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
 | kubeconfig            | string  | Optional | ./config          | Path to the *kubeconfig* file           |                |
 +-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
+| manage-configmaps     | boolean | Optional | true              | Tells the controller whether or not     | true, false    |
+|                       |         |          |                   | to watch Kubernetes ConfigMaps and      |                |
+|                       |         |          |                   | apply their configuration.              |                |
+|                       |         |          |                   | If false, the controller will ignore    |                |
+|                       |         |          |                   | ConfigMap events.                       |                |
++-----------------------+---------+----------+-------------------+-----------------------------------------+----------------+
 | namespace             | string  | Optional | All               | Kubernetes namespace(s) to watch        |                |
 |                       |         |          |                   |                                         |                |
 |                       |         |          |                   | - may be a comma-separated list         |                |
@@ -617,6 +623,11 @@ Supported Ingress Annotations
 | virtual-server.f5.com/rewrite-app-root        | string      | Optional  | Root path redirection for the application.                                          | N/A         |                                         |
 +-----------------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+-----------------------------------------+
 | virtual-server.f5.com/rewrite-target-url      | string      | Optional  | URL host, path, or host and path to be rewritten.                                   | N/A         |                                         |
++-----------------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+-----------------------------------------+
+| virtual-server.f5.com/whitelist-source-range  | string      | Optional  | Comma separated list of CIDR addresses to allow inbound to Ingress services         | N/A         | Comma separated, CIDR formatted, IP     |
+|                                               |             |           |                                                                                     |             | addresses.                              |
+|                                               |             |           |                                                                                     |             |                                         |
+|                                               |             |           |                                                                                     |             | ex. 1.2.3.4/32,2.2.2.0/24               |
 +-----------------------------------------------+-------------+-----------+-------------------------------------------------------------------------------------+-------------+-----------------------------------------+
 
 Ingress Health Monitors

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -4,6 +4,11 @@ Release Notes for BIG-IP Controller for Kubernetes
 next-release
 ------------
 
+Added Functionality
+```````````````````
+* Added `--manage-configmaps` argument to CC to prevent or allow CC to respond to ConfigMap events. Defaults to `true`.
+* Added `virtual-server.f5.com/whitelist-source-range` annotation to support CIDR whitelisting.
+
 v1.6.1
 ------
 

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -2822,6 +2822,192 @@ var _ = Describe("AppManager Tests", func() {
 				deleteServices()
 			})
 
+			It("configure whitelist annotation on Ingress", func() {
+				var found *condition
+
+				// Multi-service Ingress
+				ingressConfig := v1beta1.IngressSpec{
+					Rules: []v1beta1.IngressRule{
+						{Host: "host1",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{
+										{Path: "/foo",
+											Backend: v1beta1.IngressBackend{
+												ServiceName: "foo",
+												ServicePort: intstr.IntOrString{IntVal: 80},
+											},
+										},
+										{Path: "/bar",
+											Backend: v1beta1.IngressBackend{
+												ServiceName: "bar",
+												ServicePort: intstr.IntOrString{IntVal: 80},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				barSvc := test.NewService(
+					"bar",
+					"2", namespace,
+					"NodePort",
+					[]v1.ServicePort{{Port: 80, NodePort: 37002}})
+				r := mockMgr.addService(barSvc)
+				Expect(r).To(BeTrue(), "Service should be processed.")
+
+				ingress3 := test.NewIngress(
+					"ingress",
+					"2",
+					namespace,
+					ingressConfig,
+					map[string]string{
+						f5VsBindAddrAnnotation:             "1.2.3.4",
+						f5VsPartitionAnnotation:            "velcro",
+						f5VsWhitelistSourceRangeAnnotation: "1.2.3.4/32,2.2.2.0/24",
+					})
+				ingress4 := test.NewIngress(
+					"ingress",
+					"2",
+					namespace,
+					ingressConfig,
+					map[string]string{
+						f5VsBindAddrAnnotation:  "2.2.2.2",
+						f5VsPartitionAnnotation: "velcro",
+					})
+				r = mockMgr.addIngress(ingress3)
+				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
+				resources := mockMgr.resources()
+
+				rs, ok := resources.Get(
+					serviceKey{"bar", 80, "default"},
+					formatIngressVSName("1.2.3.4", 80))
+				Expect(ok).To(BeTrue(), "Ingress should be accessible.")
+				Expect(rs).ToNot(BeNil(), "Ingress should be object.")
+				Expect(rs.MetaData.Active).To(BeTrue())
+
+				// Check to see that the condition
+				Expect(len(rs.Policies)).To(Equal(1))
+				Expect(len(rs.Policies[0].Rules)).To(Equal(1))
+
+				// Check to see if there are three conditions.
+				//
+				// One condition for the /foo rule
+				// One condition for the /bar condition
+				// One condition for the whitelist entry
+				//
+				// as defined in ingressConfig above.
+				Expect(len(rs.Policies[0].Rules[0].Conditions)).To(Equal(3))
+				for _, x := range rs.Policies[0].Rules[0].Conditions {
+					if x.Tcp == true {
+						found = x
+					}
+				}
+				Expect(found).NotTo(BeNil())
+				Expect(found.Values).Should(ConsistOf("1.2.3.4/32", "2.2.2.0/24"))
+
+				mockMgr.deleteIngress(ingress3)
+				r = mockMgr.addIngress(ingress4)
+
+				resources = mockMgr.resources()
+				rs, ok = resources.Get(
+					serviceKey{"bar", 80, "default"},
+					formatIngressVSName("2.2.2.2", 80))
+				Expect(ok).To(BeTrue(), "Ingress should be accessible.")
+				Expect(len(rs.Policies[0].Rules[0].Conditions)).To(Equal(2))
+
+				found = nil
+				for _, x := range rs.Policies[0].Rules[0].Conditions {
+					if x.Tcp == true {
+						found = x
+					}
+				}
+				Expect(found).To(BeNil())
+			})
+
+			It("configure whitelist annotation, extra spaces, on Ingress", func() {
+				var found *condition
+
+				// Multi-service Ingress
+				ingressConfig := v1beta1.IngressSpec{
+					Rules: []v1beta1.IngressRule{
+						{
+							Host: "host1",
+							IngressRuleValue: v1beta1.IngressRuleValue{
+								HTTP: &v1beta1.HTTPIngressRuleValue{
+									Paths: []v1beta1.HTTPIngressPath{
+										{
+											Path: "/foo",
+											Backend: v1beta1.IngressBackend{
+												ServiceName: "foo",
+												ServicePort: intstr.IntOrString{IntVal: 80},
+											},
+										},
+										{
+											Path: "/bar",
+											Backend: v1beta1.IngressBackend{
+												ServiceName: "bar",
+												ServicePort: intstr.IntOrString{IntVal: 80},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				}
+				barSvc := test.NewService(
+					"bar",
+					"2", namespace,
+					"NodePort",
+					[]v1.ServicePort{{Port: 80, NodePort: 37002}})
+				r := mockMgr.addService(barSvc)
+				Expect(r).To(BeTrue(), "Service should be processed.")
+
+				ingress3 := test.NewIngress(
+					"ingress",
+					"2",
+					namespace,
+					ingressConfig,
+					map[string]string{
+						f5VsBindAddrAnnotation:             "1.2.3.4",
+						f5VsPartitionAnnotation:            "velcro",
+						f5VsWhitelistSourceRangeAnnotation: "10.10.10.0/24, 192.168.0.0/16, 172.16.0.0/18",
+					})
+				r = mockMgr.addIngress(ingress3)
+				Expect(r).To(BeTrue(), "Ingress resource should be processed.")
+				resources := mockMgr.resources()
+
+				rs, ok := resources.Get(
+					serviceKey{"bar", 80, "default"},
+					formatIngressVSName("1.2.3.4", 80))
+				Expect(ok).To(BeTrue(), "Ingress should be accessible.")
+				Expect(rs).ToNot(BeNil(), "Ingress should be object.")
+				Expect(rs.MetaData.Active).To(BeTrue())
+
+				// Check to see that the condition
+				Expect(len(rs.Policies)).To(Equal(1))
+				Expect(len(rs.Policies[0].Rules)).To(Equal(1))
+
+				// Check to see if there are three conditions.
+				//
+				// One condition for the /foo rule
+				// One condition for the /bar condition
+				// One condition for the whitelist entry
+				//
+				// as defined in ingressConfig above.
+				Expect(len(rs.Policies[0].Rules[0].Conditions)).To(Equal(3))
+				for _, x := range rs.Policies[0].Rules[0].Conditions {
+					if x.Tcp == true {
+						found = x
+					}
+				}
+				Expect(found).NotTo(BeNil())
+				Expect(found.Values).Should(ConsistOf("10.10.10.0/24", "192.168.0.0/16", "172.16.0.0/18"))
+			})
+
 			It("properly uses the default Ingress IP", func() {
 				mockMgr.appMgr.defaultIngIP = "10.1.2.3"
 

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -173,12 +173,14 @@ type (
 		Replace   bool   `json:"replace,omitempty"`
 		Request   bool   `json:"request,omitempty"`
 		Reset     bool   `json:"reset,omitempty"`
+		Select    bool   `json:"select,omitempty"`
 		Value     string `json:"value,omitempty"`
 	}
 
 	// condition config for a Rule
 	condition struct {
 		Name            string   `json:"name"`
+		Address         bool     `json:"address,omitempty"`
 		CaseInsensitive bool     `json:"caseInsensitive,omitempty"`
 		Equals          bool     `json:"equals,omitempty"`
 		EndsWith        bool     `json:"endsWith,omitempty"`
@@ -187,12 +189,14 @@ type (
 		Host            bool     `json:"host,omitempty"`
 		HTTPURI         bool     `json:"httpUri,omitempty"`
 		Index           int      `json:"index,omitempty"`
+		Matches         bool     `json:"matches,omitempty"`
 		Path            bool     `json:"path,omitempty"`
 		PathSegment     bool     `json:"pathSegment,omitempty"`
 		Present         bool     `json:"present,omitempty"`
 		Remote          bool     `json:"remote,omitempty"`
 		Request         bool     `json:"request,omitempty"`
 		Scheme          bool     `json:"scheme,omitempty"`
+		Tcp             bool     `json:"tcp,omitempty"`
 		Values          []string `json:"values"`
 	}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/f5devcentral/f5-ctlr-agent.git@435f049bf1a36c56293e57686d88a0bcd03e4cf6#egg=f5-ctlr-agent
+-e git+https://github.com/f5devcentral/f5-ctlr-agent.git@87e4c06dca2102ad4e9239a7c71692cbc0719369#egg=f5-ctlr-agent


### PR DESCRIPTION
This patch adds whitelist annotation processing to CC. Whitelist
entries are created as part of L7 policies.