### PR TITLE
Implementation of sending AS3 declaration to bigip only if there is change in declaration

### DIFF
--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -18,6 +18,7 @@ package appmanager
 
 import (
 	"bytes"
+	"crypto/md5"
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
@@ -45,13 +46,16 @@ type as3Object map[tenantName]tenant
 
 //Rest client creation for big ip
 type As3RestClient struct {
-	client  *http.Client
-	baseURL string
+	client      *http.Client
+	baseURL     string
+	oldChecksum string
+	newChecksum string
 }
 
 var BigIPUsername string
 var BigIPPassword string
 var BigIPURL string
+var as3RC As3RestClient
 
 var buffer map[Member]struct{}
 
@@ -369,18 +373,23 @@ func (appMgr *Manager) buildAS3Declaration(obj as3Object, template as3Template) 
 // Takes AS3 Declaration and post it to BigIP
 func (appMgr *Manager) postAS3Declaration(declaration as3Declaration) {
 	log.Debugf("[as3_log] Processing AS3 POST call with AS3 Manager")
-	var as3RC As3RestClient
 	as3RC.baseURL = BigIPURL
-	response, _ := as3RC.restCallToBigIP("POST", "/mgmt/shared/appsvcs/declare", declaration, appMgr.sslInsecure)
-	log.Debugf("[as3_log] AS3 declaration POST call response %s", response)
+	as3RC.restCallToBigIP("POST", "/mgmt/shared/appsvcs/declare", declaration, appMgr.sslInsecure)
 
 }
 
 // Takes AS3 Declaration, method, API route and post it to BigIP
 func (as3RestClient *As3RestClient) restCallToBigIP(method string, route string, declaration as3Declaration, sslInsecure bool) (string, bool) {
 	log.Debugf("[as3_log] REST call with AS3 Manager")
-	timeout := time.Duration(15 * time.Second)
+	hash := md5.New()
+	io.WriteString(hash, string(declaration))
+	as3RestClient.newChecksum = string(hash.Sum(nil))
+	timeout := time.Duration(60 * time.Second)
 	var body []byte
+	if as3RestClient.oldChecksum == as3RestClient.newChecksum {
+		log.Debugf("[as3_log] No change in declaration.")
+		return string(body), true
+	}
 	//FIXME: tr flag is set true to disable SSL validation
 	//Please remove SSL disable settings at RTW
 	tr := &http.Transport{
@@ -427,6 +436,7 @@ func (as3RestClient *As3RestClient) restCallToBigIP(method string, route string,
 			log.Debugf("[as3_log] Response from Big-IP")
 			log.Debugf("[as3_log] code: %v --- tenant:%v --- message: %v", v["code"], v["tenant"], v["message"])
 		}
+		as3RestClient.oldChecksum = as3RestClient.newChecksum
 		return string(body), true
 	} else {
 		//Other then 200 status code

--- a/pkg/appmanager/as3Manager_test.go
+++ b/pkg/appmanager/as3Manager_test.go
@@ -16,6 +16,8 @@
 package appmanager
 
 import (
+	"crypto/md5"
+	"io"
 	"net/http"
 	"net/http/httptest"
 
@@ -102,7 +104,7 @@ var _ = Describe("As3Manager Tests", func() {
 			// Close the server when test finishes
 			defer server.Close()
 			// Use Client & URL from our local test server
-			api := As3RestClient{server.Client(), server.URL}
+			api := As3RestClient{server.Client(), server.URL, "", ""}
 			_, status := api.restCallToBigIP(method, route, template, false)
 			Expect(status).To(BeTrue())
 		})
@@ -123,7 +125,7 @@ var _ = Describe("As3Manager Tests", func() {
 			// Close the server when test finishes
 			defer server.Close()
 			// Use Client & URL from our local test server
-			api := As3RestClient{server.Client(), server.URL}
+			api := As3RestClient{server.Client(), server.URL, "", ""}
 			_, status := api.restCallToBigIP(method, route, template, false)
 			Expect(status).To(BeFalse())
 		})
@@ -144,7 +146,7 @@ var _ = Describe("As3Manager Tests", func() {
 			// Close the server when test finishes
 			defer server.Close()
 			// Use Client & URL from our local test server
-			api := As3RestClient{server.Client(), server.URL}
+			api := As3RestClient{server.Client(), server.URL, "", ""}
 			_, status := api.restCallToBigIP(method, route, template, false)
 			Expect(status).To(BeFalse())
 		})
@@ -163,11 +165,54 @@ var _ = Describe("As3Manager Tests", func() {
 			// Close the server when test finishes
 			defer server.Close()
 			// Use Client & URL from our local test server
-			api := As3RestClient{server.Client(), server.URL}
+			api := As3RestClient{server.Client(), server.URL, "", ""}
 			//Close serve to test serve failure
 			server.Close()
 			_, status := api.restCallToBigIP(method, route, template, false)
 			Expect(status).To(BeFalse())
+		})
+
+		It("Test for same declaration posting to bigip", func() {
+			route := "/mgmt/shared/appsvcs/declare"
+			method := "POST"
+			var template as3Declaration = `{"class":"AS3","action":"deploy","persist":true,}`
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				// Test request parameters
+				Expect(req.URL.String()).To(BeEquivalentTo("/mgmt/shared/appsvcs/declare"))
+				// Send response to be tested
+				data := `{"results":[{"message":"no change","host":"localhost","tenant":"Sample_01","runTime":262,"code":200}]}`
+				_, err := rw.Write([]byte(data))
+				Expect(err).To(BeNil(), "Response writer should be written.")
+			}))
+			// Close the server when test finishes
+			defer server.Close()
+			h := md5.New()
+			io.WriteString(h, string(template))
+			oldChecksum := string(h.Sum(nil))
+			// Use Client & URL from our local test server
+			api := As3RestClient{server.Client(), server.URL, oldChecksum, ""}
+			_, status := api.restCallToBigIP(method, route, template, false)
+			Expect(status).To(BeTrue())
+		})
+
+		It("Test for new declaration posting to bigip", func() {
+			route := "/mgmt/shared/appsvcs/declare"
+			method := "POST"
+			var template as3Declaration = `{"class":"AS3","action":"deploy","persist":false,}`
+			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+				// Test request parameters
+				Expect(req.URL.String()).To(BeEquivalentTo("/mgmt/shared/appsvcs/declare"))
+				// Send response to be tested
+				data := `{"results":[{"message":"no change","host":"localhost","tenant":"Sample_01","runTime":262,"code":200}]}`
+				_, err := rw.Write([]byte(data))
+				Expect(err).To(BeNil(), "Response writer should be written.")
+			}))
+			// Close the server when test finishes
+			defer server.Close()
+			// Use Client & URL from our local test server
+			api := As3RestClient{server.Client(), server.URL, "", ""}
+			_, status := api.restCallToBigIP(method, route, template, false)
+			Expect(status).To(BeTrue())
 		})
 	})
 })


### PR DESCRIPTION
Problem:
CIS always posting same AS3 declaration to BIGIP if there are no changes in the declaration.

Solution:
Implemented MD5 checksum mechanism on the AS3 declaration to identify the changes on the declaration.

Affected Branches:
master