### PR TITLE
AS3 override feature in CIS

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -113,6 +113,7 @@ var (
 	trustedCertsCfgmap *string
 	agent              *string
 	logAS3Response     *bool
+	overrideAS3Decl    *string
 
 	vxlanMode        string
 	openshiftSDNName *string
@@ -191,7 +192,9 @@ func _init() {
 	// TODO: Rephrase agent functionality
 	agent = bigIPFlags.String("agent", "cccl",
 		"Optional, when set to as3, orchestration agent will be AS3 instead of CCCL")
-
+	overrideAS3UsageStr := "Optional, provide Namespace and Name of that ConfigMap as <namespace>/<configmap-name>." +
+		"The JSON key/values from this ConfigMap will override key/values from internally generated AS3 declaration."
+	overrideAS3Decl = bigIPFlags.String("override-as3-declaration", "", overrideAS3UsageStr)
 	bigIPFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  BigIP:\n%s\n", bigIPFlags.FlagUsagesWrapped(width))
 	}
@@ -398,7 +401,12 @@ func verifyArgs() error {
 			return fmt.Errorf("Missing required parameter route-vserver-addr")
 		}
 	}
-
+	if *overrideAS3Decl != "" {
+		if len(strings.Split(*overrideAS3Decl, "/")) != 2 {
+			return fmt.Errorf("Invalid value provided for --override-as3-declaration" +
+				"Usage: --override-as3-declaration=<namespace>/<configmap-name>")
+		}
+	}
 	return nil
 }
 
@@ -653,6 +661,7 @@ func main() {
 		AS3Validation:      *as3Validation,
 		SSLInsecure:        *sslInsecure,
 		TrustedCertsCfgmap: *trustedCertsCfgmap,
+		OverrideAS3Decl:    *overrideAS3Decl,
 		Agent:              *agent,
 		LogAS3Response:     *logAS3Response,
 	}

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -7,6 +7,7 @@ Added Functionality
 `````````````````````
 * Controller handles extended URL paths to the nearest matching backend context paths.
 * Support AS3 for BIG-IP orchestration with Kubernetes Ingress.
+* Controller implements support for overriding already existing AS3 resources(ConfigMap, Route and Ingress) through ConfigMap. 
 
 Bug Fixes
 `````````

