### PR TITLE
Remove libidn11 package from controller

### DIFF
--- a/build-tools/Dockerfile.debian.runtime
+++ b/build-tools/Dockerfile.debian.runtime
@@ -17,6 +17,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
     && apt-get remove -y git
 
+# FIXME: Remove this fix once libidn is no longer vulnerable
+RUN apt-get remove -y libidn11
+
 COPY bigip-virtual-server_v*.json $APPPATH/vendor/src/f5/schemas/
 COPY as3-schema-3.11.0-3-cis.json $APPPATH/vendor/src/f5/schemas/
 COPY k8s-bigip-ctlr $APPPATH/bin


### PR DESCRIPTION
Problem: libidn11 package used by upstream debian stretch is vulnerable
to remote attacks.

Solution: Remove libidn11 package during controller build.

Affecetd-branches: master, 1.9-stable