### PR TITLE
Add arplearning option to disable static POD ARP creation in BIGIP HA deployment

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -107,6 +107,7 @@ var (
 	credsDir           *string
 	as3Validation      *bool
 	sslInsecure        *bool
+	arpLearning        *bool
 	trustedCertsCfgmap *string
 
 	vxlanMode        string
@@ -179,6 +180,8 @@ func _init() {
 		"Optional, when set to false, disables as3 template validation on the controller.")
 	sslInsecure = bigIPFlags.Bool("insecure", false,
 		"Optional, when set to true, enable insecure SSL communication to BIGIP.")
+	arpLearning = bigIPFlags.Bool("arplearning", false,
+		"Optional, when set to true, Allow BIGIP ARP learning k8s POD.")
 	trustedCertsCfgmap = bigIPFlags.String("trusted-certs-cfgmap", "",
 		"Optional, when certificates are provided, adds them to controller’s trusted certificate store.")
 
@@ -490,7 +493,7 @@ func setupNodePolling(
 			return fmt.Errorf("error registering node update listener for vxlan mode: %v",
 				err)
 		}
-		if eventChan != nil {
+		if (eventChan != nil) && (!appMgr.ARPLearning()) {
 			vxMgr.ProcessAppmanagerEvents(kubeClient)
 		}
 	}
@@ -620,6 +623,7 @@ func main() {
 		SchemaLocal:        *schemaLocal,
 		AS3Validation:      *as3Validation,
 		SSLInsecure:        *sslInsecure,
+		ARPLearning:        *arpLearning,
 		TrustedCertsCfgmap: *trustedCertsCfgmap,
 	}
 

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -131,6 +131,7 @@ type Manager struct {
 	as3Members         map[Member]struct{}
 	as3Validation      bool
 	sslInsecure        bool
+	arpLearning        bool
 	trustedCertsCfgmap string
 	// Active User Defined ConfigMap details
 	activeCfgMap ActiveAS3ConfigMap
@@ -168,6 +169,7 @@ type Params struct {
 	ManageConfigMaps   bool
 	AS3Validation      bool
 	SSLInsecure        bool
+	ARPLearning        bool
 	TrustedCertsCfgmap string
 }
 
@@ -219,6 +221,7 @@ func NewManager(params *Params) *Manager {
 		as3Members:         make(map[Member]struct{}, 0),
 		as3Validation:      params.AS3Validation,
 		sslInsecure:        params.SSLInsecure,
+		arpLearning:        params.ARPLearning,
 		trustedCertsCfgmap: params.TrustedCertsCfgmap,
 	}
 	if nil != manager.kubeClient && nil == manager.restClientv1 {
@@ -740,6 +743,10 @@ func (appMgr *Manager) IsNodePort() bool {
 
 func (appMgr *Manager) UseNodeInternal() bool {
 	return appMgr.useNodeInternal
+}
+
+func (appMgr *Manager) ARPLearning() bool {
+	return appMgr.arpLearning
 }
 
 func (appMgr *Manager) ConfigWriter() writer.Writer {


### PR DESCRIPTION
Problem: when deploy BIGIP HA in K8S flannel environment, static POD ARP
uses K8S node flannel vxlan device MAC as POD MAC as it normally does,
but this won't work when BIGIP HA is designed to auto learn the POD ARP
when fl-vxlan tunnel vxlan profile flooding type is set to multipoint.

Solution: add arplearning option to disable static POD ARP creation