### PR TITLE
Ignore Master Node as Pool member

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -2238,6 +2238,10 @@ func (appMgr *Manager) getNodes(
 
 	// Append list of nodes to watchedNodes
 	for _, node := range nodes {
+		// Ignore Master Node from the list of Watched nodes.
+		if node.ObjectMeta.Labels["node-role.kubernetes.io/master"] == "true" {
+			continue
+		}
 		nodeAddrs := node.Status.Addresses
 		for _, addr := range nodeAddrs {
 			if addr.Type == addrType {


### PR DESCRIPTION
Problem:
Master node is considered as a pool member when it is in ready to schedule state.

Solution:
Ignore Master node always.

Affected branches:
master, feature.as3