### PR TITLE
Ingress data traffic fails for ClusterIP mode as there are no static ARP entries available in BIG-IP

### DIFF
--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -890,7 +890,9 @@ func (appMgr *Manager) processResourcesForAS3(sharedApp as3Application) {
 		createMonitorDecl(cfg, sharedApp)
 
 		//Create pools
+		buffer = make(map[Member]struct{}, 0)
 		createPoolDecl(cfg, sharedApp)
+		appMgr.as3Members = buffer
 
 		//Create AS3 Service for virtual server
 		createServiceDecl(cfg, sharedApp)
@@ -1164,6 +1166,12 @@ func createPoolDecl(cfg *ResourceConfig, sharedApp as3Application) {
 			member.ServicePort = val.Port
 			member.ServerAddresses = append(member.ServerAddresses, val.Address)
 			pool.Members = append(pool.Members, member)
+			var ingPoolMember Member
+			if cfg.MetaData.ResourceType == "ingress" {
+				ingPoolMember.Address = val.Address
+				ingPoolMember.Port = val.Port
+				buffer[ingPoolMember] = struct{}{}
+			}
 		}
 		for _, val := range v.MonitorNames {
 			var monitor as3ResourcePointer


### PR DESCRIPTION
**Problem:**
For Ingress resource in K8S setup, Data plane traffic fails for ClusterIP mode because there were no static ARP entries available in BIG-IP to forward traffic to flannel/sdn interface.

**Solution:**
Using Ingress pool members populating the AS3 Members list and sending the list to VxLAN manager for ARP update.

**Branches-effected:** master


