### PR TITLE
Enabling multi-arch "F5Networks/k8s-bigip-ctlr" image for IBM Cloud Private

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,14 +6,24 @@ git:
   # don't limit git clone depth
   depth: false
 
+addons:
+  apt:
+    packages:
+      - docker-ce
+
+matrix:
+  include:
+    - os: linux
+    - os: linux-ppc64le
+
 before_install:
   - docker pull golang:1.11.1
-  - docker pull node:6.11.0-slim
+  - docker pull node:8.15.0-slim
   - docker pull f5devcentral/containthedocs
 
 script:
   - set -e
-  - docker run --rm -it -v `pwd`:`pwd` -w `pwd` node:6.11.0-slim build-tools/schema-tests.sh
+  - docker run --rm -it -v `pwd`:`pwd` -w `pwd` node:8.15.0-slim build-tools/schema-tests.sh
   - if [ "$DOCKER_NAMESPACE" == "" ]; then DOCKER_NAMESPACE="local"; fi
   - BASE_PUSH_TARGET="$DOCKER_NAMESPACE/k8s-bigip-ctlr"
   - |
@@ -55,15 +65,19 @@ script:
       docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:$BUILD_STAMP"
       docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:$BUILD_VERSION"
       docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:$BUILD_VERSION-$BUILD_INFO"
+      docker tag "$IMG_TAG" "$BASE_PUSH_TARGET:$TRAVIS_BRANCH-$ARCH"
       docker push "$IMG_TAG"
       docker push "$BASE_PUSH_TARGET:devel-$TRAVIS_BRANCH"
       docker push "$BASE_PUSH_TARGET:$BUILD_STAMP"
       docker push "$BASE_PUSH_TARGET:$BUILD_VERSION"
       docker push "$BASE_PUSH_TARGET:$BUILD_VERSION-$BUILD_INFO"
       docker push "$BASE_PUSH_TARGET:latest"
+      docker push "$BASE_PUSH_TARGET:$TRAVIS_BRANCH-$ARCH"
+      docker manifest create "$BASE_PUSH_TARGET:$TRAVIS_BRANCH" "$BASE_PUSH_TARGET:$TRAVIS_BRANCH-amd64" "$BASE_PUSH_TARGET:$TRAVIS_BRANCH-ppc64le"
+      docker manifest push "$BASE_PUSH_TARGET:$TRAVIS_BRANCH"
     fi
-  - make docs
-
+  - if [[ "$ARCH" == "amd64" ]]; then make docs; fi #f5devcentral/attributions-generator:latest docker image available only for x86.
+        #TO DO, https://github.com/F5Networks/k8s-bigip-ctlr/issues/806
 deploy:
   - provider: script
     skip_cleanup: true

--- a/build-tools/Dockerfile.debian.builder
+++ b/build-tools/Dockerfile.debian.builder
@@ -61,7 +61,7 @@ COPY requirements.docs.txt /tmp/requirements.docs.txt
 
 RUN pip install --no-cache-dir --upgrade pip && \
     pip install --no-cache-dir setuptools flake8 virtualenv && \
-	pip install --no-cache-dir --process-dependency-links -r /tmp/requirements.txt && \
+	pip install --no-cache-dir -r /tmp/requirements.txt && \
 	pip install --no-cache-dir -r /tmp/requirements.docs.txt && \
 	go get github.com/wadey/gocovmerge && \
 	go get golang.org/x/tools/cmd/cover && \

--- a/build-tools/Dockerfile.debian.runtime
+++ b/build-tools/Dockerfile.debian.runtime
@@ -13,7 +13,7 @@ COPY requirements.txt /tmp/requirements.txt
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
     && pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir --process-dependency-links -r /tmp/requirements.txt \
+    && pip install --no-cache-dir -r /tmp/requirements.txt \
     && apt-get remove -y git
 
 COPY bigip-virtual-server_v*.json $APPPATH/vendor/src/f5/schemas/

