### PR TITLE
Fix Controleller crash with WAF Route and unavaible service

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -11,6 +11,7 @@ Bug Fixes
 * :issues:`1041` Controller now does not log dozens of "INFO" log messages frequently.
 * :issues:`1040` Controller does not crashes if latest AS3 schema is not available.
 * Controller updates Route Status in OpenShift Management Console (OCP 4.x)
+* Controller does not crash when handling Route with WAF Policy that does not have a service.
 
 
 v1.11.0


### PR DESCRIPTION
Problem: Controller is crashing when Route with WAF Policy is deployed with unavailable service

Solution: Make sure, policy exists in AS3 declaration before applying WAF related to conditions and actions. Because Controller does not create policy if Route is configured with unavailable service.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>