### PR TITLE
route-vserver-addr is required when mange-routes is enabled

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -389,6 +389,11 @@ func verifyArgs() error {
 		vxlanMode = "maintain"
 		vxlanName = *flannelName
 	}
+	if *manageRoutes {
+		if len(*routeVserverAddr) == 0 {
+			return fmt.Errorf("Missing required parameter route-vserver-addr")
+		}
+	}
 
 	return nil
 }

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -8,6 +8,10 @@ Added Functionality
 * Support Path Based Routing for Openshift reencrypt routes.
 * OpenShift 4.1, Kubernetes 1.14 support and other dependency package upgrade.
 
+Bug Fixes
+`````````
+* Controller configured to manage-routes now exist with readable help message in logs when router-vserver-addr is not configured.
+
 v1.10.0
 ------------
 Added Functionality


### PR DESCRIPTION
Problem: When manage-routes is enabled and route-vserver-addr is not given then deployment fails with unknown error.

Solution: Check whether cis deployment option route-vserver-addr is also given when manage-routes is enabled. This will not crash the deployment but provide a detailed help message.

Affected-branches: master