### PR TITLE
Change Redhat registry location

### DIFF
--- a/.approvals.json
+++ b/.approvals.json
@@ -673,7 +673,7 @@
  },
  {
    "name": "six",
-   "version": "1.11.0",
+   "version": "1.12.0",
    "license": "MIT",
    "category": 3,
    "status": "approved"

--- a/build-tools/Dockerfile.rhel7.builder
+++ b/build-tools/Dockerfile.rhel7.builder
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel7
+FROM registry.redhat.io/rhel7
 
 # GOLANG install steps
 

--- a/build-tools/Dockerfile.rhel7.runtime
+++ b/build-tools/Dockerfile.rhel7.runtime
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhel-atomic
+FROM registry.redhat.io/rhel-atomic
 
 LABEL name="f5networks/k8s-bigip-ctlr" \
       vendor="F5 Networks" \


### PR DESCRIPTION
RedHat is decommissioning their registry **registry.access.redhat.com** and changing it to **registry.redhat.io**. This PR contains necessary changes to adapt to the new registry.