### PR TITLE
Update Route admitted status in OpenShift 3.11 GUI

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -7,6 +7,7 @@ Added Functionality
 `````````````````````
 * Support Path Based Routing for Openshift reencrypt routes.
 * OpenShift 4.1, Kubernetes 1.14 support and other dependency package upgrade.
+* Update OpenShift 3.11 GUI with Route admitted status based on BIG-IP response.
 
 Bug Fixes
 `````````

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -132,7 +132,7 @@ rst_epilog = '''
 .. _NodePort mode: %(base_url)s/containers/latest/kubernetes/kctlr-modes.html
 .. _OpenShift Route: https://docs.openshift.org/1.4/dev_guide/routes.html
 .. _Overview of SNAT features: https://support.f5.com/csp/article/K7820
-.. _route domain: https://support.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-0-0/9.html
+.. _route domain: https://techdocs.f5.com/kb/en-us/products/big-ip_ltm/manuals/product/tmos-routing-administration-12-1-1/9.html
 .. _`F5 Controller Agent`: https://github.com/f5devcentral/f5-ctlr-agent
 .. _Manage OpenShift Routes:  %(base_url)s/containers/latest/openshift/kctlr-openshift-routes.html
 .. _Kubernetes Installation: %(base_url)s/containers/latest/kubernetes/kctlr-app-install.html

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -205,6 +205,8 @@ type RouteConfig struct {
 	ServerSSL   string
 }
 
+var RoutesProcessed []*routeapi.Route
+
 // Create and return a new app manager that meets the Manager interface
 func NewManager(params *Params) *Manager {
 	vsQueue := workqueue.NewNamedRateLimitingQueue(
@@ -1368,6 +1370,7 @@ func (appMgr *Manager) syncRoutes(
 		if route.ObjectMeta.Namespace != sKey.Namespace {
 			continue
 		}
+		RoutesProcessed = append(RoutesProcessed, route)
 
 		//FIXME(kenr): why do we process services that aren't associated
 		//             with a route?


### PR DESCRIPTION
Problem: In Openshift ROUTE status is updated by its default router. We need to update it with respect to BIG-IP acceptance of the route.

Solution: OpenShift default router is scaled down. BIG-IP controller is updated to handle Route ADMITTED status based on the response from BIGIP. 

Affected-branches: master

Signed-off-by: Trinath SOMANCHI trinath.somanchi@gmail.com