### PR TITLE
Handle AS3 Templates with no ADC class.

### DIFF
--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -65,16 +65,20 @@ func (appMgr *Manager) getAS3ObjectFromTemplate(
 	}
 
 	as3 := make(as3Object)
+	if len(as3) == 0 {
+		log.Error("No ADC class found in AS3 template")
+		return as3, false
+	}
 	// extract as3 declaration from template
 	dclr := (tmpl.(map[string]interface{}))["declaration"]
 
 	// Loop over all the tenants
-	for tn, t := range dclr.(map[string]interface{}) {
+	if dclr != nil{
+		for tn, t := range dclr.(map[string]interface{}) {
 		// Filter out non-json values
 		if _, ok := t.(map[string]interface{}); !ok {
 			continue
 		}
-
 		as3[tenantName(tn)] = make(tenant, 0)
 		// Loop over all the services in a tenant
 		for an, a := range t.(map[string]interface{}) {
@@ -109,10 +113,7 @@ func (appMgr *Manager) getAS3ObjectFromTemplate(
 		if len(as3[tenantName(tn)]) == 0 {
 			log.Debugf("No applications declared for tenant: %s\n", tn)
 		}
-	}
-	if len(as3) == 0 {
-		log.Error("No tenants declared in AS3 template")
-		return as3, false
+	    }
 	}
 	return as3, true
 }

--- a/pkg/appmanager/as3Manager_test.go
+++ b/pkg/appmanager/as3Manager_test.go
@@ -19,30 +19,71 @@ import (
 	"net/http"
 	"net/http/httptest"
 
+	"github.com/F5Networks/k8s-bigip-ctlr/pkg/test"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+
+	"k8s.io/client-go/kubernetes/fake"
 )
 
-var _ = Describe("Create HTTP REST mock client and test POST call", func() {
+var _ = Describe("As3Manager Unit Tests", func() {
 
-	It("AS3 declaratyion POST call test with 200 OK response", func() {
-		route := "/mgmt/shared/appsvcs/declare"
-		method := "POST"
-		var template as3Declaration = `{"class":"AS3","action":"deploy","persist":true,}`
-		server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
-			// Test request parameters
-			Expect(req.URL.String()).To(BeEquivalentTo("/mgmt/shared/appsvcs/declare"))
-			// Send response to be tested
-			_, err := rw.Write([]byte("OK"))
-			Expect(err).To(BeNil(), "Response writer should be written.")
-		}))
-		// Close the server when test finishes
-		defer server.Close()
-		// Use Client & URL from our local test server
-		api := As3RestClient{server.Client(), server.URL}
-		body, status := api.restCallToBigIP(method, route, template)
-		Expect(status).To(BeTrue())
-		Expect(body).To(BeEquivalentTo("OK"), "Response should be captured.")
+	Describe("Validating AS3 ConfigMap with AS3Manager", func() {
+		var mockMgr *mockAppManager
+		var mw *test.MockWriter
+		BeforeEach(func() {
+			RegisterBigIPSchemaTypes()
+
+			mw = &test.MockWriter{
+				FailStyle: test.Success,
+				Sections:  make(map[string]interface{}),
+			}
+			fakeClient := fake.NewSimpleClientset()
+			Expect(fakeClient).ToNot(BeNil())
+
+			mockMgr = newMockAppManager(&Params{
+				KubeClient:       fakeClient,
+				ConfigWriter:     mw,
+				restClient:       test.CreateFakeHTTPClient(),
+				RouteClientV1:    test.CreateFakeHTTPClient(),
+				IsNodePort:       true,
+				broadcasterFunc:  NewFakeEventBroadcaster,
+				ManageConfigMaps: true,
+			})
+		})
+		AfterEach(func() {
+			mockMgr.shutdown()
+		})
+
+		It("AS3 declaration without ADC Class", func() {
+			data := readConfigFile(configPath + "as3config_without_adc.json")
+			_, ok := mockMgr.appMgr.getAS3ObjectFromTemplate(as3Template(data))
+			Expect(ok).To(Equal(false), "AS3 Template without ADC class should not be processed.")
+		})
 	})
 
+	Describe("Create HTTP REST mock client and test POST call", func() {
+
+		It("AS3 declaratyion POST call test with 200 OK response", func() {
+			route := "/mgmt/shared/appsvcs/declare"
+			method := "POST"
+			var template as3Declaration = `{"class":"AS3","action":"deploy","persist":true,}`
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				// Test request parameters
+				Expect(req.URL.String()).To(BeEquivalentTo("/mgmt/shared/appsvcs/declare"))
+				// Send response to be tested
+				_, err := rw.Write([]byte("OK"))
+				Expect(err).To(BeNil(), "Response writer should be written.")
+			}))
+			// Close the server when test finishes
+			defer server.Close()
+			// Use Client & URL from our local test server
+			api := As3RestClient{server.Client(), server.URL}
+			body, status := api.restCallToBigIP(method, route, template)
+			Expect(status).To(BeTrue())
+			Expect(body).To(BeEquivalentTo("OK"), "Response should be captured.")
+		})
+
+	})
 })

--- a/pkg/test/configs/as3config_without_adc.json
+++ b/pkg/test/configs/as3config_without_adc.json
@@ -1,0 +1,47 @@
+{
+      "AS3": {
+         "class": "Tenant",
+         "A2": {
+        "class": "Applicati{on",
+        "template": "https",
+        "serviceMain": {
+            "class": "Service_HTTPS",
+            "virtualAddresses": [
+                "1.1.1.2"
+            ],
+            "pool": "web_pool",
+            "serverTLS": "webtls"
+        },
+        "web_pool": {
+            "class": "Pool",
+            "loadBalancingMode": "predictive-node",
+           "monitors": [
+                "http"
+            ],
+            "members": [
+                {
+                    "servicePort": 8080,
+                    "serverAddresses": []
+                }
+            ]
+        },
+        "webtls": {
+            "class": "TLS_Server",
+            "certificates": [
+                {
+                    "certificate": "webcert"
+                }
+            ]
+        },
+        "webcert": {
+
+            "class": "Certificate",
+            "certificate": "-----BEGIN CERTIFICATE-----",
+            "privateKey": "-----BEGIN RSA PRIVATE KEY-----",
+            "passphrase": {
+               "ciphertext": "ZjVmNQ==",
+               "protected": "eyJhbGciOiJkaXIiLCJlbmMiOiJub25lIn0"
+            }
+        }
+}}}
+


### PR DESCRIPTION
Problem:
Without ADC class also, AS3 Template is being parsed and Controller is crashing.

Solution:
Updated logic not to handle any AS3 Template without ADC class.

All related unit tests pass.

affects-branches: feature.user-defined-as3