### PR TITLE
Delete CIS managed partition when agent altered

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -749,9 +749,7 @@ func main() {
 
 	appMgr := appmanager.NewManager(&appMgrParms)
 	// Delete as3 managed partition when switching back to agent cccl from as3
-	if appMgr.Agent == "cccl" {
-		appMgr.DeleteAS3ManagedPartition()
-	}
+	appMgr.DeleteCISManagedPartition()
 
 	// AS3 schema validation using latest AS3 version
 	fetchAS3Schema(appMgr)

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -1602,11 +1602,17 @@ func deriveResourceTypeFromAS3Value(val string) string {
 	return resourceTypeIngress
 }
 
-func (appMgr *Manager) DeleteAS3ManagedPartition() {
+func (appMgr *Manager) DeleteCISManagedPartition() {
 	var as3Config map[string]interface{}
 	_ = json.Unmarshal([]byte(baseAS3Config), &as3Config)
 	decl := as3Config["declaration"].(map[string]interface{})
-	decl[DEFAULT_PARTITION+"_AS3"] = map[string]string{"class": "Tenant"}
+	if appMgr.Agent == "cccl" {
+		decl[DEFAULT_PARTITION+"_AS3"] = map[string]string{"class": "Tenant"}
+	} else if appMgr.Agent == "as3" {
+		decl[DEFAULT_PARTITION] = map[string]string{"class": "Tenant"}
+	} else {
+		return
+	}
 	data, _ := json.Marshal(as3Config)
 	appMgr.postAS3Declaration(as3Declaration(data), "", nil)
 }


### PR DESCRIPTION
Problem: When agent changes from "cccl" to "as3" or vice versa, there is stale configuration on BIG-IP for the old agent.

Solution: Deleted CIS managed old partition when agent altered.

Docker Image: amit49g/k8s-bigip-ctlr:deletePartition