### PR TITLE
Combine AS3 ARP Update with legacy ARP Processing

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -900,7 +900,7 @@ func (appMgr *Manager) syncVirtualServer(sKey serviceQueueKey) error {
 	appMgr.deleteUnusedProfiles(appInf, sKey.Namespace, &stats)
 
 	if stats.vsUpdated > 0 || stats.vsDeleted > 0 || stats.cpUpdated > 0 ||
-		stats.dgUpdated > 0 || stats.poolsUpdated > 0 {
+		stats.dgUpdated > 0 || stats.poolsUpdated > 0 || len(appMgr.as3Members) > 0 {
 		appMgr.outputConfig()
 	} else if !appMgr.initialState && appMgr.processedItems >= appMgr.queueLen {
 		appMgr.outputConfig()

--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -118,6 +118,11 @@ func (appMgr *Manager) outputConfigLocked() {
 				allPoolMembers = append(allPoolMembers, iapp.IAppPoolMemberTable.Members...)
 			}
 		}
+
+		for member := range appMgr.as3Members {
+			allPoolMembers = append(allPoolMembers, member)
+		}
+
 		select {
 		case appMgr.eventChan <- allPoolMembers:
 			log.Debugf("AppManager wrote endpoints to VxlanMgr.")


### PR DESCRIPTION
Problem: Sending AS3 Static ARP entry updates deletes existing ARP
entries from legacy resources.

Solution: This is happening because CCCL is declarative. AS3 member
update is handled along with legacy ARP processing.

Affected branches: feature.user-defined-as3