### PR TITLE
Add Debugger Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,12 @@ prod-build-quick: pre-build
 	RUN_TESTS=0 BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-release-artifacts.sh
 	BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-release-images.sh
 
+debug: pre-build
+	@echo "Building with debug support..."
+	BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-devel-image.sh
+	DEBUG=0 RUN_TESTS=0 BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-release-artifacts.sh
+	DEBUG=0 BASE_OS=$(BASE_OS) $(CURDIR)/build-tools/build-release-images.sh
+
 fmt:
 	@echo "Enforcing code formatting using 'go fmt'..."
 	$(CURDIR)/build-tools/fmt.sh

--- a/build-tools/Dockerfile.debug.runtime
+++ b/build-tools/Dockerfile.debug.runtime
@@ -1,0 +1,37 @@
+FROM golang as builder
+ENV CGO_ENABLE 0
+
+RUN go get github.com/go-delve/delve/cmd/dlv
+
+FROM python:2.7-slim-buster
+
+ENV APPPATH /app
+
+RUN mkdir -p "$APPPATH/bin" \
+ && chmod -R 755 "$APPPATH" \
+ && adduser --disabled-password --gecos "" ctlr
+
+WORKDIR $APPPATH
+
+COPY requirements.txt /tmp/requirements.txt
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        git \
+    && apt-get upgrade -y \
+    && pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir -r /tmp/requirements.txt \
+    && apt-get remove -y git
+
+# FIXME: Remove this fix once libidn is no longer vulnerable
+RUN apt-get remove -y libidn11
+
+COPY bigip-virtual-server_v*.json $APPPATH/vendor/src/f5/schemas/
+COPY as3-schema-3.11.0-3-cis.json $APPPATH/vendor/src/f5/schemas/
+COPY k8s-bigip-ctlr $APPPATH/bin
+COPY VERSION_BUILD.json $APPPATH/vendor/src/f5/
+COPY --from=builder /go/bin/dlv /app/bin
+
+USER ctlr
+EXPOSE 40000
+# Run the run application in the projects bin directory.
+CMD [ "/app/bin/k8s-bigip-ctlr" ]

--- a/build-tools/_build-lib.sh
+++ b/build-tools/_build-lib.sh
@@ -72,6 +72,11 @@ go_install () {
   BUILDDIR=$(get_builddir)
   local GO_BUILD_FLAGS=( -v -ldflags "-extldflags \"-static\" -X main.version=${BUILD_VERSION} -X main.buildInfo=${BUILD_INFO}" )
 
+  if [ $DEBUG == 0 ]
+  then
+    GO_BUILD_FLAGS+=( -gcflags "all=-N -l" )
+  fi
+
   mkdir -p "$BUILDDIR"
   (
     export GOBIN="$BUILDDIR/bin"

--- a/build-tools/build-release-images.sh
+++ b/build-tools/build-release-images.sh
@@ -13,7 +13,14 @@ CURDIR="$(dirname $BASH_SOURCE)"
 
 # Setup a temp docker build context dir
 WKDIR=$(mktemp -d docker-build.XXXX)
+DEBUG=${DEBUG:-1}
+
 cp $CURDIR/Dockerfile.$BASE_OS.runtime $WKDIR/Dockerfile.runtime
+
+if [ $DEBUG == 0 ]
+then
+  cp $CURDIR/Dockerfile.debug.runtime $WKDIR/Dockerfile.runtime
+fi
 
 BUILD_INFO=$(${CURDIR}/version-tool build-info)
 VERSION_INFO=$(${CURDIR}/version-tool version)

--- a/build-tools/rel-build.sh
+++ b/build-tools/rel-build.sh
@@ -5,13 +5,14 @@ set -ex
 
 CURDIR="$(dirname $BASH_SOURCE)"
 RUN_TESTS=${RUN_TESTS:-1}
+DEBUG=${DEBUG:-1}
 
 . $CURDIR/_build-lib.sh
 BUILDDIR=$(get_builddir)
 
 export BUILDDIR=$BUILDDIR
 
-go_install $(all_cmds)
+DEBUG=$DEBUG go_install $(all_cmds)
 
 if [ $RUN_TESTS -eq 1 ]; then
     echo "Gathering unit test code coverage for 'release' build..."

--- a/build-tools/run-in-docker.sh
+++ b/build-tools/run-in-docker.sh
@@ -36,6 +36,7 @@ RUN_ARGS=( \
   -e COVERALLS_TOKEN=$COVERALLS_REPO_TOKEN
   -e RUN_TESTS=$RUN_TESTS
   -e BASE_OS=$BASE_OS
+  -e DEBUG=$DEBUG
 )
 
 # Add -it if caller is a terminal


### PR DESCRIPTION
Problem: It is not possibe to debug controller from IDE using debugger
such as Go Delve.

Solution: Introduced a target to Makefile named `debug` which will
disable compiler optimization and embed *dlv* binary in to the
controller image.

Signed-off-by: Surendhar <surendhar@ymail.com>