### PR TITLE
Performance issue in CIS when simultaneously processing more number of ingress resources

### DIFF
--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -2716,7 +2716,7 @@ var _ = Describe("AppManager Tests", func() {
 					serviceKey{"foo", 80, "default"}, formatIngressVSName("1.2.3.4", 80))
 				Expect(len(rs.Policies[0].Rules)).To(Equal(2))
 				events = mockMgr.getFakeEvents(namespace)
-				Expect(len(events)).To(Equal(8))
+				Expect(len(events)).To(Equal(7))
 
 				mockMgr.deleteIngress(ingress5)
 				Expect(resources.VirtualCount()).To(Equal(1))

--- a/pkg/appmanager/profiles.go
+++ b/pkg/appmanager/profiles.go
@@ -28,7 +28,6 @@ import (
 	routeapi "github.com/openshift/api/route/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type secretKey struct {
@@ -658,10 +657,8 @@ func (appMgr *Manager) checkProfile(
 		*referenced = true
 		// May reference a secret that no longer exists
 		if appMgr.useSecrets {
-			_, err := appMgr.kubeClient.CoreV1().
-				Secrets(namespace).
-				Get(testName, metav1.GetOptions{})
-			if nil != err && !strings.ContainsAny(secretName, "/") {
+			secret := appMgr.IngressSSLCtxt[testName]
+			if secret == nil && !strings.ContainsAny(secretName, "/") {
 				// No secret with this name, and name does not
 				// contain "/", meaning it isn't a valid BIG-IP profile
 				*toRemove = append(*toRemove, prof)


### PR DESCRIPTION
Problem: Ingress resource - Performance problem with a large number of ingresses(git hub issue #1014)

Solution: Optimized the Kubernetes client API calls in CIS while processing Ingress resources

Docker Image: snatra27/k8s-bigip-ctlr:ingress-performance-issue