### PR TITLE
Option to enable insecure communication

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -106,6 +106,7 @@ var (
 	bigIPPartitions *[]string
 	credsDir        *string
 	as3Validation   *bool
+	sslInsecure     *bool
 
 	vxlanMode        string
 	openshiftSDNName *string
@@ -174,7 +175,9 @@ func _init() {
 		"Optional, directory that contains the BIG-IP username, password, and/or "+
 			"url files. To be used instead of username, password, and/or url arguments.")
 	as3Validation = bigIPFlags.Bool("as3-validation", true,
-		"Optional, when set to false, disables as3 template validation on the controller")
+		"Optional, when set to false, disables as3 template validation on the controller.")
+	sslInsecure = bigIPFlags.Bool("insecure", false,
+		"Optional, when set to true, enable insecure SSL communication to BIGIP.")
 
 	bigIPFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  BigIP:\n%s\n", bigIPFlags.FlagUsagesWrapped(width))
@@ -608,6 +611,7 @@ func main() {
 		ManageConfigMaps:  *manageConfigMaps,
 		SchemaLocal:       *schemaLocal,
 		AS3Validation:     *as3Validation,
+		SSLInsecure:       *sslInsecure,
 	}
 
 	// If running with Flannel, create an event channel that the appManager

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -129,6 +129,7 @@ type Manager struct {
 	manageConfigMaps bool
 	as3Members       map[Member]struct{}
 	as3Validation    bool
+	sslInsecure      bool
 }
 
 // Struct to allow NewManager to receive all or only specific parameters.
@@ -152,6 +153,7 @@ type Params struct {
 	SchemaLocal      string
 	ManageConfigMaps bool
 	AS3Validation    bool
+	SSLInsecure      bool
 }
 
 // Configuration options for Routes in OpenShift
@@ -201,6 +203,7 @@ func NewManager(params *Params) *Manager {
 		manageConfigMaps:  params.ManageConfigMaps,
 		as3Members:        make(map[Member]struct{}, 0),
 		as3Validation:     params.AS3Validation,
+		sslInsecure:       params.SSLInsecure,
 	}
 	if nil != manager.kubeClient && nil == manager.restClientv1 {
 		// This is the normal production case, but need the checks for unit tests.

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -384,20 +384,20 @@ func (appMgr *Manager) postAS3Declaration(declaration as3Declaration) {
 	log.Debugf("[as3_log] Processing AS3 POST call with AS3 Manager")
 	var as3RC As3RestClient
 	as3RC.baseURL = BigIPURL
-	response, _ := as3RC.restCallToBigIP("POST", "/mgmt/shared/appsvcs/declare", declaration)
+	response, _ := as3RC.restCallToBigIP("POST", "/mgmt/shared/appsvcs/declare", declaration, appMgr.sslInsecure)
 	log.Debugf("[as3_log] AS3 declaration POST call response %s", response)
 
 }
 
 // Takes AS3 Declaration, method, API route and post it to BigIP
-func (as3RestClient *As3RestClient) restCallToBigIP(method string, route string, declaration as3Declaration) (string, bool) {
+func (as3RestClient *As3RestClient) restCallToBigIP(method string, route string, declaration as3Declaration, sslInsecure bool) (string, bool) {
 	log.Debugf("[as3_log] REST call with AS3 Manager")
 	timeout := time.Duration(15 * time.Second)
 	var body []byte
 	//FIXME: tr flag is set true to disable SSL validation
 	//Please remove SSL disable settings at RTW
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: sslInsecure},
 	}
 	as3RestClient.client = &http.Client{
 		Transport: tr,

--- a/pkg/appmanager/as3Manager_test.go
+++ b/pkg/appmanager/as3Manager_test.go
@@ -103,7 +103,7 @@ var _ = Describe("As3Manager Tests", func() {
 			defer server.Close()
 			// Use Client & URL from our local test server
 			api := As3RestClient{server.Client(), server.URL}
-			_, status := api.restCallToBigIP(method, route, template)
+			_, status := api.restCallToBigIP(method, route, template, false)
 			Expect(status).To(BeTrue())
 		})
 
@@ -124,7 +124,7 @@ var _ = Describe("As3Manager Tests", func() {
 			defer server.Close()
 			// Use Client & URL from our local test server
 			api := As3RestClient{server.Client(), server.URL}
-			_, status := api.restCallToBigIP(method, route, template)
+			_, status := api.restCallToBigIP(method, route, template, false)
 			Expect(status).To(BeFalse())
 		})
 
@@ -145,7 +145,7 @@ var _ = Describe("As3Manager Tests", func() {
 			defer server.Close()
 			// Use Client & URL from our local test server
 			api := As3RestClient{server.Client(), server.URL}
-			_, status := api.restCallToBigIP(method, route, template)
+			_, status := api.restCallToBigIP(method, route, template, false)
 			Expect(status).To(BeFalse())
 		})
 
@@ -166,7 +166,7 @@ var _ = Describe("As3Manager Tests", func() {
 			api := As3RestClient{server.Client(), server.URL}
 			//Close serve to test serve failure
 			server.Close()
-			_, status := api.restCallToBigIP(method, route, template)
+			_, status := api.restCallToBigIP(method, route, template, false)
 			Expect(status).To(BeFalse())
 		})
 	})


### PR DESCRIPTION
Problem: Insecure flag was always set to true.

Solution: Introducing --insecure flag option. The default option is set as false for secure communication. User can change it as true to enable insecure communication to bigip.

affects-branches: feature.user-defined-as3



