### PR TITLE
Upgrading CIS Debian base os from 9 to 10

### DIFF
--- a/build-tools/Dockerfile.debian.builder
+++ b/build-tools/Dockerfile.debian.builder
@@ -1,4 +1,4 @@
-FROM python:2.7-slim-stretch
+FROM python:2.7-slim-buster
 
 # gcc for cgo
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/build-tools/Dockerfile.debian.runtime
+++ b/build-tools/Dockerfile.debian.runtime
@@ -1,4 +1,4 @@
-FROM python:2.7-slim-stretch
+FROM python:2.7-slim-buster
 
 ENV APPPATH /app
 


### PR DESCRIPTION
Problem:
There were a few  security Vulnerability issues were there in Debina Base OS 9(python:2.7-slim-stretch)

Solution:
Upgrading Debian base os from 9 to 10

Affected Branches:
Master
