### PR TITLE
AS3 declaration REST call implementation

### DIFF
--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -1,5 +1,16 @@
 package appmanager
 
+import (
+	"bytes"
+	"crypto/tls"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"time"
+
+	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
+)
+
 type as3Template string
 type as3Declaration string
 
@@ -10,6 +21,12 @@ type tenantName string
 type pool []Member
 type tenant map[appName][]serviceName
 type as3Object map[tenantName]tenant
+
+//Rest client creation for big ip
+type As3RestClient struct {
+	Client  *http.Client
+	baseURL string
+}
 
 // Takes an AS3 Template and perform service discovery with Kubernetes to generate AS3 Declaration
 func (appMgr *Manager) processUserDefinedAS3(template as3Template) {
@@ -48,4 +65,53 @@ func buildAS3Declaration(obj as3Object, template as3Template) as3Declaration {
 //Story 5
 // Takes AS3 Declaration and posting it to BigIP
 func (appMgr *Manager) postAS3Declaration(declaration as3Declaration) {
+	log.Debugf("[amit] Processing AS3 POST call with AS3 Manager")
+	var as3RC As3RestClient
+	as3RC.baseURL = "https://10.145.67.90"
+	_, status := as3RC.restCallToBigIP("POST", "/mgmt/shared/appsvcs/declare", declaration)
+	if status {
+		log.Infof("[as3_log] AS3 declaration POST to BIG-IP success")
+	}
+
+}
+
+// Takes AS3 Declaration and REST method and post it to BigIP
+func (as3RestClient *As3RestClient) restCallToBigIP(method string, route string, declaration as3Declaration) (string, bool) {
+	log.Debugf("[as3_log] REST call with AS3 Manager")
+	timeout := time.Duration(5 * time.Second)
+	var body []byte
+	//tr flag is set true to disable SSL validation
+	//Please remove SSL disable settings at RTW
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	as3RestClient.Client = &http.Client{
+		Transport: tr,
+		Timeout:   timeout,
+	}
+	var data io.Reader
+	if method == "POST" || method == "PUT" {
+		var s = []byte(declaration)
+		data = bytes.NewBuffer(s)
+	}
+	req, err := http.NewRequest(method, as3RestClient.baseURL+route, data)
+	if err != nil {
+		log.Errorf("[as3_log] Creating new HTTP request error: %s ", err)
+		return string(body), false
+	}
+	req.SetBasicAuth("admin", "admin")
+	resp, err := as3RestClient.Client.Do(req)
+	if err != nil {
+		log.Errorf("[as3_log] REST call error: %s ", err)
+		return string(body), false
+	}
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Errorf("[as3_log] REST call error: %s ", err)
+		return string(body), false
+	}
+	log.Infof("[as3_log] AS3 REST call response: %s ", string(body))
+	defer resp.Body.Close()
+	return string(body), true
+
 }

--- a/pkg/appmanager/as3Manager_test.go
+++ b/pkg/appmanager/as3Manager_test.go
@@ -1,0 +1,46 @@
+/*-
+ * Copyright (c) 2016-2018, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package appmanager
+
+import (
+	"net/http"
+	"net/http/httptest"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Create HTTP REST mock client and test POST call", func() {
+
+	It("AS3 declaratyion POST call test", func() {
+		route := "/mgmt/shared/appsvcs/declare"
+		method := "POST"
+		var template as3Declaration = `{"class":"AS3","action":"deploy","persist":true,}`
+		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+			// Test request parameters
+			// equals(t, req.URL.String(), "/mgmt/shared/appsvcs/info")
+			// Send response to be tested
+			rw.Write([]byte("OK"))
+		}))
+		// Close the server when test finishes
+		defer server.Close()
+		// Use Client & URL from our local test server
+		api := As3RestClient{server.Client(), server.URL}
+		body, _ := api.restCallToBigIP(method, route, template)
+		Expect(body).To(BeEquivalentTo("OK"))
+	})
+
+})


### PR DESCRIPTION
This code will POST AS3 declaration to Big-IP.
1. Implemented function postAS3Declaration to POST AS3 declaration to Big IP.
2. Created new generic function restCallToBigIP to handle all REST calls.
3. Created new file as3Manager_test.go to write unit test cases.

Known Issue:
1. Needs to fetch Big IP URL and basic auth credential for REST calls to BigIP.

