### PR TITLE
Reduce object name length for AS3

### DIFF
--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -1409,6 +1409,10 @@ func as3FormatedString(str string, resourceType string) string {
 	default:
 		formattedString = strings.Replace(str, "-", "_", -1)
 	}
+	//Reducing object name length by giving a shortened form of a word.
+	formattedString = strings.ReplaceAll(formattedString, "openshift_route", "osr")
+	formattedString = strings.ReplaceAll(formattedString, "client_ssl", "cssl")
+	formattedString = strings.ReplaceAll(formattedString, "server_ssl", "sssl")
 	return formattedString
 }
 


### PR DESCRIPTION
Problem: AS3 accepts max 64 characters for BIG-IP object name. 
Solution: Need to reduce object name length created by CIS, by using short names instead of complete names that frame the object name.

Image: amit49g/k8s-bigip-ctlr:1287 