### PR TITLE
Handling Node changes (Add and Delete)

### DIFF
--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -565,6 +565,17 @@ func (appMgr *Manager) SetupAS3Informers() error {
 			resyncPeriod,
 			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
 		),
+		nodeInformer: cache.NewSharedIndexInformer(
+			newListWatchWithLabelSelector(
+				appMgr.restClientv1,
+				"nodes",
+				namespace,
+				labels.Everything(),
+			),
+			&v1.Node{},
+			resyncPeriod,
+			cache.Indexers{cache.NamespaceIndex: cache.MetaNamespaceIndexFunc},
+		),
 	}
 
 	appMgr.as3Informer.cfgMapInformer.AddEventHandler(
@@ -585,6 +596,13 @@ func (appMgr *Manager) SetupAS3Informers() error {
 			AddFunc:    func(obj interface{}) { appMgr.enqueueAS3Endpoints(obj) },
 			UpdateFunc: func(old, cur interface{}) { appMgr.enqueueAS3Endpoints(cur) },
 			DeleteFunc: func(obj interface{}) { appMgr.enqueueAS3Endpoints(obj) },
+		},
+	)
+	appMgr.as3Informer.nodeInformer.AddEventHandler(
+		&cache.ResourceEventHandlerFuncs{
+			AddFunc:    func(obj interface{}) { appMgr.enqueueNode(obj) },
+			UpdateFunc: func(old, cur interface{}) { appMgr.enqueueNode(cur) },
+			DeleteFunc: func(obj interface{}) { appMgr.enqueueNode(obj) },
 		},
 	)
 

--- a/pkg/appmanager/validateResources.go
+++ b/pkg/appmanager/validateResources.go
@@ -241,6 +241,25 @@ func (appMgr *Manager) checkValidIngress(
 	return true, keyList
 }
 
+func (appMgr *Manager) checkValidNode(
+	obj interface{},
+) (bool, []*serviceQueueKey) {
+	// Check if an active configMap exists.
+	// if existis get it from appMgr struct and return.
+	// if not existis return false, nil.
+	if "" != appMgr.activeCfgMap.Name && "" != appMgr.activeCfgMap.Data {
+		key := &serviceQueueKey{
+			As3Name: appMgr.activeCfgMap.Name,
+			As3Data: appMgr.activeCfgMap.Data,
+		}
+		var keyList []*serviceQueueKey
+		keyList = append(keyList, key)
+		log.Debugf("[as3_log] NodeInformer: ConfigMap '%s' placed in Queue.", appMgr.activeCfgMap.Name)
+		return true, keyList
+	}
+	return false, nil
+}
+
 func (appMgr *Manager) checkValidRoute(
 	obj interface{},
 ) (bool, []*serviceQueueKey) {


### PR DESCRIPTION
Problem: Active configMap need to be pushed to vsQueue when ever there
are node changes (add or delete)

Solution: Node changes are triggered with Node SharedIndexInformer and
Active config maps are pushed into vsQueue when ever a node is added or
deleted.