### PR TITLE
Handle AS3 Templates with no ADC class

### DIFF
--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -1,3 +1,19 @@
+/*-
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package appmanager
 
 import (
@@ -65,8 +81,13 @@ func (appMgr *Manager) getAS3ObjectFromTemplate(
 	}
 
 	as3 := make(as3Object)
+
 	// extract as3 declaration from template
 	dclr := (tmpl.(map[string]interface{}))["declaration"]
+	if dclr == nil {
+		log.Error("No ADC class declaration found.")
+		return nil, false
+	}
 
 	// Loop over all the tenants
 	for tn, t := range dclr.(map[string]interface{}) {

--- a/pkg/appmanager/as3Manager_test.go
+++ b/pkg/appmanager/as3Manager_test.go
@@ -78,6 +78,11 @@ var _ = Describe("As3Manager Tests", func() {
 			_, ok := mockMgr.appMgr.getAS3ObjectFromTemplate(as3Template(data))
 			Expect(ok).To(Equal(false), "AS3 Template parsed succesfully, [No Tenants].")
 		})
+		It("AS3 template without ADC declaration", func() {
+			data := readConfigFile(configPath + "as3config_without_adc.json")
+			_, ok := mockMgr.appMgr.getAS3ObjectFromTemplate(as3Template(data))
+			Expect(ok).To(Equal(false), "AS3 Template without ADC declaration should not be processed.")
+		})
 	})
 
 	Describe("Create HTTP REST mock client and test POST call", func() {

--- a/pkg/test/configs/as3config_without_adc.json
+++ b/pkg/test/configs/as3config_without_adc.json
@@ -1,0 +1,46 @@
+{
+      "AS3": {
+         "class": "Tenant",
+         "A2": {
+        "class": "Applicati{on",
+        "template": "https",
+        "serviceMain": {
+            "class": "Service_HTTPS",
+            "virtualAddresses": [
+                "1.1.1.2"
+            ],
+            "pool": "web_pool",
+            "serverTLS": "webtls"
+        },
+        "web_pool": {
+            "class": "Pool",
+            "loadBalancingMode": "predictive-node",
+           "monitors": [
+                "http"
+            ],
+            "members": [
+                {
+                    "servicePort": 8080,
+                    "serverAddresses": []
+                }
+            ]
+        },
+        "webtls": {
+            "class": "TLS_Server",
+            "certificates": [
+                {
+                    "certificate": "webcert"
+                }
+            ]
+        },
+        "webcert": {
+
+            "class": "Certificate",
+            "certificate": "-----BEGIN CERTIFICATE-----",
+            "privateKey": "-----BEGIN RSA PRIVATE KEY-----",
+            "passphrase": {
+               "ciphertext": "ZjVmNQ==",
+               "protected": "eyJhbGciOiJkaXIiLCJlbmMiOiJub25lIn0"
+            }
+        }
+}}}


### PR DESCRIPTION
Problem:
Without ADC class also, AS3 Template is being parsed and Controller is crashing.

Solution:
Updated logic not to handle any AS3 Template without ADC class.

All related unit tests pass.

affects-branches: feature.user-defined-as3