### PR TITLE
Add Feature Tenant Filter

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -117,6 +117,7 @@ var (
 	agent              *string
 	logAS3Response     *bool
 	overrideAS3Decl    *string
+	filterTenants      *bool
 
 	vxlanMode        string
 	openshiftSDNName *string
@@ -198,6 +199,8 @@ func _init() {
 	overrideAS3UsageStr := "Optional, provide Namespace and Name of that ConfigMap as <namespace>/<configmap-name>." +
 		"The JSON key/values from this ConfigMap will override key/values from internally generated AS3 declaration."
 	overrideAS3Decl = bigIPFlags.String("override-as3-declaration", "", overrideAS3UsageStr)
+	filterTenants = kubeFlags.Bool("filter-tenants", false,
+		"Optional, specify whether or not to use tenant filtering API for AS3 declaration")
 	bigIPFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  BigIP:\n%s\n", bigIPFlags.FlagUsagesWrapped(width))
 	}
@@ -675,6 +678,7 @@ func main() {
 		TrustedCertsCfgmap:     *trustedCertsCfgmap,
 		OverrideAS3Decl:        *overrideAS3Decl,
 		Agent:                  *agent,
+		FilterTenants:          *filterTenants,
 	}
 
 	// If running with Flannel, create an event channel that the appManager

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -10,6 +10,7 @@ Added Functionality
   - `--manage-ingress-class-only`: A flag whether to handle Ingresses that do not have the class annotation and with annotation `kubernetes.io/ingress.class` set to `f5`. When set to `true`, process ingress resources with `kubernetes.io/ingress.class` set to `f5` or custom ingress class.
   - `--ingress-class` to define custom ingress class to watch.
   - Controller now pushes configuration after 3 seconds when encounters http response with code 503 from busy BIG-IP.
+  - Controller now complies with BIG-IP to filter out tenants, with `--filter-tenants` option.
 
 Bug Fixes
 `````````

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -166,6 +166,8 @@ type AS3Manager struct {
 	RoutesProcessed RouteMap
 	// POSTs configuration to BIG-IP using AS3
 	PostManager *postmanager.PostManager
+	// To put list of tenants in BIG-IP REST call URL that are in AS3 declaration
+	FilterTenants bool
 }
 
 // AS3Config consists of all the AS3 related configurations
@@ -217,6 +219,7 @@ type Params struct {
 	Agent                  string
 	OverrideAS3Decl        string
 	SchemaLocalPath        string
+	FilterTenants          bool
 }
 
 // Configuration options for Routes in OpenShift
@@ -278,6 +281,7 @@ func NewManager(params *Params) *Manager {
 			OverrideAS3Decl:    params.OverrideAS3Decl,
 			intF5Res:           make(map[string]InternalF5Resources),
 			SchemaLocalPath:    params.SchemaLocal,
+			FilterTenants:      params.FilterTenants,
 		},
 	}
 	if nil != manager.kubeClient && nil == manager.restClientv1 {

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -454,6 +454,17 @@ func (appMgr *Manager) updateAdmitStatus() {
 	}
 }
 
+func (appMgr *Manager) getTenants(decl as3Declaration) []string {
+	if as3Obj, ok := appMgr.getAS3ObjectFromTemplate(as3Template(string(decl))); ok {
+		var tenants []string
+		for k, _ := range as3Obj {
+			tenants = append(tenants, string(k))
+		}
+		return tenants
+	}
+	return nil
+}
+
 func (appMgr *Manager) postAS3Config(tempAS3Config AS3Config) {
 	unifiedDecl := tempAS3Config.getUnifiedDeclaration()
 
@@ -474,7 +485,12 @@ func (appMgr *Manager) postAS3Config(tempAS3Config AS3Config) {
 	}
 
 	appMgr.as3ActiveConfig.updateConfig(tempAS3Config)
-	appMgr.PostManager.Write(string(unifiedDecl))
+	if appMgr.FilterTenants {
+		appMgr.PostManager.Write(string(unifiedDecl), appMgr.getTenants(unifiedDecl))
+	} else {
+		appMgr.PostManager.Write(string(unifiedDecl), nil)
+	}
+
 }
 
 // Read certificate from configmap


### PR DESCRIPTION
Problem: Controller posts a declaration to /declare/, and TMOS has no idea about the partitions(tenants) that are going to be affected.

Solution: Controller posts declaration to /declare/\<list of comma separated tenants in the declaration\>, so that TMOS has visibility about tenants and it can filter out tenants.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>
