### PR TITLE
ConfigMap serverssl support with f5ServerSslProfileAnnotation

### DIFF
--- a/pkg/appmanager/profiles.go
+++ b/pkg/appmanager/profiles.go
@@ -490,6 +490,19 @@ func (appMgr *Manager) deleteUnusedProfiles(
 								)
 							}
 						}
+						if serverProfile, ok :=
+							cm.ObjectMeta.Annotations[f5ServerSslProfileAnnotation]; ok == true {
+							appMgr.checkProfile(
+								prof,
+								&toRemove,
+								cm.ObjectMeta.Namespace,
+								serverProfile,
+								&referenced,
+							)
+						}
+						if referenced {
+							break
+						}
 					}
 				}
 			} else if cfg.MetaData.ResourceType == "ingress" {

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -1310,6 +1310,13 @@ func parseConfigMap(cm *v1.ConfigMap, schemaDBPath, snatPoolName string) (*Resou
 						}
 					}
 				}
+				if serverProfile, ok :=
+					cm.ObjectMeta.Annotations[f5ServerSslProfileAnnotation]; ok == true {
+					secretName := formatIngressSslProfileName(serverProfile)
+					profRef := convertStringToProfileRef(
+						secretName, customProfileServer, cm.ObjectMeta.Namespace)
+					cfg.Virtual.AddOrUpdateProfile(profRef)
+				}
 			} else {
 				var errors []string
 				for _, desc := range result.Errors() {


### PR DESCRIPTION
ConfigMap does not support serverssl like ingress with annotation f5ServerSslProfileAnnotation, some customers want to add both clientssl and serverssl with ConfigMap, see https://github.com/F5Networks/k8s-bigip-ctlr/issues/768, this patch add ConfigMap with serverssl support