### PR TITLE
Fix path and ssl based routing

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -3,6 +3,18 @@ Release Notes for BIG-IP Controller for Kubernetes
 
 Next Release
 ------------
+Added Functionality
+`````````````````````
+* Controller handles extended URL paths to the nearest matching backend context paths.
+
+Bug Fixes
+`````````
+* Controller handles combination of Edge and Reencrypt Openshift routes.
+* Controller now does not send encrypted traffic to backend.
+
+
+v1.11.1
+------------
 Bug Fixes
 `````````
 * Controller handles WAF Policy in the root path of a domain in OpenShift Routes.

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -2054,6 +2054,11 @@ func (appMgr *Manager) handleRouteRules(
 					appMgr.addInternalDataGroup(abDeploymentDgName, DEFAULT_PARTITION)
 					rc.Virtual.AddIRule(abPathIRuleName)
 				} else {
+					appMgr.addIRule(
+						sslPassthroughIRuleName, DEFAULT_PARTITION, appMgr.sslPassthroughIRule())
+					appMgr.addInternalDataGroup(edgeHostsDgName, DEFAULT_PARTITION)
+					appMgr.addInternalDataGroup(edgeServerSslDgName, DEFAULT_PARTITION)
+					rc.Virtual.AddIRule(passThroughIRuleName)
 					rc.AddRuleToPolicy(policyName, rule)
 					setAnnotationRulesForRoute(policyName, virtualName, poolName, urlRewriteRule, appRootRules, rc, appMgr)
 				}


### PR DESCRIPTION
Problem: 
1. CC does not deal with the situation where one URI for a hostname should be re-encrypted and another URI should be edge terminated
2. CC does not handle child paths 
3. SSL based routing is incorrect for child paths.

Solution:
1. As of today Server SSL Datagroup(ReencryptServersslDg) created by CIS creates keyvalue pair with key as ServerName and value as ServerSSL. When a reencrypt route and Edge route are attached to the same hostname, the ServerSSL of reencrypt route is used by Edge Route as well.
The best way to overcome this situation is to update the Datagroup with Servername and Path.
Example:
For Route With Host-> foo.com and Path-> /foo ......... update the data group key as foo.com/foo instead of foo.com
2. Added new logic into Irule to handle problem2
3. Added two new data groups for edge. 

Image: abhishekf5/k8s-bigip-ctlr:updatedatagroup

Affected Branches: master