### PR TITLE
Clean up reset rules when service goes away

### DIFF
--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -2346,6 +2346,12 @@ func (rc *ResourceConfig) RemovePool(
 				}
 				ruleOffsets = append(ruleOffsets, i)
 				unmerged := rc.UnmergeRule(rule.Name, appMgr.mergedRulesMap)
+				// If the next rule is a reset rule, remove that as well
+				if len(policy.Rules) > i+1 &&
+					strings.HasSuffix(policy.Rules[i+1].Name, "-reset") &&
+					policy.Rules[i+1].FullURI == rule.FullURI {
+					ruleOffsets = append(ruleOffsets, i+1)
+				}
 				if unmerged {
 					cfgChanged = true
 				}


### PR DESCRIPTION
Problem: If a service was deleted or goes away, the reset rule for routes using that service was not cleaned up.

Solution: Clean up reset rules if they exist when a pool is removed.