### PR TITLE
Fix Issue with WAF Policy for routes in Multiple Namespaces

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -6,6 +6,9 @@ Next Release
 Bug Fixes
 `````````
 * Controller handles WAF Policy in the root path of a domain in OpenShift Routes.
+* Controller handles OpenShift Routes with WAF Policy in multiple namespaces.
+* Controller now does not push configuration to BigIP using AS3 for every 30 seconds with no changes.
+* :issues:`1041` Controller now does not log dozens of "INFO" log messages frequently.
 
 v1.11.0
 ------------

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -145,7 +145,7 @@ type Manager struct {
 	WatchedNS       WatchedNamespaces
 	as3RouteCfg     ActiveAS3Route
 	As3SchemaLatest string
-	intF5Res        InternalF5Resources // AS3 Specific features that can be applied to a Route/Ingress
+	intF5Res        InternalF5ResourcesGroup // AS3 Specific features that can be applied to a Route/Ingress
 }
 
 // FIXME: Refactor to have one struct to hold all AS3 specific data.
@@ -248,6 +248,7 @@ func NewManager(params *Params) *Manager {
 		sslInsecure:        params.SSLInsecure,
 		trustedCertsCfgmap: params.TrustedCertsCfgmap,
 		Agent:              getValidAgent(params.Agent),
+		intF5Res:           make(map[string]InternalF5Resources),
 	}
 	if nil != manager.kubeClient && nil == manager.restClientv1 {
 		// This is the normal production case, but need the checks for unit tests.
@@ -1364,7 +1365,7 @@ func (appMgr *Manager) syncRoutes(
 	svcFwdRulesMap := NewServiceFwdRuleMap()
 
 	// buffer to hold F5Resources till all routes are processed
-	bufferF5Res := map[Record]F5Resources{}
+	bufferF5Res := InternalF5Resources{}
 
 	for _, route := range routeByIndex {
 		if route.ObjectMeta.Namespace != sKey.Namespace {
@@ -1521,8 +1522,10 @@ func (appMgr *Manager) syncRoutes(
 	}
 
 	// if buffer is updated then update the appMgr and stats
-	if !reflect.DeepEqual(appMgr.intF5Res, bufferF5Res) {
-		appMgr.intF5Res = bufferF5Res
+	if (len(appMgr.intF5Res[sKey.Namespace]) != 0 || len(bufferF5Res) != 0) &&
+		(!reflect.DeepEqual(appMgr.intF5Res[sKey.Namespace], bufferF5Res)) {
+
+		appMgr.intF5Res[sKey.Namespace] = bufferF5Res
 		stats.vsUpdated++
 	}
 

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -983,23 +983,25 @@ func (appMgr *Manager) processF5ResourcesForAS3(sharedApp as3Application) {
 	var ep *as3EndpointPolicy
 
 	// Update Rules with WAF action
-	for rec, res := range appMgr.intF5Res {
-		switch res.Virtual {
-		case HTTPS:
-			isSecureWAF = true
-			ep = sharedApp["openshift_secure_routes"].(*as3EndpointPolicy)
-		case HTTPANDS:
-			isSecureWAF = true
-			ep = sharedApp["openshift_secure_routes"].(*as3EndpointPolicy)
+	for _, resGroup := range appMgr.intF5Res {
+		for rec, res := range resGroup {
+			switch res.Virtual {
+			case HTTPS:
+				isSecureWAF = true
+				ep = sharedApp["openshift_secure_routes"].(*as3EndpointPolicy)
+			case HTTPANDS:
+				isSecureWAF = true
+				ep = sharedApp["openshift_secure_routes"].(*as3EndpointPolicy)
+				updatePolicyWithWAF(ep, rec, res)
+				fallthrough
+			case HTTP:
+				isInsecureWAF = true
+				ep = sharedApp["openshift_insecure_routes"].(*as3EndpointPolicy)
+			default:
+				continue
+			}
 			updatePolicyWithWAF(ep, rec, res)
-			fallthrough
-		case HTTP:
-			isInsecureWAF = true
-			ep = sharedApp["openshift_insecure_routes"].(*as3EndpointPolicy)
-		default:
-			continue
 		}
-		updatePolicyWithWAF(ep, rec, res)
 	}
 
 	enabled := false

--- a/pkg/appmanager/types.go
+++ b/pkg/appmanager/types.go
@@ -366,7 +366,9 @@ type (
 	// | Host + Path | Virtual Server to Apply | WAF Policy Name |
 	// |-------------|-------------------------|-----------------|
 	// Host + Path is a unique record. The columns can be extended to add future features.
-	InternalF5Resources map[Record]F5Resources
+	// InternalF5ResourcesGroup takes OpenShift/Kubernetes namespace as key
+	InternalF5ResourcesGroup map[string]InternalF5Resources
+	InternalF5Resources      map[Record]F5Resources
 
 	Record struct {
 		Host string


### PR DESCRIPTION
Problem: Routes in one namespace leading to override the AS3 configuration of routes in another namespace. The AS3 generated by controller consists of configuration related to routes that belong to only one namespace at any point of time. 

Solution: Handling multiple namespaces and make sure the AS3 configuration generated by controller consists of configuration related to all routes in all namespaces.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>