### PR TITLE
Updated Copyright Text to include 2019

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2017,2018, F5 Networks, Inc.
+ * Copyright (c) 2017,2018,2019 F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/k8s-bigip-ctlr/main_test.go
+++ b/cmd/k8s-bigip-ctlr/main_test.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2017,2018, F5 Networks, Inc.
+ * Copyright (c) 2017,2018,2019 F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cmd/k8s-bigip-ctlr/pythonDriver.go
+++ b/cmd/k8s-bigip-ctlr/pythonDriver.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2018, F5 Networks, Inc.
+ * Copyright (c) 2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/as3Manager_test.go
+++ b/pkg/appmanager/as3Manager_test.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/eventNotifier.go
+++ b/pkg/appmanager/eventNotifier.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/eventNotifier_test.go
+++ b/pkg/appmanager/eventNotifier_test.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/healthMonitors.go
+++ b/pkg/appmanager/healthMonitors.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/healthMonitors_test.go
+++ b/pkg/appmanager/healthMonitors_test.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/profiles_test.go
+++ b/pkg/appmanager/profiles_test.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/routeDomain.go
+++ b/pkg/appmanager/routeDomain.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/schema.go
+++ b/pkg/appmanager/schema.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/schema_test.go
+++ b/pkg/appmanager/schema_test.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2017,2018, F5 Networks, Inc.
+ * Copyright (c) 2017,2018,2019 F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/appmanager/validateResources.go
+++ b/pkg/appmanager/validateResources.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2016-2018, F5 Networks, Inc.
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/pollers/nodePoller.go
+++ b/pkg/pollers/nodePoller.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2017,2018, F5 Networks, Inc.
+ * Copyright (c) 2017,2018,2019 F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/pollers/nodePoller_test.go
+++ b/pkg/pollers/nodePoller_test.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2017,2018, F5 Networks, Inc.
+ * Copyright (c) 2017,2018,2019 F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/pollers/pollers.go
+++ b/pkg/pollers/pollers.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2017,2018, F5 Networks, Inc.
+ * Copyright (c) 2017,2018,2019 F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2017,2018, F5 Networks, Inc.
+ * Copyright (c) 2017,2018,2019 F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/vlogger/console/log_console.go
+++ b/pkg/vlogger/console/log_console.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, F5 Networks, Inc.
+// Copyright (c) 2019, F5 Networks, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/vlogger/doc.go
+++ b/pkg/vlogger/doc.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, F5 Networks, Inc.
+// Copyright (c) 2019, F5 Networks, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/vlogger/log.go
+++ b/pkg/vlogger/log.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, F5 Networks, Inc.
+// Copyright (c) 2019, F5 Networks, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/vlogger/log_null.go
+++ b/pkg/vlogger/log_null.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2018, F5 Networks, Inc.
+// Copyright (c) 2019, F5 Networks, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/vxlan/vxlanMgr.go
+++ b/pkg/vxlan/vxlanMgr.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2017,2018, F5 Networks, Inc.
+ * Copyright (c) 2017,2018,2019 F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/vxlan/vxlanMgr_test.go
+++ b/pkg/vxlan/vxlanMgr_test.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2017,2018, F5 Networks, Inc.
+ * Copyright (c) 2017,2018,2019 F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/writer/configWriter.go
+++ b/pkg/writer/configWriter.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2017,2018, F5 Networks, Inc.
+ * Copyright (c) 2017,2018,2019 F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pkg/writer/configWriter_test.go
+++ b/pkg/writer/configWriter_test.go
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2017,2018, F5 Networks, Inc.
+ * Copyright (c) 2017,2018,2019 F5 Networks, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updated Copyright Text to include 2019

Problem : 
The Copyright in the repository was only till 2018

Solution : 
Updated Copyright Text

affects-branches: master