### PR TITLE
Fix calling unsafer method of Output Config

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -459,7 +459,7 @@ func (appMgr *Manager) syncNamespace(nsName string) error {
 			}
 		})
 		if rsDeleted > 0 {
-			appMgr.outputConfigLocked()
+			appMgr.outputConfig()
 		}
 	}
 

--- a/pkg/appmanager/validateResources.go
+++ b/pkg/appmanager/validateResources.go
@@ -157,14 +157,14 @@ func (appMgr *Manager) checkValidIngress(
 				sKey := serviceKey{serviceName, servicePort, namespace}
 				if _, ok := appMgr.resources.Get(sKey, rsName); ok {
 					appMgr.resources.Delete(sKey, rsName)
-					appMgr.outputConfigLocked()
+					appMgr.outputConfig()
 				}
 			} else { //multi-service
 				rsType = multiServiceIngressType
 				_, keys := appMgr.resources.GetAllWithName(rsName)
 				for _, key := range keys {
 					appMgr.resources.Delete(key, rsName)
-					appMgr.outputConfigLocked()
+					appMgr.outputConfig()
 				}
 			}
 			return false, nil


### PR DESCRIPTION
Problem: outputConfigLocked is being called without locking properly

Solution: Call outputConfig instead of outputConfigLocked so that locking of resources is ensured