### PR TITLE
Fixes #789: Fixes the tls http to https route for child paths

### DIFF
--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -359,7 +359,7 @@ func httpRedirectIRule(port int32) string {
 				set redir 0
 				foreach s [split $paths "|"] {
 					# See if the request path starts with the prefix
-					append prefix "^" $s "($|/)"
+					append prefix "^" $s "($|/*)"
 					if {[HTTP::path] matches_regex $prefix} {
 						set redir 1
 						break


### PR DESCRIPTION
Problem:
The customer was facing the issue in routing the child paths of service from HTTP to HTTPS. 

Fix:
Modified the BIG-IP IRules to handle this situation. 