### PR TITLE
Add whitelist reset rule, fix Route sorting

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -14,6 +14,8 @@ Bug Fixes
 `````````
 * :issues:`735` - Deleted rules from routes and ingresses on the same service not cleaned up properly.
 * :issues:`753` - Controller doesn't delete and recreate annotation-based policy rules.
+* :issues:`755` - Controller implements best-match by setting first-match and sorting rules in reverse lexical order.
+* :issues:`765` - Controller properly sorts Route rules in reverse lexical order.
 
 v1.6.1
 ------

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -3530,7 +3530,7 @@ var _ = Describe("AppManager Tests", func() {
 
 					// Verify whitelist conditions exist
 					var found *condition
-					Expect(len(rs.Policies[0].Rules)).To(Equal(2))
+					Expect(len(rs.Policies[0].Rules)).To(Equal(3))
 					Expect(len(rs.Policies[0].Rules[0].Conditions)).To(Equal(3))
 					for _, x := range rs.Policies[0].Rules[0].Conditions {
 						if x.Tcp == true {

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -92,9 +92,20 @@ func (r Rules) Less(i, j int) bool {
 		return true
 	}
 
+	if r[i].FullURI == r[j].FullURI {
+		if len(r[j].Actions) > 0 && r[j].Actions[0].Reset {
+			return false
+		}
+		return true
+	}
+
 	return r[i].FullURI < r[j].FullURI
 }
-func (r Rules) Swap(i, j int) { r[i], r[j] = r[j], r[i] }
+func (r Rules) Swap(i, j int) {
+	r[i], r[j] = r[j], r[i]
+	r[i].Ordinal = i
+	r[j].Ordinal = j
+}
 
 type Routes []*routeapi.Route
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--e git+https://github.com/f5devcentral/f5-ctlr-agent.git@586f3908b095c75dd381eb66db34c26cac4d06d5#egg=f5-ctlr-agent
+-e git+https://github.com/f5devcentral/f5-ctlr-agent.git@671a0defbea9e7def753adb685cbd9230754f131#egg=f5-ctlr-agent


### PR DESCRIPTION
Problem: 1. Route rules were not sorted correctly, causing "first-match" to behave unintentionally.
2. Whitelisted L7 rules for Routes with iRules would still allow traffic to flow through the iRule even when failing the policy.
3. Policy with whitelist rules didn't have the required "tcp" flag.

Solution: 1. Sorted Routes by URI to mimic "best-match".
2. Whitelisted Route rules now add a "reset connection" rule to prevent traffic from unintentionally flowing through an iRule.
3. Added "tcp" field to policy.

Fixes #755 #765