### PR TITLE
Update routing.go

### DIFF
--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -557,7 +557,7 @@ func sslPassthroughIRule() string {
 
 		when SERVER_CONNECTED {
 			set svrssl_class "/%[1]s/ssl_reencrypt_serverssl_dg"
-			if { [class exists $svrssl_class] } {
+			if { [info exists servername_lower] and [class exists $svrssl_class] } {
 				set profile [class match -value $servername_lower equals $svrssl_class]
 				if { not ($profile equals "") } {
 					SSL::profile $profile


### PR DESCRIPTION
SSL requests without SNI causes TCL error. This is why 
[info exists servername_lower] and 
has been added to:
		when SERVER_CONNECTED {
			set svrssl_class "/%[1]s/ssl_reencrypt_serverssl_dg"
			if { [info exists servername_lower] and [class exists $svrssl_class] } {
Please refer to C2831712 for further details.