### PR TITLE
Support Ingress.Class and Manage default Ingresses.

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -87,21 +87,23 @@ var (
 	printVersion     *bool
 	httpAddress      *string
 
-	namespaces        *[]string
-	useNodeInternal   *bool
-	poolMemberType    *string
-	inCluster         *bool
-	kubeConfig        *string
-	namespaceLabel    *string
-	manageRoutes      *bool
-	manageConfigMaps  *bool
-	manageIngress     *bool
-	nodeLabelSelector *string
-	resolveIngNames   *string
-	defaultIngIP      *string
-	vsSnatPoolName    *string
-	useSecrets        *bool
-	schemaLocal       *string
+	namespaces             *[]string
+	useNodeInternal        *bool
+	poolMemberType         *string
+	inCluster              *bool
+	kubeConfig             *string
+	namespaceLabel         *string
+	manageRoutes           *bool
+	manageConfigMaps       *bool
+	manageIngress          *bool
+	nodeLabelSelector      *string
+	resolveIngNames        *string
+	defaultIngIP           *string
+	vsSnatPoolName         *string
+	useSecrets             *bool
+	schemaLocal            *string
+	manageIngressClassOnly *bool
+	ingressClass           *string
 
 	bigIPURL           *string
 	bigIPUsername      *string
@@ -239,6 +241,14 @@ func _init() {
 		"Optional, enable/disable use of Secrets for Ingress or ConfigMap SSL Profiles.")
 	schemaLocal = kubeFlags.String("schema-db-base-dir", "file:///app/vendor/src/f5/schemas/",
 		"Optional, where the schema db's locally reside")
+	manageIngressClassOnly = kubeFlags.Bool("manage-ingress-class-only", false,
+		"Optional, default `false`. Process all ingress resources without `kubernetes.io/ingress.class`"+
+			"annotation and ingresses with annotation `kubernetes.io/ingress.class=f5`.")
+	ingressClass = kubeFlags.String("ingress-class", "f5",
+		"Optional, default `f5`. A class of the Ingress controller. The Ingress controller only processes Ingress"+
+			"resources that belong to its class - i.e. have the annotation `kubernetes.io/ingress.class` equal to the class."+
+			"Additionally, the Ingress controller processes Ingress resources that do not have that annotation,"+
+			"which can be disabled by setting the `-manage-ingress-class-only` flag")
 
 	// If the flag is specified with no argument, default to LOOKUP
 	kubeFlags.Lookup("resolve-ingress-names").NoOptDefVal = "LOOKUP"
@@ -646,24 +656,26 @@ func main() {
 	}
 
 	var appMgrParms = appmanager.Params{
-		ConfigWriter:       configWriter,
-		UseNodeInternal:    *useNodeInternal,
-		IsNodePort:         isNodePort,
-		RouteConfig:        routeConfig,
-		NodeLabelSelector:  *nodeLabelSelector,
-		ResolveIngress:     *resolveIngNames,
-		DefaultIngIP:       *defaultIngIP,
-		VsSnatPoolName:     *vsSnatPoolName,
-		UseSecrets:         *useSecrets,
-		ManageConfigMaps:   *manageConfigMaps,
-		ManageIngress:      *manageIngress,
-		SchemaLocal:        *schemaLocal,
-		AS3Validation:      *as3Validation,
-		SSLInsecure:        *sslInsecure,
-		TrustedCertsCfgmap: *trustedCertsCfgmap,
-		OverrideAS3Decl:    *overrideAS3Decl,
-		Agent:              *agent,
-		LogAS3Response:     *logAS3Response,
+		ConfigWriter:           configWriter,
+		UseNodeInternal:        *useNodeInternal,
+		IsNodePort:             isNodePort,
+		RouteConfig:            routeConfig,
+		NodeLabelSelector:      *nodeLabelSelector,
+		ResolveIngress:         *resolveIngNames,
+		DefaultIngIP:           *defaultIngIP,
+		VsSnatPoolName:         *vsSnatPoolName,
+		UseSecrets:             *useSecrets,
+		ManageConfigMaps:       *manageConfigMaps,
+		ManageIngress:          *manageIngress,
+		ManageIngressClassOnly: *manageIngressClassOnly,
+		IngressClass:           *ingressClass,
+		SchemaLocal:            *schemaLocal,
+		AS3Validation:          *as3Validation,
+		SSLInsecure:            *sslInsecure,
+		TrustedCertsCfgmap:     *trustedCertsCfgmap,
+		OverrideAS3Decl:        *overrideAS3Decl,
+		Agent:                  *agent,
+		LogAS3Response:         *logAS3Response,
 	}
 
 	// If running with Flannel, create an event channel that the appManager

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -3,6 +3,13 @@ Release Notes for BIG-IP Controller for Kubernetes
 
 Next Release
 ------------
+
+Added Functionality
+`````````````````````
+* Added new command-line options:
+  - `--manage-ingress-class-only`: A flag whether to handle Ingresses that do not have the class annotation and with annotation `kubernetes.io/ingress.class` set to `f5`. When set to `true`, process ingress resources with `kubernetes.io/ingress.class` set to `f5` or custom ingress class.
+  - `--ingress-class` to define custom ingress class to watch.
+
 Bug Fixes
 `````````
 * Controller handles data group correctly with routes/ingress in multiple namespaces. 

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -894,14 +894,16 @@ var _ = Describe("AppManager Tests", func() {
 			Expect(fakeClient).ToNot(BeNil())
 
 			mockMgr = newMockAppManager(&Params{
-				KubeClient:       fakeClient,
-				ConfigWriter:     mw,
-				restClient:       test.CreateFakeHTTPClient(),
-				RouteClientV1:    fakeRouteClient.NewSimpleClientset().RouteV1(),
-				IsNodePort:       true,
-				broadcasterFunc:  NewFakeEventBroadcaster,
-				ManageConfigMaps: true,
-				ManageIngress:    true,
+				KubeClient:             fakeClient,
+				ConfigWriter:           mw,
+				restClient:             test.CreateFakeHTTPClient(),
+				RouteClientV1:          fakeRouteClient.NewSimpleClientset().RouteV1(),
+				IsNodePort:             true,
+				broadcasterFunc:        NewFakeEventBroadcaster,
+				ManageConfigMaps:       true,
+				ManageIngress:          true,
+				ManageIngressClassOnly: false,
+				IngressClass:           "f5",
 			})
 		})
 		AfterEach(func() {

--- a/pkg/appmanager/eventNotifier_test.go
+++ b/pkg/appmanager/eventNotifier_test.go
@@ -144,13 +144,15 @@ var _ = Describe("Event Notifier Tests", func() {
 			Expect(fakeClient).ToNot(BeNil())
 
 			mockMgr = newMockAppManager(&Params{
-				KubeClient:      fakeClient,
-				ConfigWriter:    mw,
-				restClient:      test.CreateFakeHTTPClient(),
-				RouteClientV1:   fakeRouteClient.NewSimpleClientset().RouteV1(),
-				IsNodePort:      true,
-				ManageIngress:   true,
-				broadcasterFunc: NewFakeEventBroadcaster,
+				KubeClient:             fakeClient,
+				ConfigWriter:           mw,
+				restClient:             test.CreateFakeHTTPClient(),
+				RouteClientV1:          fakeRouteClient.NewSimpleClientset().RouteV1(),
+				IsNodePort:             true,
+				ManageIngress:          true,
+				broadcasterFunc:        NewFakeEventBroadcaster,
+				ManageIngressClassOnly: false,
+				IngressClass:           "f5",
 			})
 			namespaces = []string{"ns0", "ns1", "ns2", "ns3", "ns4", "ns5"}
 			err := mockMgr.startNonLabelMode(namespaces)

--- a/pkg/appmanager/healthMonitors_test.go
+++ b/pkg/appmanager/healthMonitors_test.go
@@ -43,13 +43,15 @@ var _ = Describe("Health Monitor Tests", func() {
 		Expect(fakeClient).ToNot(BeNil())
 
 		mockMgr = newMockAppManager(&Params{
-			KubeClient:      fakeClient,
-			ConfigWriter:    mw,
-			restClient:      test.CreateFakeHTTPClient(),
-			RouteClientV1:   fakeRouteClient.NewSimpleClientset().RouteV1(),
-			IsNodePort:      true,
-			ManageIngress:   true,
-			broadcasterFunc: NewFakeEventBroadcaster,
+			KubeClient:             fakeClient,
+			ConfigWriter:           mw,
+			restClient:             test.CreateFakeHTTPClient(),
+			RouteClientV1:          fakeRouteClient.NewSimpleClientset().RouteV1(),
+			IsNodePort:             true,
+			ManageIngress:          true,
+			broadcasterFunc:        NewFakeEventBroadcaster,
+			ManageIngressClassOnly: false,
+			IngressClass:           "f5",
 		})
 		namespace = "default"
 		err := mockMgr.startNonLabelMode([]string{namespace})

--- a/pkg/appmanager/profiles_test.go
+++ b/pkg/appmanager/profiles_test.go
@@ -49,14 +49,16 @@ var _ = Describe("AppManager Profile Tests", func() {
 			Expect(fakeClient).ToNot(BeNil())
 
 			mockMgr = newMockAppManager(&Params{
-				KubeClient:       fakeClient,
-				ConfigWriter:     mw,
-				restClient:       test.CreateFakeHTTPClient(),
-				RouteClientV1:    fakeRouteClient.NewSimpleClientset().RouteV1(),
-				IsNodePort:       true,
-				broadcasterFunc:  NewFakeEventBroadcaster,
-				ManageConfigMaps: true,
-				ManageIngress:    true,
+				KubeClient:             fakeClient,
+				ConfigWriter:           mw,
+				restClient:             test.CreateFakeHTTPClient(),
+				RouteClientV1:          fakeRouteClient.NewSimpleClientset().RouteV1(),
+				IsNodePort:             true,
+				broadcasterFunc:        NewFakeEventBroadcaster,
+				ManageConfigMaps:       true,
+				ManageIngress:          true,
+				ManageIngressClassOnly: false,
+				IngressClass:           "f5",
 			})
 			namespace = "default"
 			mockMgr.appMgr.routeConfig = RouteConfig{

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -1451,11 +1451,16 @@ func (appMgr *Manager) createRSConfigFromIngress(
 	snatPoolName string,
 ) *ResourceConfig {
 	if class, ok := ing.ObjectMeta.Annotations[k8sIngressClass]; ok == true {
-		if class != "f5" {
+		if class != appMgr.ingressClass {
+			return nil
+		}
+	} else {
+		// at this point we dont have k8sIngressClass defined in Ingress definition.
+		// So check whether we need to process those ingress or not.
+		if appMgr.manageIngressClassOnly {
 			return nil
 		}
 	}
-
 	var cfg ResourceConfig
 	var balance string
 	if bal, ok := ing.ObjectMeta.Annotations[f5VsBalanceAnnotation]; ok == true {

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -606,6 +606,8 @@ var _ = Describe("Resource Config Tests", func() {
 
 			It("properly configures ingress resources", func() {
 				namespace := "default"
+				mockMgr.appMgr.manageIngressClassOnly = false
+				mockMgr.appMgr.ingressClass = "f5"
 				ingressConfig := v1beta1.IngressSpec{
 					Backend: &v1beta1.IngressBackend{
 						ServiceName: "foo",


### PR DESCRIPTION
**Problem:**

[1] CIS watches all `Ingress` resources that either have `kubernetes.io/ingress.class: f5` or that don't have that annotation at all.
In a cluster that has multiple ingress controllers, it ends up with unpredictable results for ingresses that do not specify their class, the different controllers fighting against each other to handle the resource.

[2] CIS processes ingresses with ingress.class defaults to "f5" and there is no option for custom ingress classes.

**Solution:**

New controller deployment options:

- `--manage-ingress-class-only` (default - `false`) is added. when set to `true`, only considers `ingress.class` annotated ingresses. Using the below option, user can configure the controller with custom `ingress.class`. 
-  `--ingress-class` (default - `f5`) is added to enable CIS to process Ingresses with custom ingress.class.

**Build**: somanchit/k8s-bigip-ctlr:ingclass_fix

**Affected Branches**: master

**Release:** 1.13

Fixes #976