### PR TITLE
Option to pass the BIG IP's third party certificates/ self signed certificates (using config map) to CIS container

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -100,13 +100,14 @@ var (
 	useSecrets        *bool
 	schemaLocal       *string
 
-	bigIPURL        *string
-	bigIPUsername   *string
-	bigIPPassword   *string
-	bigIPPartitions *[]string
-	credsDir        *string
-	as3Validation   *bool
-	sslInsecure     *bool
+	bigIPURL           *string
+	bigIPUsername      *string
+	bigIPPassword      *string
+	bigIPPartitions    *[]string
+	credsDir           *string
+	as3Validation      *bool
+	sslInsecure        *bool
+	trustedCertsCfgmap *string
 
 	vxlanMode        string
 	openshiftSDNName *string
@@ -178,6 +179,8 @@ func _init() {
 		"Optional, when set to false, disables as3 template validation on the controller.")
 	sslInsecure = bigIPFlags.Bool("insecure", false,
 		"Optional, when set to true, enable insecure SSL communication to BIGIP.")
+	trustedCertsCfgmap = bigIPFlags.String("trusted-certs-cfgmap", "",
+		"Optional, when certificates are provided, enable secure SSL communication to BIGIP.")
 
 	bigIPFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  BigIP:\n%s\n", bigIPFlags.FlagUsagesWrapped(width))
@@ -599,19 +602,20 @@ func main() {
 	}
 
 	var appMgrParms = appmanager.Params{
-		ConfigWriter:      configWriter,
-		UseNodeInternal:   *useNodeInternal,
-		IsNodePort:        isNodePort,
-		RouteConfig:       routeConfig,
-		NodeLabelSelector: *nodeLabelSelector,
-		ResolveIngress:    *resolveIngNames,
-		DefaultIngIP:      *defaultIngIP,
-		VsSnatPoolName:    *vsSnatPoolName,
-		UseSecrets:        *useSecrets,
-		ManageConfigMaps:  *manageConfigMaps,
-		SchemaLocal:       *schemaLocal,
-		AS3Validation:     *as3Validation,
-		SSLInsecure:       *sslInsecure,
+		ConfigWriter:       configWriter,
+		UseNodeInternal:    *useNodeInternal,
+		IsNodePort:         isNodePort,
+		RouteConfig:        routeConfig,
+		NodeLabelSelector:  *nodeLabelSelector,
+		ResolveIngress:     *resolveIngNames,
+		DefaultIngIP:       *defaultIngIP,
+		VsSnatPoolName:     *vsSnatPoolName,
+		UseSecrets:         *useSecrets,
+		ManageConfigMaps:   *manageConfigMaps,
+		SchemaLocal:        *schemaLocal,
+		AS3Validation:      *as3Validation,
+		SSLInsecure:        *sslInsecure,
+		TrustedCertsCfgmap: *trustedCertsCfgmap,
 	}
 
 	// If running with Flannel, create an event channel that the appManager

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -126,10 +126,11 @@ type Manager struct {
 	// map of rules that have been merged
 	mergedRulesMap map[string]map[string]mergedRuleEntry
 	// Whether to watch ConfigMap resources or not
-	manageConfigMaps bool
-	as3Members       map[Member]struct{}
-	as3Validation    bool
-	sslInsecure      bool
+	manageConfigMaps   bool
+	as3Members         map[Member]struct{}
+	as3Validation      bool
+	sslInsecure        bool
+	trustedCertsCfgmap string
 }
 
 // Struct to allow NewManager to receive all or only specific parameters.
@@ -147,13 +148,14 @@ type Params struct {
 	UseSecrets        bool
 	EventChan         chan interface{}
 	// Package local for unit testing only
-	restClient       rest.Interface
-	initialState     bool
-	broadcasterFunc  NewBroadcasterFunc
-	SchemaLocal      string
-	ManageConfigMaps bool
-	AS3Validation    bool
-	SSLInsecure      bool
+	restClient         rest.Interface
+	initialState       bool
+	broadcasterFunc    NewBroadcasterFunc
+	SchemaLocal        string
+	ManageConfigMaps   bool
+	AS3Validation      bool
+	SSLInsecure        bool
+	TrustedCertsCfgmap string
 }
 
 // Configuration options for Routes in OpenShift
@@ -173,37 +175,38 @@ func NewManager(params *Params) *Manager {
 	nsQueue := workqueue.NewNamedRateLimitingQueue(
 		workqueue.DefaultControllerRateLimiter(), "namespace-controller")
 	manager := Manager{
-		resources:         NewResources(),
-		customProfiles:    NewCustomProfiles(),
-		irulesMap:         make(IRulesMap),
-		intDgMap:          make(InternalDataGroupMap),
-		kubeClient:        params.KubeClient,
-		restClientv1:      params.restClient,
-		restClientv1beta1: params.restClient,
-		routeClientV1:     params.RouteClientV1,
-		configWriter:      params.ConfigWriter,
-		useNodeInternal:   params.UseNodeInternal,
-		isNodePort:        params.IsNodePort,
-		initialState:      params.initialState,
-		queueLen:          0,
-		processedItems:    0,
-		routeConfig:       params.RouteConfig,
-		nodeLabelSelector: params.NodeLabelSelector,
-		resolveIng:        params.ResolveIngress,
-		defaultIngIP:      params.DefaultIngIP,
-		vsSnatPoolName:    params.VsSnatPoolName,
-		useSecrets:        params.UseSecrets,
-		eventChan:         params.EventChan,
-		vsQueue:           vsQueue,
-		nsQueue:           nsQueue,
-		appInformers:      make(map[string]*appInformer),
-		eventNotifier:     NewEventNotifier(params.broadcasterFunc),
-		schemaLocal:       params.SchemaLocal,
-		mergedRulesMap:    make(map[string]map[string]mergedRuleEntry),
-		manageConfigMaps:  params.ManageConfigMaps,
-		as3Members:        make(map[Member]struct{}, 0),
-		as3Validation:     params.AS3Validation,
-		sslInsecure:       params.SSLInsecure,
+		resources:          NewResources(),
+		customProfiles:     NewCustomProfiles(),
+		irulesMap:          make(IRulesMap),
+		intDgMap:           make(InternalDataGroupMap),
+		kubeClient:         params.KubeClient,
+		restClientv1:       params.restClient,
+		restClientv1beta1:  params.restClient,
+		routeClientV1:      params.RouteClientV1,
+		configWriter:       params.ConfigWriter,
+		useNodeInternal:    params.UseNodeInternal,
+		isNodePort:         params.IsNodePort,
+		initialState:       params.initialState,
+		queueLen:           0,
+		processedItems:     0,
+		routeConfig:        params.RouteConfig,
+		nodeLabelSelector:  params.NodeLabelSelector,
+		resolveIng:         params.ResolveIngress,
+		defaultIngIP:       params.DefaultIngIP,
+		vsSnatPoolName:     params.VsSnatPoolName,
+		useSecrets:         params.UseSecrets,
+		eventChan:          params.EventChan,
+		vsQueue:            vsQueue,
+		nsQueue:            nsQueue,
+		appInformers:       make(map[string]*appInformer),
+		eventNotifier:      NewEventNotifier(params.broadcasterFunc),
+		schemaLocal:        params.SchemaLocal,
+		mergedRulesMap:     make(map[string]map[string]mergedRuleEntry),
+		manageConfigMaps:   params.ManageConfigMaps,
+		as3Members:         make(map[Member]struct{}, 0),
+		as3Validation:      params.AS3Validation,
+		sslInsecure:        params.SSLInsecure,
+		trustedCertsCfgmap: params.TrustedCertsCfgmap,
 	}
 	if nil != manager.kubeClient && nil == manager.restClientv1 {
 		// This is the normal production case, but need the checks for unit tests.
@@ -735,6 +738,10 @@ func (appMgr *Manager) startAndSyncNamespaceInformer(stopCh <-chan struct{}) {
 }
 
 func (appMgr *Manager) startAndSyncAppInformers() {
+
+	//Setup certificates
+	appMgr.getCertFromConfigMap(appMgr.trustedCertsCfgmap)
+
 	appMgr.informersMutex.Lock()
 	defer appMgr.informersMutex.Unlock()
 	appMgr.startAppInformersLocked()


### PR DESCRIPTION
Problem:
CIS was not supporting third party certificates/self-signed certificates for secure communication to BIG-IP
Solution:
Given an option to pass the BIG IP's third-party certificates/self-signed certificates using config map for secure communication

Affected Branches:
master