### PR TITLE
Option to add BIG-IP third party certificate/self signd certificate (using config map) to CIS

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -100,13 +100,14 @@ var (
 	useSecrets        *bool
 	schemaLocal       *string
 
-	bigIPURL        *string
-	bigIPUsername   *string
-	bigIPPassword   *string
-	bigIPPartitions *[]string
-	credsDir        *string
-	as3Validation   *bool
-	sslInsecure     *bool
+	bigIPURL           *string
+	bigIPUsername      *string
+	bigIPPassword      *string
+	bigIPPartitions    *[]string
+	credsDir           *string
+	as3Validation      *bool
+	sslInsecure        *bool
+	trustedCertsCfgmap *string
 
 	vxlanMode        string
 	openshiftSDNName *string
@@ -178,6 +179,8 @@ func _init() {
 		"Optional, when set to false, disables as3 template validation on the controller.")
 	sslInsecure = bigIPFlags.Bool("insecure", false,
 		"Optional, when set to true, enable insecure SSL communication to BIGIP.")
+	trustedCertsCfgmap = bigIPFlags.String("trusted-certs-cfgmap", "",
+		"Optional, when certificates are provided, enable secure SSL communication to BIGIP.")
 
 	bigIPFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  BigIP:\n%s\n", bigIPFlags.FlagUsagesWrapped(width))
@@ -604,19 +607,20 @@ func main() {
 	}
 
 	var appMgrParms = appmanager.Params{
-		ConfigWriter:      configWriter,
-		UseNodeInternal:   *useNodeInternal,
-		IsNodePort:        isNodePort,
-		RouteConfig:       routeConfig,
-		NodeLabelSelector: *nodeLabelSelector,
-		ResolveIngress:    *resolveIngNames,
-		DefaultIngIP:      *defaultIngIP,
-		VsSnatPoolName:    *vsSnatPoolName,
-		UseSecrets:        *useSecrets,
-		ManageConfigMaps:  *manageConfigMaps,
-		SchemaLocal:       *schemaLocal,
-		AS3Validation:     *as3Validation,
-		SSLInsecure:       *sslInsecure,
+		ConfigWriter:       configWriter,
+		UseNodeInternal:    *useNodeInternal,
+		IsNodePort:         isNodePort,
+		RouteConfig:        routeConfig,
+		NodeLabelSelector:  *nodeLabelSelector,
+		ResolveIngress:     *resolveIngNames,
+		DefaultIngIP:       *defaultIngIP,
+		VsSnatPoolName:     *vsSnatPoolName,
+		UseSecrets:         *useSecrets,
+		ManageConfigMaps:   *manageConfigMaps,
+		SchemaLocal:        *schemaLocal,
+		AS3Validation:      *as3Validation,
+		SSLInsecure:        *sslInsecure,
+		TrustedCertsCfgmap: *trustedCertsCfgmap,
 	}
 
 	// If running with Flannel, create an event channel that the appManager

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -127,10 +127,11 @@ type Manager struct {
 	// map of rules that have been merged
 	mergedRulesMap map[string]map[string]mergedRuleEntry
 	// Whether to watch ConfigMap resources or not
-	manageConfigMaps bool
-	as3Members       map[Member]struct{}
-	as3Validation    bool
-	sslInsecure      bool
+	manageConfigMaps   bool
+	as3Members         map[Member]struct{}
+	as3Validation      bool
+	sslInsecure        bool
+	trustedCertsCfgmap string
 }
 
 // Struct to allow NewManager to receive all or only specific parameters.
@@ -148,13 +149,14 @@ type Params struct {
 	UseSecrets        bool
 	EventChan         chan interface{}
 	// Package local for unit testing only
-	restClient       rest.Interface
-	initialState     bool
-	broadcasterFunc  NewBroadcasterFunc
-	SchemaLocal      string
-	ManageConfigMaps bool
-	AS3Validation    bool
-	SSLInsecure      bool
+	restClient         rest.Interface
+	initialState       bool
+	broadcasterFunc    NewBroadcasterFunc
+	SchemaLocal        string
+	ManageConfigMaps   bool
+	AS3Validation      bool
+	SSLInsecure        bool
+	TrustedCertsCfgmap string
 }
 
 // Configuration options for Routes in OpenShift
@@ -174,37 +176,38 @@ func NewManager(params *Params) *Manager {
 	nsQueue := workqueue.NewNamedRateLimitingQueue(
 		workqueue.DefaultControllerRateLimiter(), "namespace-controller")
 	manager := Manager{
-		resources:         NewResources(),
-		customProfiles:    NewCustomProfiles(),
-		irulesMap:         make(IRulesMap),
-		intDgMap:          make(InternalDataGroupMap),
-		kubeClient:        params.KubeClient,
-		restClientv1:      params.restClient,
-		restClientv1beta1: params.restClient,
-		routeClientV1:     params.RouteClientV1,
-		configWriter:      params.ConfigWriter,
-		useNodeInternal:   params.UseNodeInternal,
-		isNodePort:        params.IsNodePort,
-		initialState:      params.initialState,
-		queueLen:          0,
-		processedItems:    0,
-		routeConfig:       params.RouteConfig,
-		nodeLabelSelector: params.NodeLabelSelector,
-		resolveIng:        params.ResolveIngress,
-		defaultIngIP:      params.DefaultIngIP,
-		vsSnatPoolName:    params.VsSnatPoolName,
-		useSecrets:        params.UseSecrets,
-		eventChan:         params.EventChan,
-		vsQueue:           vsQueue,
-		nsQueue:           nsQueue,
-		appInformers:      make(map[string]*appInformer),
-		eventNotifier:     NewEventNotifier(params.broadcasterFunc),
-		schemaLocal:       params.SchemaLocal,
-		mergedRulesMap:    make(map[string]map[string]mergedRuleEntry),
-		manageConfigMaps:  params.ManageConfigMaps,
-		as3Members:        make(map[Member]struct{}, 0),
-		as3Validation:     params.AS3Validation,
-		sslInsecure:       params.SSLInsecure,
+		resources:          NewResources(),
+		customProfiles:     NewCustomProfiles(),
+		irulesMap:          make(IRulesMap),
+		intDgMap:           make(InternalDataGroupMap),
+		kubeClient:         params.KubeClient,
+		restClientv1:       params.restClient,
+		restClientv1beta1:  params.restClient,
+		routeClientV1:      params.RouteClientV1,
+		configWriter:       params.ConfigWriter,
+		useNodeInternal:    params.UseNodeInternal,
+		isNodePort:         params.IsNodePort,
+		initialState:       params.initialState,
+		queueLen:           0,
+		processedItems:     0,
+		routeConfig:        params.RouteConfig,
+		nodeLabelSelector:  params.NodeLabelSelector,
+		resolveIng:         params.ResolveIngress,
+		defaultIngIP:       params.DefaultIngIP,
+		vsSnatPoolName:     params.VsSnatPoolName,
+		useSecrets:         params.UseSecrets,
+		eventChan:          params.EventChan,
+		vsQueue:            vsQueue,
+		nsQueue:            nsQueue,
+		appInformers:       make(map[string]*appInformer),
+		eventNotifier:      NewEventNotifier(params.broadcasterFunc),
+		schemaLocal:        params.SchemaLocal,
+		mergedRulesMap:     make(map[string]map[string]mergedRuleEntry),
+		manageConfigMaps:   params.ManageConfigMaps,
+		as3Members:         make(map[Member]struct{}, 0),
+		as3Validation:      params.AS3Validation,
+		sslInsecure:        params.SSLInsecure,
+		trustedCertsCfgmap: params.TrustedCertsCfgmap,
 	}
 	if nil != manager.kubeClient && nil == manager.restClientv1 {
 		// This is the normal production case, but need the checks for unit tests.
@@ -736,6 +739,10 @@ func (appMgr *Manager) startAndSyncNamespaceInformer(stopCh <-chan struct{}) {
 }
 
 func (appMgr *Manager) startAndSyncAppInformers() {
+
+	//Setup certificates
+	appMgr.getCertFromConfigMap(appMgr.trustedCertsCfgmap)
+
 	appMgr.informersMutex.Lock()
 	defer appMgr.informersMutex.Unlock()
 	appMgr.startAppInformersLocked()

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -20,11 +20,13 @@ import (
 	"bytes"
 	"crypto/md5"
 	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
 	"net/http"
+	"strings"
 	"time"
 
 	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
@@ -62,6 +64,7 @@ var BigIPUsername string
 var BigIPPassword string
 var BigIPURL string
 var as3RC As3RestClient
+var certificates string
 
 var buffer map[Member]struct{}
 
@@ -396,10 +399,27 @@ func (as3RestClient *As3RestClient) restCallToBigIP(method string, route string,
 		log.Debugf("[as3_log] No change in declaration.")
 		return string(body), true
 	}
-	//FIXME: tr flag is set true to disable SSL validation
-	//Please remove SSL disable settings at RTW
+
+	//Certificate setting
+	// Get the SystemCertPool, continue with an empty pool on error
+	rootCAs, _ := x509.SystemCertPool()
+	if rootCAs == nil {
+		rootCAs = x509.NewCertPool()
+	}
+
+	// Get the cert
+	certs := []byte(certificates)
+
+	// Append our cert to the system pool
+	if ok := rootCAs.AppendCertsFromPEM(certs); !ok {
+		log.Debug("[as3_log] No certs appended, using system certs only")
+	}
+
 	tr := &http.Transport{
-		TLSClientConfig: &tls.Config{InsecureSkipVerify: sslInsecure},
+		TLSClientConfig: &tls.Config{
+			InsecureSkipVerify: sslInsecure,
+			RootCAs:            rootCAs,
+		},
 	}
 	as3RestClient.client = &http.Client{
 		Transport: tr,
@@ -450,6 +470,30 @@ func (as3RestClient *As3RestClient) restCallToBigIP(method string, route string,
 		return string(body), false
 	}
 
+}
+
+// Read certificate from configmap
+func (appMgr *Manager) getCertFromConfigMap(cfgmap string) {
+
+	certificates = ""
+	namespaceCfgmapSlice := strings.Split(cfgmap, "/")
+	if len(namespaceCfgmapSlice) < 2 {
+		log.Debugf("[as3_log] Invalid trusted-certs-cfgmap option provided.")
+	} else {
+		certs := ""
+		namespace := namespaceCfgmapSlice[0]
+		cfgmapName := namespaceCfgmapSlice[1]
+		cm, err := appMgr.kubeClient.CoreV1().ConfigMaps(namespace).Get(cfgmapName, metaV1.GetOptions{})
+		if err != nil {
+			log.Debugf("[as3_log] Reading certificate from configmap error: %v", err)
+		} else {
+			//Fetching all certificates from configmap
+			for _, v := range cm.Data {
+				certs = certs + v + "\n"
+			}
+			certificates = certs
+		}
+	}
 }
 
 // SetupAS3Informers returns an appInformer that includes the following set of informers.


### PR DESCRIPTION
Problem:
CIS was not supporting third party certificates/self-signed certificates for secure communication to BIG-IP
Solution:
Given an option to pass the BIG IP's third-party certificates/self-signed certificates using config map for secure communication

Affected Branches:
master