### PR TITLE
fix the rhel nss-tools vulnerabilities

### DIFF
--- a/build-tools/Dockerfile.rhel7.runtime
+++ b/build-tools/Dockerfile.rhel7.runtime
@@ -27,6 +27,7 @@ RUN microdnf --enablerepo=rhel-7-server-rpms --enablerepo=rhel-7-server-optional
       --enablerepo=rhel-server-rhscl-7-rpms install --nodocs \
       golang-github-cpuguy83-go-md2man python27-python-pip git shadow-utils && \
     microdnf update && \
+    microdnf --enablerepo=rhel-7-server-rpms update nss-tools nss-softokn nss-util && \
     go-md2man -in /tmp/help.md -out /help.1 && rm -f /tmp/help.md && \
     source scl_source enable python27 && \
     pip install --no-cache-dir --upgrade pip && \


### PR DESCRIPTION
Problem:
Fix RHSA-2019:4190 - Security Advisory

Solution:
Update nss and dependent packages.

Affected Branches:
master