### PR TITLE
Add Static ARP for AS3 Members

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -127,6 +127,7 @@ type Manager struct {
 	mergedRulesMap map[string]map[string]mergedRuleEntry
 	// Whether to watch ConfigMap resources or not
 	manageConfigMaps bool
+	as3Members       map[Member]struct{}
 }
 
 // Struct to allow NewManager to receive all or only specific parameters.
@@ -196,6 +197,7 @@ func NewManager(params *Params) *Manager {
 		schemaLocal:       params.SchemaLocal,
 		mergedRulesMap:    make(map[string]map[string]mergedRuleEntry),
 		manageConfigMaps:  params.ManageConfigMaps,
+		as3Members:        make(map[Member]struct{}, 0),
 	}
 	if nil != manager.kubeClient && nil == manager.restClientv1 {
 		// This is the normal production case, but need the checks for unit tests.


### PR DESCRIPTION
##### Problem:
Data plane traffic fails in ClusterIP mode because there are no static ARP entries available in BIG-IP to forward traffic to flannel/sdn interface.
 
##### Solution:
Created a master list to track discovered AS3 Members and sending the list to VxLAN manager for ARP update and FDB update.
   
affects-branches: feature.user-defined-as3