### PR TITLE
Delay vsQueue Length Assessment

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -3,6 +3,7 @@ Release Notes for BIG-IP Controller for Kubernetes
 
 next-release
 ------------
+* :issues: `810` - Controller deletes services and recreates during bigip-ctlr pod restart
 
 v1.7.1
 ------

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -765,6 +765,8 @@ func (appMgr *Manager) virtualServerWorker() {
 func (appMgr *Manager) processNextVirtualServer() bool {
 	key, quit := appMgr.vsQueue.Get()
 	if !appMgr.initialState && appMgr.processedItems == 0 {
+		//TODO: Properly handlle queueLen assessment and remove Sleep function
+		time.Sleep(1 * time.Second)
 		appMgr.queueLen = appMgr.vsQueue.Len()
 	}
 	if quit {


### PR DESCRIPTION
Mitigates #810 where the controller deletes BigIP resources on startup and restart where a large number of services present in Kubernetes