### PR TITLE
Add Feature Tenant Filter

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -102,6 +102,7 @@ var (
 	vsSnatPoolName    *string
 	useSecrets        *bool
 	schemaLocal       *string
+	filterTenants     *bool
 
 	bigIPURL           *string
 	bigIPUsername      *string
@@ -236,6 +237,8 @@ func _init() {
 		"Optional, enable/disable use of Secrets for Ingress or ConfigMap SSL Profiles.")
 	schemaLocal = kubeFlags.String("schema-db-base-dir", "file:///app/vendor/src/f5/schemas/",
 		"Optional, where the schema db's locally reside")
+	filterTenants = kubeFlags.Bool("filter-tenants", false,
+		"Optional, specify whether or not to use tenant filtering API for AS3 declaration")
 
 	// If the flag is specified with no argument, default to LOOKUP
 	kubeFlags.Lookup("resolve-ingress-names").NoOptDefVal = "LOOKUP"
@@ -655,6 +658,7 @@ func main() {
 		TrustedCertsCfgmap: *trustedCertsCfgmap,
 		Agent:              *agent,
 		LogAS3Response:     *logAS3Response,
+		FilterTenants:      *filterTenants,
 	}
 
 	// If running with Flannel, create an event channel that the appManager

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,5 +1,10 @@
 Release Notes for BIG-IP Controller for Kubernetes
 ==================================================
+Next Release
+------------
+Added Functionality
+`````````````````````
+* Added support for Tenant Filtering using `--filter-tenants=true` option.
 
 Next Release
 ------------

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -154,6 +154,7 @@ type Manager struct {
 	As3SchemaFlag   bool
 	RoutesProcessed RouteMap // Processed routes for updating Admit Status
 	logAS3Response  bool     //Log the AS3 response body in Controller logs
+	FilterTenants   bool
 }
 
 // FIXME: Refactor to have one struct to hold all AS3 specific data.
@@ -203,6 +204,7 @@ type Params struct {
 	Agent              string
 	SchemaLocalPath    string
 	LogAS3Response     bool
+	FilterTenants      bool
 }
 
 // Configuration options for Routes in OpenShift
@@ -261,6 +263,7 @@ func NewManager(params *Params) *Manager {
 		intF5Res:           make(map[string]InternalF5Resources),
 		SchemaLocalPath:    params.SchemaLocal,
 		logAS3Response:     params.LogAS3Response,
+		FilterTenants:      params.FilterTenants,
 	}
 	if nil != manager.kubeClient && nil == manager.restClientv1 {
 		// This is the normal production case, but need the checks for unit tests.

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -470,12 +470,30 @@ func (appMgr *Manager) updateAdmitStatus() {
 	}
 }
 
+func (appMgr *Manager) getAS3APIURL(decl as3Declaration) string {
+	apiURL := "/mgmt/shared/appsvcs/declare/"
+	if !appMgr.FilterTenants {
+		return apiURL
+	}
+
+	if as3Obj, ok := appMgr.getAS3ObjectFromTemplate(as3Template(string(decl))); ok {
+		var tenants []string
+		for tenant, _ := range as3Obj {
+			tenants = append(tenants, string(tenant))
+		}
+		apiURL += strings.Join(tenants, ",")
+	}
+	return apiURL
+}
+
 // TODO: Refactor
 // Takes AS3 Declaration and post it to BigIP
 func (appMgr *Manager) postAS3Declaration(declaration as3Declaration, tempAs3ConfigmapDecl as3Declaration, tempRouteConfigDecl as3ADC) {
 	log.Debugf("[as3_log] Processing AS3 POST call with AS3 Manager")
 	as3RC.baseURL = BigIPURL
-	_, ok := as3RC.restCallToBigIP("POST", "/mgmt/shared/appsvcs/declare", declaration, appMgr)
+
+	as3APIURL := appMgr.getAS3APIURL(declaration)
+	_, ok := as3RC.restCallToBigIP("POST", as3APIURL, declaration, appMgr)
 	if ok {
 		appMgr.activeCfgMap.Data = string(tempAs3ConfigmapDecl)
 		appMgr.as3RouteCfg.Data = tempRouteConfigDecl

--- a/pkg/appmanager/as3Manager_test.go
+++ b/pkg/appmanager/as3Manager_test.go
@@ -51,6 +51,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			IsNodePort:       true,
 			broadcasterFunc:  NewFakeEventBroadcaster,
 			ManageConfigMaps: true,
+			FilterTenants:    true,
 		})
 	})
 	AfterEach(func() {
@@ -284,6 +285,23 @@ var _ = Describe("AS3Manager Tests", func() {
 			Expect(err).To(BeNil(), "Failed to Create Valid JSON")
 
 			Expect(reflect.DeepEqual(origCfg, generatedCfg)).To(BeTrue(), "Failed to Create JSON with correct configuration")
+		})
+	})
+	Describe("Validate Generated AS3 API URL", func() {
+		It("AS3 API URL for single Tenant", func() {
+			data := readConfigFile(configPath + "as3_route_declaration.json")
+			apiURL := mockMgr.appMgr.getAS3APIURL(as3Declaration(data))
+
+			Expect(apiURL).To(Equal("/mgmt/shared/appsvcs/declare/openshift"))
+		})
+		It("AS3 API URL for multiple Tenants", func() {
+			data := readConfigFile(configPath + "as3_route_cfgmap_declaration.json")
+			apiURL := mockMgr.appMgr.getAS3APIURL(as3Declaration(data))
+
+			Expect(apiURL).To(Or(
+				Equal("/mgmt/shared/appsvcs/declare/openshift,Tenant1"),
+				Equal("/mgmt/shared/appsvcs/declare/Tenant1,openshift"),
+			))
 		})
 	})
 })


### PR DESCRIPTION
Problem: Controller posts a declaration to /declare/, and TMOS has no idea about the partitions(tenants) that are going to be affected.

Solution: Controller posts declaration to /declare/, so that TMOS has visibility about tenants and it can filter out tenants.

affected branch: master

Docker image: amit49g/k8s-bigip-ctlr:tenantFilteringFeature