### PR TITLE
Added new command line option, --log-response-body which will log the…

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -112,6 +112,7 @@ var (
 	sslInsecure        *bool
 	trustedCertsCfgmap *string
 	agent              *string
+	logAS3Response     *bool
 
 	vxlanMode        string
 	openshiftSDNName *string
@@ -183,6 +184,8 @@ func _init() {
 		"Optional, when set to false, disables as3 template validation on the controller.")
 	sslInsecure = bigIPFlags.Bool("insecure", false,
 		"Optional, when set to true, enable insecure SSL communication to BIGIP.")
+	logAS3Response = bigIPFlags.Bool("log-as3-response", false,
+		"Optional, when set to true, add the body of AS3 API response in Controller logs.")
 	trustedCertsCfgmap = bigIPFlags.String("trusted-certs-cfgmap", "",
 		"Optional, when certificates are provided, adds them to controller’s trusted certificate store.")
 	// TODO: Rephrase agent functionality
@@ -651,6 +654,7 @@ func main() {
 		SSLInsecure:        *sslInsecure,
 		TrustedCertsCfgmap: *trustedCertsCfgmap,
 		Agent:              *agent,
+		LogAS3Response:     *logAS3Response,
 	}
 
 	// If running with Flannel, create an event channel that the appManager

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -153,6 +153,7 @@ type Manager struct {
 	// Flag to check schema validation using reference or string
 	As3SchemaFlag   bool
 	RoutesProcessed RouteMap // Processed routes for updating Admit Status
+	logAS3Response  bool     //Log the AS3 response body in Controller logs
 }
 
 // FIXME: Refactor to have one struct to hold all AS3 specific data.
@@ -201,6 +202,7 @@ type Params struct {
 	TrustedCertsCfgmap string
 	Agent              string
 	SchemaLocalPath    string
+	LogAS3Response     bool
 }
 
 // Configuration options for Routes in OpenShift
@@ -258,6 +260,7 @@ func NewManager(params *Params) *Manager {
 		Agent:              getValidAgent(params.Agent),
 		intF5Res:           make(map[string]InternalF5Resources),
 		SchemaLocalPath:    params.SchemaLocal,
+		logAS3Response:     params.LogAS3Response,
 	}
 	if nil != manager.kubeClient && nil == manager.restClientv1 {
 		// This is the normal production case, but need the checks for unit tests.

--- a/pkg/appmanager/as3Manager_test.go
+++ b/pkg/appmanager/as3Manager_test.go
@@ -96,6 +96,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			route := "/mgmt/shared/appsvcs/declare"
 			method := "POST"
 			var template as3Declaration = `{"class":"AS3","action":"deploy","persist":true,}`
+			appMgr := NewManager(&Params{SSLInsecure: false})
 			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				// Test request parameters
 				Expect(req.URL.String()).To(BeEquivalentTo("/mgmt/shared/appsvcs/declare"))
@@ -108,7 +109,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			defer server.Close()
 			// Use Client & URL from our local test server
 			api := AS3RESTClient{server.Client(), server.URL, "", ""}
-			_, status := api.restCallToBigIP(method, route, template, false)
+			_, status := api.restCallToBigIP(method, route, template, appMgr)
 			Expect(status).To(BeTrue())
 		})
 
@@ -116,6 +117,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			route := "/mgmt/shared/appsvcs/declare"
 			method := "POST"
 			var template as3Declaration = `{"class":"AS3","action":"deploy","persist":true,}`
+			appMgr := NewManager(&Params{SSLInsecure: false})
 			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				// Test request parameters
 				Expect(req.URL.String()).To(BeEquivalentTo("/mgmt/shared/appsvcs/declare"))
@@ -129,7 +131,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			defer server.Close()
 			// Use Client & URL from our local test server
 			api := AS3RESTClient{server.Client(), server.URL, "", ""}
