### PR TITLE
log as3 error response body

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,6 +1,13 @@
 Release Notes for BIG-IP Controller for Kubernetes
 ==================================================
 
+v1.10
+------
+Added Functionality
+`````````````````````
+* Logging BIP-IP AS3 error response body for better readability and appropriate logs.
+
+
 v1.9.1
 ------
 Added Functionality

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -443,18 +443,19 @@ func (as3RestClient *AS3RestClient) restCallToBigIP(method string, route string,
 		return string(body), false
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode == 200 {
-		body, err = ioutil.ReadAll(resp.Body)
-		if err != nil {
-			log.Errorf("[as3_log] REST call response error: %v ", err)
-			return string(body), false
-		}
-		var response map[string]interface{}
-		err = json.Unmarshal([]byte(body), &response)
-		if err != nil {
-			log.Errorf("[as3_log] Response body unmarshal failed: %v\n", err)
-			return string(body), false
-		}
+
+	body, err = ioutil.ReadAll(resp.Body)
+	if err != nil {
+		log.Errorf("[as3_log] REST call response error: %v ", err)
+		return string(body), false
+	}
+	var response map[string]interface{}
+	err = json.Unmarshal([]byte(body), &response)
+	if err != nil {
+		log.Errorf("[as3_log] Response body unmarshal failed: %v\n", err)
+		return string(body), false
+	}
+	if resp.StatusCode == http.StatusOK {
 		//traverse all response results
 		results := (response["results"]).([]interface{})
 		for _, value := range results {
@@ -465,11 +466,15 @@ func (as3RestClient *AS3RestClient) restCallToBigIP(method string, route string,
 		}
 		as3RestClient.oldChecksum = as3RestClient.newChecksum
 		return string(body), true
-	} else {
-		//Other then 200 status code
-		log.Errorf("[as3_log] Big-IP Response error %v", resp)
-		return string(body), false
 	}
+	//Other then 200 status code
+	results := (response["results"]).([]interface{})
+	for _, value := range results {
+		v := value.(map[string]interface{})
+		//log result with code, tenant and message
+		log.Debugf("[as3_log] Big-IP Response error code: %v,response:%v, message: %v", v["code"], v["response"], v["message"])
+	}
+	return string(body), false
 
 }
 


### PR DESCRIPTION
Problem:
The BIG-IP response is not being captured properly. It results in inappropriate logs. 

Solution:
Logging BIP-IP AS3 error response body for better readability and appropriate logs.

Affected Branches:
feature.as3