### PR TITLE
Update FDB Entries for Openshift Routes Using CIS

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -2238,6 +2238,10 @@ func (appMgr *Manager) getNodes(
 
 	// Append list of nodes to watchedNodes
 	for _, node := range nodes {
+		// Ignore Master Node from the list of Watched nodes.
+		if node.ObjectMeta.Labels["node-role.kubernetes.io/master"] == "true" {
+			continue
+		}
 		nodeAddrs := node.Status.Addresses
 		for _, addr := range nodeAddrs {
 			if addr.Type == addrType {

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -34,7 +34,7 @@ import (
 	routeapi "github.com/openshift/origin/pkg/route/api"
 	"github.com/xeipuuv/gojsonschema"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/pkg/api/v1"
+	v1 "k8s.io/client-go/pkg/api/v1"
 	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/tools/cache"
 )


### PR DESCRIPTION
Problem:
In Openshift, CIS does not populate FDB entries in BIGIP when agent is selected as AS3.

Solution:
Allow cccl to do this, This will be eliminated when we develop our own go-sdk for FDB and ARP Entries.

Affected Branches:
feature.as3 and master