### PR TITLE
Remove AS3 Template and Declaration Logging

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -839,7 +839,6 @@ func (appMgr *Manager) processNextVirtualServer() bool {
 
 		appMgr.vsQueue.Done(key)
 		log.Debugf("[as3_log] Processing AS3 cfgMap (%s) with AS3 Manager.\n", k.As3Name)
-		log.Debugf("[as3_log] AS3 ConfigMap Data: %s\n", k.As3Data)
 		appMgr.processUserDefinedAS3(k.As3Data)
 
 		appMgr.vsQueue.Forget(key)

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -97,7 +97,6 @@ func (appMgr *Manager) processUserDefinedAS3(template string) bool {
 	epbuffer = make(map[string]struct{}, 0)
 
 	declaration := appMgr.buildAS3Declaration(obj, templateObj)
-	log.Debugf("Generated AS3 Declaration: \n%v", declaration)
 
 	appMgr.as3Members = buffer
 	appMgr.watchedAS3Endpoints = epbuffer
@@ -305,7 +304,7 @@ func (appMgr *Manager) getEndpointsForPool(tenant tenantName, app appName, pool 
 			}
 		}
 
-		log.Debugf("[as3] Discovered members for service %v is %v", service, members)
+		log.Debugf("[as3] Discovered members for service %v is %v", service.Name, members)
 	}
 
 	return members
@@ -380,8 +379,6 @@ func (appMgr *Manager) buildAS3Declaration(obj as3Object, template as3Template) 
 		log.Errorf("[as3_log] Issue marshalling AS3 Json")
 	}
 	log.Debugf("[as3_log] AS3 Template is populated with the pool members")
-	log.Debugf("[as3_log] Printing AS3 Template ...")
-	log.Debugf("%s", declaration)
 
 	return as3Declaration(declaration)
 


### PR DESCRIPTION
Problem: AS3 Template and declaration may contain sensitive data such as
private keys and passwords. Adding them in log will make them visible in
plain text at unintended places.

Solution: Remove AS3 Template and Declaration logging. Instead, log the
matched kubernetes Service along with discovered endpoints for the
service.

Signed-off-by: Surendhar <surendhar@ymail.com>