### PR TITLE
Option to disable AS3 Validation

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -105,6 +105,7 @@ var (
 	bigIPPassword   *string
 	bigIPPartitions *[]string
 	credsDir        *string
+	as3Validation   *bool
 
 	vxlanMode        string
 	openshiftSDNName *string
@@ -172,6 +173,8 @@ func _init() {
 	credsDir = bigIPFlags.String("credentials-directory", "",
 		"Optional, directory that contains the BIG-IP username, password, and/or "+
 			"url files. To be used instead of username, password, and/or url arguments.")
+	as3Validation = bigIPFlags.Bool("as3-validation", true,
+		"Optional, when set to false, disables as3 template validation on the controller")
 
 	bigIPFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  BigIP:\n%s\n", bigIPFlags.FlagUsagesWrapped(width))
@@ -604,6 +607,7 @@ func main() {
 		UseSecrets:        *useSecrets,
 		ManageConfigMaps:  *manageConfigMaps,
 		SchemaLocal:       *schemaLocal,
+		AS3Validation:     *as3Validation,
 	}
 
 	// If running with Flannel, create an event channel that the appManager

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -128,6 +128,7 @@ type Manager struct {
 	// Whether to watch ConfigMap resources or not
 	manageConfigMaps bool
 	as3Members       map[Member]struct{}
+	as3Validation    bool
 }
 
 // Struct to allow NewManager to receive all or only specific parameters.
@@ -150,6 +151,7 @@ type Params struct {
 	broadcasterFunc  NewBroadcasterFunc
 	SchemaLocal      string
 	ManageConfigMaps bool
+	AS3Validation    bool
 }
 
 // Configuration options for Routes in OpenShift
@@ -198,6 +200,7 @@ func NewManager(params *Params) *Manager {
 		mergedRulesMap:    make(map[string]map[string]mergedRuleEntry),
 		manageConfigMaps:  params.ManageConfigMaps,
 		as3Members:        make(map[Member]struct{}, 0),
+		as3Validation:     params.AS3Validation,
 	}
 	if nil != manager.kubeClient && nil == manager.restClientv1 {
 		// This is the normal production case, but need the checks for unit tests.

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -57,18 +57,20 @@ var BigIPURL string
 func (appMgr *Manager) processUserDefinedAS3(template string) bool {
 
 	// Validate AS3 Template
-	ok := appMgr.validateAS3Template(template)
+	if appMgr.as3Validation == true {
+		log.Debugf("[as3] Start validating template")
 
-	if !ok {
-		log.Errorf("Error processing AS3 template \n")
-		return false
+		if ok := appMgr.validateAS3Template(template); !ok {
+			log.Errorf("[as3] Error validating template \n")
+			return false
+		}
 	}
 
 	templateObj := as3Template(template)
 	obj, ok := appMgr.getAS3ObjectFromTemplate(templateObj)
 
 	if !ok {
-		log.Errorf("Error processing template\n")
+		log.Errorf("[as3] Error processing template\n")
 		return false
 	}
 	declaration := appMgr.buildAS3Declaration(obj, templateObj)


### PR DESCRIPTION
Problem: We are customizing and hard linking AS3 JSON Schema with the
controller. If there are bugs in the JSON schema or the validator we use,
there is no way to address this situation without shipping a new release.

Solution: Make AS3 Schema validation configurable so that the user can
disable validation.

affected-branches: feature.user-defined-as3