--- a/build-tools/Dockerfile.rhel7.builder
+++ b/build-tools/Dockerfile.rhel7.builder
@@ -56,7 +56,7 @@ COPY requirements.docs.txt /tmp/requirements.docs.txt
 RUN source scl_source enable python27 && \
 	pip install --no-cache-dir --upgrade pip && \
 	pip install --no-cache-dir setuptools flake8 && \
-	pip install --no-cache-dir --process-dependency-links --ignore-installed -r /tmp/requirements.txt && \
+	pip install --no-cache-dir --ignore-installed -r /tmp/requirements.txt && \
 	pip install --no-cache-dir -r /tmp/requirements.docs.txt && \
 	go get github.com/wadey/gocovmerge && \
 	go get golang.org/x/tools/cmd/cover && \

--- a/build-tools/Dockerfile.rhel7.runtime
+++ b/build-tools/Dockerfile.rhel7.runtime
@@ -30,7 +30,7 @@ RUN microdnf --enablerepo=rhel-7-server-rpms --enablerepo=rhel-7-server-optional
     go-md2man -in /tmp/help.md -out /help.1 && rm -f /tmp/help.md && \
     source scl_source enable python27 && \
     pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir --process-dependency-links -r /tmp/requirements.txt && \
+    pip install --no-cache-dir -r /tmp/requirements.txt && \
     python -m pip uninstall -y pip && \
     adduser ctlr && \
     microdnf remove golang-github-cpuguy83-go-md2man git fipscheck fipscheck-lib groff-base \

--- a/build-tools/_build-lib.sh
+++ b/build-tools/_build-lib.sh
@@ -51,7 +51,7 @@ get_builddir() {
 }
 
 # This is the expected output location, from the release build container
-RELEASE_PLATFORM=linux-amd64-release-go1.11.1
+RELEASE_PLATFORM="linux-$(go env GOARCH)-release-go1.11.1"
 
 NO_CACHE_ARGS=""
 if $CLEAN_BUILD; then
@@ -146,7 +146,11 @@ tmpdir_for_test() {
   local WKDIR=$(mktemp -d $BUILDDIR/tmpXXXXXX)
   # src dir to follow gopath convention
   mkdir -p $WKDIR/src
-  # Copy over mounted src to our writable src
-  rsync -a --exclude '.git' --exclude '_docker_workspace' $GOPATH/src/ $WKDIR/src
+  if [ "$(go env GOARCH)" == "amd64" ]; then
+     # Copy over mounted src to our writable src
+     rsync -a --exclude '.git' --exclude '_docker_workspace' $GOPATH/src/ $WKDIR/src
+  else
+     rsync -r --exclude '.git' --exclude '_docker_workspace' $GOPATH/src/ $WKDIR/src
+  fi
   echo $WKDIR
 }

--- a/build-tools/entrypoint.builder.sh
+++ b/build-tools/entrypoint.builder.sh
@@ -17,6 +17,9 @@ fi
 if [ -x /sbin/su-exec ]; then
     adduser -D --shell /bin/bash --uid $USER_ID ${ADDUSER_FLAG} user
     su_binary=/sbin/su-exec
+elif [[ "$(go env GOARCH)" == "ppc64le" ]]; then
+    adduser --shell /bin/bash --uid $USER_ID ${ADDUSER_FLAG} user
+    su_binary=gosu
 else
     adduser --shell /bin/bash --uid $USER_ID ${ADDUSER_FLAG} user
     su_binary=gosu

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 -e git+https://github.com/f5devcentral/f5-ctlr-agent.git@671a0defbea9e7def753adb685cbd9230754f131#egg=f5-ctlr-agent
+-e git+https://github.com/f5devcentral/f5-cccl.git@cfaaa7713fddf9fe28400317548d25b104d3b865#egg=f5-cccl


### PR DESCRIPTION
 Currently `F5Networks/k8s-bigip-ctlr:latest` docker image is only supporting ICP on amd64 architecture. 
This PR will enable IBM Cloud Private(ICP) on ppc64le Platform also.