### PR TITLE
Update the unscheduled node list for master label change in Openshift

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -2407,22 +2407,6 @@ func (appMgr *Manager) getNodes(
 
 	// Append list of nodes to watchedNodes
 	for _, node := range nodes {
-		// Ignore Master Node from the list of watched nodes
-		// only when master is in UnSchedulable state.
-		if node.ObjectMeta.Labels["node-role.kubernetes.io/master"] == "true" {
-			isUnSchedulable := false
-			// Iterate through the list of taints available
-			// on master node and look for no schedule taint
-			for _, t := range node.Spec.Taints {
-				if v1.TaintEffectNoSchedule == t.Effect {
-					isUnSchedulable = true
-				}
-			}
-			if isUnSchedulable == true {
-				continue
-			}
-		}
-		// Consider all the other nodes except master.
 		nodeAddrs := node.Status.Addresses
 		for _, addr := range nodeAddrs {
 			if addr.Type == addrType {


### PR DESCRIPTION
Problem:
master label changed from node-role.kubernetes.io/master: "true" to node-role.kubernetes.io/master: "" in Openshift 4.1 and k8s 1.13.

Solution:
Start considering all the nodes including master. 

Affected branches:
master