### PR TITLE
Support "manage-ingress" configuration option in BIGIP controller deployment

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -93,6 +93,7 @@ var (
 	namespaceLabel    *string
 	manageRoutes      *bool
 	manageConfigMaps  *bool
+	manageIngress     *bool
 	nodeLabelSelector *string
 	resolveIngNames   *string
 	defaultIngIP      *string
@@ -206,6 +207,8 @@ func _init() {
 		"Optional, used to watch for namespaces with this label")
 	manageRoutes = kubeFlags.Bool("manage-routes", false,
 		"Optional, specify whether or not to manage Route resources")
+	manageIngress = kubeFlags.Bool("manage-ingress", true,
+		"Optional, specify whether or not to manage Ingress resources")
 	manageConfigMaps = kubeFlags.Bool("manage-configmaps", true,
 		"Optional, specify whether or not to manage ConfigMap resources")
 	nodeLabelSelector = kubeFlags.String("node-label-selector", "",
@@ -627,6 +630,7 @@ func main() {
 		VsSnatPoolName:     *vsSnatPoolName,
 		UseSecrets:         *useSecrets,
 		ManageConfigMaps:   *manageConfigMaps,
+		ManageIngress:      *manageIngress,
 		SchemaLocal:        *schemaLocal,
 		AS3Validation:      *as3Validation,
 		SSLInsecure:        *sslInsecure,

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -889,6 +889,7 @@ var _ = Describe("AppManager Tests", func() {
 				IsNodePort:       true,
 				broadcasterFunc:  NewFakeEventBroadcaster,
 				ManageConfigMaps: true,
+				ManageIngress:    true,
 			})
 		})
 		AfterEach(func() {

--- a/pkg/appmanager/eventNotifier_test.go
+++ b/pkg/appmanager/eventNotifier_test.go
@@ -140,6 +140,7 @@ var _ = Describe("Event Notifier Tests", func() {
 				restClient:      test.CreateFakeHTTPClient(),
 				RouteClientV1:   test.CreateFakeHTTPClient(),
 				IsNodePort:      true,
+				ManageIngress:   true,
 				broadcasterFunc: NewFakeEventBroadcaster,
 			})
 			namespaces = []string{"ns0", "ns1", "ns2", "ns3", "ns4", "ns5"}

--- a/pkg/appmanager/healthMonitors_test.go
+++ b/pkg/appmanager/healthMonitors_test.go
@@ -47,6 +47,7 @@ var _ = Describe("Health Monitor Tests", func() {
 			restClient:      test.CreateFakeHTTPClient(),
 			RouteClientV1:   test.CreateFakeHTTPClient(),
 			IsNodePort:      true,
+			ManageIngress:   true,
 			broadcasterFunc: NewFakeEventBroadcaster,
 		})
 		namespace = "default"

--- a/pkg/appmanager/profiles_test.go
+++ b/pkg/appmanager/profiles_test.go
@@ -55,6 +55,7 @@ var _ = Describe("AppManager Profile Tests", func() {
 				IsNodePort:       true,
 				broadcasterFunc:  NewFakeEventBroadcaster,
 				ManageConfigMaps: true,
+				ManageIngress:    true,
 			})
 			namespace = "default"
 			mockMgr.appMgr.routeConfig = RouteConfig{

--- a/pkg/appmanager/routing_test.go
+++ b/pkg/appmanager/routing_test.go
@@ -43,6 +43,7 @@ var _ = Describe("Routing Tests", func() {
 			restClient:    test.CreateFakeHTTPClient(),
 			RouteClientV1: test.CreateFakeHTTPClient(),
 			IsNodePort:    true,
+			ManageIngress: true,
 		})
 		err := appMgr.startNonLabelMode([]string{"test"})
 		Expect(err).To(BeNil())


### PR DESCRIPTION
This fix will add new argument to the BIGIP Controller deployment
--manage-ingress=true/false