--- a/pkg/appmanager/as3Utils.go
+++ b/pkg/appmanager/as3Utils.go
@@ -1,0 +1,119 @@
+/*-
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package appmanager
+
+import (
+	"encoding/json"
+	"fmt"
+	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
+)
+
+func ValidateJSONStringAndFetchObject(jsonData string, jsonObj *map[string]interface{}) error {
+
+	if jsonData == "" {
+		log.Errorf("[AS3] Empty JSON string passed as an input !!!")
+		return fmt.Errorf("Empty Input JSON String")
+	}
+
+	if err := json.Unmarshal([]byte(jsonData), jsonObj); err != nil {
+		log.Errorf("[AS3] Failed in JSON Un-Marshal test !!!: %v", err)
+		return err
+	}
+
+	if data, err := json.Marshal(*jsonObj); err != nil && string(data) != "" {
+		log.Errorf("[AS3] Failed in JSON Marshal test  !!!: %v", err)
+		return err
+	}
+
+	return nil
+}
+
+func ValidateAndOverrideAS3JsonData(srcJsonData string, dstJsonData string) string {
+
+	var srcJsonObj map[string]interface{}
+	if err := ValidateJSONStringAndFetchObject(srcJsonData, &srcJsonObj); err != nil {
+		log.Errorf("[AS3] JSON Validation error on source JSON string !!!")
+		return ""
+	}
+
+	var dstJsonObj map[string]interface{}
+	if err := ValidateJSONStringAndFetchObject(dstJsonData, &dstJsonObj); err != nil {
+		log.Errorf("[AS3] JSON Validation error on destination JSON string !!!")
+		return ""
+	}
+
+	// Fetch AS3 declarations Objects to filter
+	// out tenants in srcJsonObj from dstJsonObj
+	dstDeclr := dstJsonObj["declaration"]
+	srcDeclr := srcJsonObj["declaration"]
+	if srcDeclr == nil {
+		log.Errorf("[AS3] Source JSON is not a valid AS3 declaration !!!")
+		return ""
+	}
+
+	// Discard all tenants from source AS3 declaration that are not available in CIS.
+	// For Example: Tenants that are not available in unified AS3 declaration.
+	for tenantKey, _ := range srcDeclr.(map[string]interface{}) {
+		// If a tenant in source json declaration not available in
+		// destination, then simply delete that tenant from srcJsonObj
+		if dstDeclr.(map[string]interface{})[tenantKey] == nil {
+			delete(srcDeclr.(map[string]interface{}), tenantKey)
+		}
+	}
+
+	// Return empty string if the Merged JSON Data fails the Marshall test
+	mergedJsonData, err := json.Marshal(mergeRecursive(srcJsonObj, dstJsonObj))
+	if err != nil {
+		log.Errorf("[AS3] CIS failed to merge JSON Data !!!: %v", err)
+		return ""
+	}
+
+	return string(mergedJsonData)
+}
+
+func mergeRecursive(srcJsonObj, dstJsonObj interface{}) interface{} {
+	//In this algorithm, preferring srcJsonObj overriding on dstJsonObj
+	switch srcJsonObj := srcJsonObj.(type) {
+	case map[string]interface{}:
+		// If any member for corresponding dstJsonObj not present
+		// then simply consider member of the src object
+		dstJsonObj, ok := dstJsonObj.(map[string]interface{})
+		if !ok {
+			return srcJsonObj
+		}
+
+		// If corresponding member of dstJsonObj present, then
+		// in this case the keys from both objects are included and
+		// only their values are merged recursively
+		for dstKey, dstVal := range dstJsonObj {
+			if srcKey, ok := srcJsonObj[dstKey]; ok {
+				srcJsonObj[dstKey] = mergeRecursive(srcKey, dstVal)
+			} else {
+				srcJsonObj[dstKey] = dstVal
+			}
+		}
+	case nil:
+		// If a member of srcJsonObj is not present and its corresponding dstJsonObj
+		// present, then simply consider member of the dstJsonObj, in which case
+		// this below code will just merge "nil" and "map[string]interface{...}" to
+		// "map[string]interface{...}"
+		dstJsonObj, ok := dstJsonObj.(map[string]interface{})
+		if ok {
+			return dstJsonObj
+		}
+	}
+	return srcJsonObj
+}

--- a/pkg/appmanager/as3Utils_test.go
+++ b/pkg/appmanager/as3Utils_test.go
@@ -1,0 +1,33 @@
+package appmanager
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Override Simple Config Map", func() {
+	It("TestValidateJSONStringAndFetchObject", func() {
+		srcCfgMapData := readConfigFile(configPath + "as3config_override_simple_cfgmap_resource.json")
+		dstCfgMapData := readConfigFile(configPath + "as3config_simple_cfgmap_resource.json")
+
+		overrideData := ValidateAndOverrideAS3JsonData(srcCfgMapData, dstCfgMapData)
+
+		Expect(overrideData != "").To(Equal(true))
+	})
+
+	It("Override Invalid AS3 Override Config Map", func() {
+		srcCfgMapData := readConfigFile(configPath + "as3config_without_adc.json")
+		dstCfgMapData := readConfigFile(configPath + "as3config_simple_cfgmap_resource.json")
+
+		overrideData := ValidateAndOverrideAS3JsonData(srcCfgMapData, dstCfgMapData)
+		Expect(overrideData == "").To(Equal(true))
+	})
+
+	It("Override Invalid AS3 Config Map", func() {
+		srcCfgMapData := readConfigFile(configPath + "as3config_override_simple_cfgmap_resource.json")
+		dstCfgMapData := readConfigFile(configPath + "as3config_invalid_JSON.json")
+
+		overrideData := ValidateAndOverrideAS3JsonData(srcCfgMapData, dstCfgMapData)
+		Expect(overrideData == "").To(Equal(true))
+	})
+})

--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -31,9 +31,12 @@ func (appMgr *Manager) outputConfig() {
 	switch appMgr.Agent {
 	case "as3":
 		if appMgr.processedItems >= appMgr.queueLen || appMgr.initialState {
-			appMgr.sendFDBEntries()
 			appMgr.postRouteDeclarationHost()
-			appMgr.sendARPEntries()
+			if appMgr.as3Modified {
+				appMgr.sendFDBEntries()
+				appMgr.sendARPEntries()
+				appMgr.as3Modified = false
+			}
 			appMgr.initialState = true
 		}
 	default:
@@ -259,7 +262,7 @@ func (appMgr *Manager) sendARPEntries() {
 
 		select {
 		case appMgr.eventChan <- allPoolMembers:
-			log.Debugf("AppManager wrote endpoints to VxlanMgr. %v", allPoolMembers)
+			log.Debugf("AppManager wrote endpoints to VxlanMgr")
 		case <-time.After(3 * time.Second):
 		}
 	}

--- a/pkg/test/configs/as3config_override_simple_cfgmap_resource.json
+++ b/pkg/test/configs/as3config_override_simple_cfgmap_resource.json
@@ -1,0 +1,13 @@
+{
+    "declaration": {
+        "example_simple_http_application": {
+            "example_simple_http_application_01": {
+                "serviceMain": {
+                    "virtualAddresses": [
+                        "172.16.3.199"
+                    ]
+                }
+            }
+        }
+    }
+}

--- a/pkg/test/configs/as3config_simple_cfgmap_resource.json
+++ b/pkg/test/configs/as3config_simple_cfgmap_resource.json
@@ -1,0 +1,39 @@
+{
+    "class": "AS3",
+    "action": "deploy",
+    "persist": true,
+    "declaration": {
+        "class": "ADC",
+        "schemaVersion": "3.11.0",
+        "id": "urn:uuid:33045210-3ab8-4636-9b2a-c98d22ab915d",
+        "label": "example_simple_http_application_01",
+        "remark": "Simple HTTP application with RR pool",
+        "example_simple_http_application": {
+            "class": "Tenant",
+            "example_simple_http_application_01": {
+                "class": "Application",
+                "template": "http",
+                "serviceMain": {
+                    "class": "Service_HTTP",
+                    "virtualAddresses": [
+                        "172.16.3.110"
+                    ],
+                    "pool": "web_pool"
+                },
+                "web_pool": {
+                    "class": "Pool",
+                    "monitors": [
+                        "http"
+                    ],
+                    "members": [
+                        {
+                            "servicePort": 80,
+                            "serverAddresses": [
+                            ]
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Problem:
Need a feature that overrides existing AS3 configuration with a new user-defined AS3 configuration, using k8s ConfigMap. So the administrator will be able to modify the existing virtual server configuration incrementally as needed without having to overwrite/delete the existing one

Solution:
Implemented AS3 override feature in CIS, this feature enables administrators to create a virtual server in a controlled and managed partition manually and add metadata so that f5-cccl will not create a new virtual server.

affects-branches: master

docker-image: snatra27/k8s-bigip-ctlr:cis-override-json-2

