### PR TITLE
Fix NS resource cleanup when not monitoring

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -449,7 +449,6 @@ func (appMgr *Manager) syncNamespace(nsName string) error {
 		appMgr.removeNamespaceLocked(nsName)
 		appMgr.eventNotifier.deleteNotifierForNamespace(nsName)
 		appMgr.resources.Lock()
-		defer appMgr.resources.Unlock()
 		rsDeleted := 0
 		appMgr.resources.ForEach(func(key serviceKey, cfg *ResourceConfig) {
 			if key.Namespace == nsName {
@@ -458,6 +457,7 @@ func (appMgr *Manager) syncNamespace(nsName string) error {
 				}
 			}
 		})
+		appMgr.resources.Unlock()
 		if rsDeleted > 0 {
 			appMgr.outputConfig()
 		}


### PR DESCRIPTION
Problem: When NS resources are not being monitored, CIS is unable to clean respective objects in BIG-IP

Solution: Lock the resources being processed and let output config processing be taken care separately. 

Signed-off-by: Trinath Somanchi trinath.somanchi@gmail.com

Affected-branches: master, 1.11-stable

Docker Image: somanchit/k8s-bigip-ctlr:nsfix