### PR TITLE
Unset prefix before handling paths

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,6 +1,13 @@
 Release Notes for BIG-IP Controller for Kubernetes
 ==================================================
 
+next release
+------------
+
+Bug Fixes
+`````````
+* Controller handles http redirects without entering into an infinite loop.
+
 v1.9.1
 ------
 Added Functionality

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -357,6 +357,7 @@ func httpRedirectIRule(port int32) string {
 			}
 			if {$paths != ""} {
 				set redir 0
+				set prefix ""
 				foreach s [split $paths "|"] {
 					# See if the request path starts with the prefix
 					append prefix "^" $s "($|/*)"


### PR DESCRIPTION
Problem: When handling multiple http connection, BIG-IP gets stuck forever
inside the "foreach" cycle, producing a 'prefix' variable. The iRule is never
unsetting 'prefix', so if you run multiple HTTP requests over the same
connection, the variable keeps being appended to, accumulating more and more
content.

Solution: Always initialize `prefix` with empty value before handling
paths.

Affected-branches: master