### PR TITLE
Fix same service rule cleanup

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -9,6 +9,10 @@ Added Functionality
 * Added `--manage-configmaps` argument to CC to prevent or allow CC to respond to ConfigMap events. Defaults to `true`.
 * Added `virtual-server.f5.com/whitelist-source-range` annotation to support CIDR whitelisting.
 
+Bug Fixes
+`````````
+* :issues:`735` - Deleted rules from routes and ingresses on the same service not cleaned up properly.
+
 v1.6.1
 ------
 

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1256,6 +1256,11 @@ func (appMgr *Manager) syncRoutes(
 						for _, rl := range pol.Rules {
 							if rl.FullURI == dep.Name {
 								rsCfg.DeleteRuleFromPolicy(pol.Name, rl, appMgr.mergedRulesMap)
+								// Delete profile (route only)
+								if rsCfg.MetaData.ResourceType == "route" {
+									resourceName := strings.Split(rl.Name, "_")[3]
+									rsCfg.DeleteRouteProfile(dep.Namespace, resourceName)
+								}
 							}
 						}
 					}

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -385,7 +385,7 @@ var _ = Describe("Resource Config Tests", func() {
 			added, removed = rs.UpdateDependencies(
 				key, deps, routeDeps[0], routeNeverFound)
 			Expect(len(added)).To(BeZero())
-			Expect(len(removed)).To(BeZero())
+			Expect(len(removed)).To(Equal(1))
 			Expect(len(rs.objDeps)).To(BeZero())
 		})
 
@@ -490,7 +490,7 @@ var _ = Describe("Resource Config Tests", func() {
 			added, removed = rs.UpdateDependencies(
 				key, deps, ingressDeps[0], ingNeverFound)
 			Expect(len(added)).To(BeZero())
-			Expect(len(removed)).To(BeZero())
+			Expect(len(removed)).To(Equal(4))
 			Expect(len(rs.objDeps)).To(BeZero())
 		})
 	})


### PR DESCRIPTION
Problem:
 Currently if there are two multi-service ingresses or routes pointed
 at the same service if one of them is deleted its rules will be left
 on the policy on the BIG-IP causing disruption to traffic as the
 controller tries to reconcile the desired config versus the left
 overs on the BIG-IP.

Solution:
 Add rule check in the dependency deletion in UpdateDependencies that
 will find the rules associated with cleaned up dependencies and add
 those to the remove dependencies slice to clean them up. Update unit
 tests to factor in this change.

Fixes: #735