### PR TITLE
Add Support for WAF Policy reference in Route

### DIFF
--- a/pkg/appmanager/as3Types.go
+++ b/pkg/appmanager/as3Types.go
@@ -53,23 +53,25 @@ type (
 
 	// as3EndpointPolicy maps to Endpoint_Policy in AS3 Resources
 	as3EndpointPolicy struct {
-		Class    string    `json:"class,omitempty"`
-		Rules    []as3Rule `json:"rules,omitempty"`
-		Strategy string    `json:"strategy,omitempty"`
+		Class    string     `json:"class,omitempty"`
+		Rules    []*as3Rule `json:"rules,omitempty"`
+		Strategy string     `json:"strategy,omitempty"`
 	}
 
 	// as3Rule maps to Endpoint_Policy_Rule in AS3 Resources
 	as3Rule struct {
-		Name       string         `json:"name,omitempty"`
-		Conditions []as3Condition `json:"conditions,omitempty"`
-		Actions    []as3Action    `json:"actions,omitempty"`
+		Name       string          `json:"name,omitempty"`
+		Conditions []*as3Condition `json:"conditions,omitempty"`
+		Actions    []*as3Action    `json:"actions,omitempty"`
 	}
 
 	// as3Action maps to Policy_Action in AS3 Resources
 	as3Action struct {
-		Type   string                  `json:"type,omitempty"`
-		Event  string                  `json:"event,omitempty"`
-		Select *as3ActionForwardSelect `json:"select,omitempty"`
+		Type    string                  `json:"type,omitempty"`
+		Event   string                  `json:"event,omitempty"`
+		Select  *as3ActionForwardSelect `json:"select,omitempty"`
+		Policy  *as3ResourcePointer     `json:"policy,omitempty"`
+		Enabled *bool                   `json:"enabled,omitempty"`
 	}
 
 	// as3Condition maps to Policy_Condition in AS3 Resources

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -357,4 +357,31 @@ type (
 
 	DataGroupNamespaceMap map[string]*InternalDataGroup
 	InternalDataGroupMap  map[nameRef]DataGroupNamespaceMap
+
+	// AS3 Backend supported features
+	virtuals int
+
+	// Routes annotation features that are possible by an AS3 declaration can be added here. Initially enabling a WAF
+	// policy is added as an AS3 feature.
+	// | Host + Path | Virtual Server to Apply | WAF Policy Name |
+	// |-------------|-------------------------|-----------------|
+	// Host + Path is a unique record. The columns can be extended to add future features.
+	InternalF5Resources map[Record]F5Resources
+
+	Record struct {
+		Host string
+		Path string
+	}
+
+	F5Resources struct {
+		Virtual   virtuals // 0 - HTTP, 1 - HTTPS, 2 - HTTP/S
+		WAFPolicy string
+	}
+)
+
+// Determines which virtual server needs a specific feature applied.
+const (
+	HTTP virtuals = iota
+	HTTPS
+	HTTPANDS
 )


### PR DESCRIPTION
Controller will look for `virtual-server.f5.com/waf` annotation in
routes. If found, it applies it to the virtuals based on the following
condition.

1. Route doesn't contain TLS spec: Applies only to HTTP virtual.
2. Route contains only TLS spec: Applies only to HTTPS virtual.
3. Route contains TLS Spec and `insecureEdgeTermination` is 'Allow':
Applies to both HTTP and HTTPS virtuals.

Signed-off-by: Surendhar <surendhar@ymail.com>