### PR TITLE
remove Local Traffic Management from 1st paragraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 F5 BIG-IP Controller for Kubernetes
 ===================================
 
-The F5 BIG-IP Controller for [Kubernetes](http://kubernetes.io/) makes F5 BIG-IP
-[Local Traffic Manager](<https://f5.com/products/big-ip/local-traffic-manager-ltm)
+The F5 BIG-IP Controller for [Kubernetes](http://kubernetes.io/) makes F5 [BIG-IP]
+(<https://f5.com/products/big-ip/local-traffic-manager-ltm)
 services available to applications running in Kubernetes.
 
 Documentation

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@
 F5 BIG-IP Controller for Kubernetes
 ===================================
 
-The F5 BIG-IP Controller for [Kubernetes](http://kubernetes.io/) makes F5 [BIG-IP]
-(<https://f5.com/products/big-ip/local-traffic-manager-ltm)
+The F5 BIG-IP Controller for [Kubernetes](http://kubernetes.io/) makes F5 [BIG-IP](https://www.f5.com/products/big-ip-services)
 services available to applications running in Kubernetes.
 
 Documentation


### PR DESCRIPTION
Removed the words "Local Traffic Management" from the readme first paragraph as we can now address other module functionality via AS3.