### PR TITLE
ARP entry issues with multiple ingress resources

### DIFF
--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -897,9 +897,7 @@ func (appMgr *Manager) processResourcesForAS3(sharedApp as3Application) {
 		createMonitorDecl(cfg, sharedApp)
 
 		//Create pools
-		buffer = make(map[Member]struct{}, 0)
 		createPoolDecl(cfg, sharedApp)
-		appMgr.as3Members = buffer
 
 		//Create AS3 Service for virtual server
 		createServiceDecl(cfg, sharedApp)
@@ -1173,12 +1171,6 @@ func createPoolDecl(cfg *ResourceConfig, sharedApp as3Application) {
 			member.ServicePort = val.Port
 			member.ServerAddresses = append(member.ServerAddresses, val.Address)
 			pool.Members = append(pool.Members, member)
-			var ingPoolMember Member
-			if cfg.MetaData.ResourceType == "ingress" {
-				ingPoolMember.Address = val.Address
-				ingPoolMember.Port = val.Port
-				buffer[ingPoolMember] = struct{}{}
-			}
 		}
 		for _, val := range v.MonitorNames {
 			var monitor as3ResourcePointer

--- a/pkg/appmanager/outputConfig.go
+++ b/pkg/appmanager/outputConfig.go
@@ -230,6 +230,25 @@ func (appMgr *Manager) sendFDBEntries() {
 
 func (appMgr *Manager) sendARPEntries() {
 
+	resources := PartitionMap{}
+	var allPoolMembers []Member
+
+	// Filter the configs to only those that have active services
+	for _, cfg := range appMgr.resources.GetAllResources() {
+		if cfg.MetaData.Active == true {
+			initPartitionData(resources, cfg.GetPartition())
+			for _, p := range cfg.Pools {
+				resources[p.Partition].Pools = appendPool(resources[p.Partition].Pools, p)
+			}
+		}
+	}
+
+	for _, cfg := range resources {
+		for _, pool := range cfg.Pools {
+			allPoolMembers = append(allPoolMembers, pool.Members...)
+		}
+	}
+
 	if appMgr.eventChan != nil {
 		// Get all pool members and write them to VxlanMgr to configure ARP entries
 		var allPoolMembers []Member


### PR DESCRIPTION
Problem:
ARP entries are improper when multiple ingress resources are configured.

Solution:
The arp entries population are corrected when there are multiple Ingress resources along with other resources.

Branches-effected: master