-			_, status := api.restCallToBigIP(method, route, template, false)
+			_, status := api.restCallToBigIP(method, route, template, appMgr)
 			Expect(status).To(BeFalse())
 		})
 
@@ -137,6 +139,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			route := "/mgmt/shared/appsvcs/declare"
 			method := "POST"
 			var template as3Declaration = `{"class":"AS3","action":"deploy","persist":true,}`
+			appMgr := NewManager(&Params{SSLInsecure: false})
 			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				// Test request parameters
 				Expect(req.URL.String()).To(BeEquivalentTo("/mgmt/shared/appsvcs/declare"))
@@ -150,7 +153,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			defer server.Close()
 			// Use Client & URL from our local test server
 			api := AS3RESTClient{server.Client(), server.URL, "", ""}
-			_, status := api.restCallToBigIP(method, route, template, false)
+			_, status := api.restCallToBigIP(method, route, template, appMgr)
 			Expect(status).To(BeFalse())
 		})
 
@@ -158,6 +161,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			route := "/mgmt/shared/appsvcs/declare"
 			method := "POST"
 			var template as3Declaration = `{"class":"AS3","action":"deploy","persist":true,}`
+			appMgr := NewManager(&Params{SSLInsecure: false})
 			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				// Test request parameters
 				Expect(req.URL.String()).To(BeEquivalentTo("/mgmt/shared/appsvcs/declare"))
@@ -171,7 +175,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			api := AS3RESTClient{server.Client(), server.URL, "", ""}
 			//Close serve to test serve failure
 			server.Close()
-			_, status := api.restCallToBigIP(method, route, template, false)
+			_, status := api.restCallToBigIP(method, route, template, appMgr)
 			Expect(status).To(BeFalse())
 		})
 
@@ -179,6 +183,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			route := "/mgmt/shared/appsvcs/declare"
 			method := "POST"
 			var template as3Declaration = `{"class":"AS3","action":"deploy","persist":true,}`
+			appMgr := NewManager(&Params{SSLInsecure: false})
 			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				// Test request parameters
 				Expect(req.URL.String()).To(BeEquivalentTo("/mgmt/shared/appsvcs/declare"))
@@ -194,7 +199,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			oldChecksum := string(h.Sum(nil))
 			// Use Client & URL from our local test server
 			api := AS3RESTClient{server.Client(), server.URL, oldChecksum, ""}
-			_, status := api.restCallToBigIP(method, route, template, false)
+			_, status := api.restCallToBigIP(method, route, template, appMgr)
 			Expect(status).To(BeTrue())
 		})
 
@@ -202,6 +207,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			route := "/mgmt/shared/appsvcs/declare"
 			method := "POST"
 			var template as3Declaration = `{"class":"AS3","action":"deploy","persist":false,}`
+			appMgr := NewManager(&Params{SSLInsecure: false})
 			server := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
 				// Test request parameters
 				Expect(req.URL.String()).To(BeEquivalentTo("/mgmt/shared/appsvcs/declare"))
@@ -214,7 +220,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			defer server.Close()
 			// Use Client & URL from our local test server
 			api := AS3RESTClient{server.Client(), server.URL, "", ""}
-			_, status := api.restCallToBigIP(method, route, template, false)
+			_, status := api.restCallToBigIP(method, route, template, appMgr)
 			Expect(status).To(BeTrue())
 		})
 	})


### PR DESCRIPTION
Problem: Controller logs the response from AS3 in BIGIP as is, which sometimes include the original request in plain text. As a result, if the AS3 request consists of secrets such as credentials, passphrase, private keys etc are getting logged in plain text.

Solution: Given the option to hide AS3 response body.
Introduce a new command-line option to k8s-bigip-ctlr Binay, named --log-as3-response which will log the AS3 response body in Controller logs. This is boolean parameter that accepts either true or false as input. By default this option should be set to false.

Affects-branches: master

docker-image: amit49g/k8s-bigip-ctlr:logResponseBodyOption