### PR TITLE
Log INFO messages in Standard Output

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -12,6 +12,10 @@ Bug Fixes
 `````````
 * Controller configured to manage-routes now exist with readable help message in logs when router-vserver-addr is not configured.
 
+Bug Fixes
+`````````
+* :issues:`1016` Controller logs INFO messages to STDOUT
+
 v1.10.0
 ------------
 Added Functionality

--- a/pkg/vlogger/console/log_console.go
+++ b/pkg/vlogger/console/log_console.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"log"
 	"log/syslog"
+	"os"
 )
 
 type (
@@ -64,15 +65,21 @@ func (cl *consoleLogger) Debugf(format string, params ...interface{}) {
 
 func (cl *consoleLogger) Info(msg string) {
 	if cl.slLogLevel >= syslog.LOG_INFO {
-		log.Println("[INFO]", msg)
+		toSTDOUT(msg)
 	}
 }
 
 func (cl *consoleLogger) Infof(format string, params ...interface{}) {
 	if cl.slLogLevel >= syslog.LOG_INFO {
 		msg := fmt.Sprintf(format, params...)
-		log.Println("[INFO]", msg)
+		toSTDOUT(msg)
 	}
+}
+
+func toSTDOUT(msg string) {
+	log.SetOutput(os.Stdout)
+	log.Println("[INFO]", msg)
+	log.SetOutput(os.Stderr)
 }
 
 func (cl *consoleLogger) Warning(msg string) {


### PR DESCRIPTION
Problem: Controller logs all messages to Standard Error by default.

Solution: Set the output destination of INFO logs to Standard output and
fall back to default behaviour of `log/syslog` package.

Fixes: #1016

affected branches: master

Signed-off-by: Surendhar <surendhar@ymail.com>