### PR TITLE
Fix applying WAF to root of a domain

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,6 +1,12 @@
 Release Notes for BIG-IP Controller for Kubernetes
 ==================================================
 
+Next Release
+------------
+Bug Fixes
+`````````
+* Controller handles WAF Policy in the root path of a domain in OpenShift Routes.
+
 v1.11.0
 ------------
 Added Functionality

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -1038,7 +1038,8 @@ func updatePolicyWithWAF(ep *as3EndpointPolicy, rec Record, res F5Resources) {
 		},
 	}
 
-	recPathElems := strings.Split(rec.Path, "/")[1:]
+	recPath := strings.TrimRight(rec.Path, "/")
+	recPathElems := strings.Split(recPath, "/")[1:]
 
 	for _, rule := range ep.Rules {
 		var hosts []string


### PR DESCRIPTION
Problem: WAF Policy is not being applied in virtual if Path in the OCP route is "/"

Solution: Remove ending "/" in a path to fix the issue.

Affected-Branches: master, 1.11-stable

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>