### PR TITLE
Log unmarshal failed error body and remove default http and tcp profi…

### DIFF
--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -1236,19 +1236,6 @@ func createServiceDecl(cfg *ResourceConfig, sharedApp as3Application) {
 
 	svc.Class = "Service_HTTP"
 
-	for _, prof := range cfg.Virtual.Profiles {
-		switch prof.Name {
-		case "http":
-			svc.ProfileHTTP = as3ResourcePointer{
-				BigIP: fmt.Sprintf("/%s/%s", prof.Partition, prof.Name),
-			}
-		case "tcp":
-			svc.ProfileTCP = as3ResourcePointer{
-				BigIP: fmt.Sprintf("/%s/%s", prof.Partition, prof.Name),
-			}
-		}
-	}
-
 	destination := strings.Split(cfg.Virtual.Destination, "/")
 	ipPort := strings.Split(destination[len(destination)-1], ":")
 	// verify that ip address and port exists else return error.

--- a/pkg/appmanager/as3Types.go
+++ b/pkg/appmanager/as3Types.go
@@ -136,8 +136,6 @@ type (
 		TranslateServerAddress bool              `json:"translateServerAddress,omitempty"`
 		TranslateServerPort    bool              `json:"translateServerPort,omitempty"`
 		Class                  string            `json:"class,omitempty"`
-		ProfileHTTP            as3MultiTypeParam `json:"profileHTTP,omitempty"`
-		ProfileTCP             as3MultiTypeParam `json:"profileTCP,omitempty"`
 		VirtualAddresses       []string          `json:"virtualAddresses,omitempty"`
 		VirtualPort            int               `json:"virtualPort,omitempty"`
 		SNAT                   string            `json:"snat,omitempty"`

--- a/pkg/appmanager/as3Utils.go
+++ b/pkg/appmanager/as3Utils.go
@@ -18,8 +18,9 @@ package appmanager
 import (
 	"encoding/json"
 	"fmt"
-	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
 	"reflect"
+
+	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
 )
 
 func ValidateJSONStringAndFetchObject(jsonData string, jsonObj *map[string]interface{}) error {
@@ -81,7 +82,7 @@ func ValidateAndOverrideAS3JsonData(srcJsonData string, dstJsonData string) stri
 		log.Errorf("[AS3] CIS failed to merge JSON Data !!!: %v", err)
 		return ""
 	}
-
+	log.Debug("[AS3] Unified AS3 declaration is overridden !!!")
 	return string(mergedJsonData)
 }
 

--- a/pkg/postmanager/postManager.go
+++ b/pkg/postmanager/postManager.go
@@ -21,10 +21,11 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
-	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
 	"io/ioutil"
 	"net/http"
 	"time"
+
+	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
 )
 
 const (
@@ -165,6 +166,9 @@ func (postMgr *PostManager) httpPOST(request *http.Request) (*http.Response, map
 	err = json.Unmarshal(body, &response)
 	if err != nil {
 		log.Errorf("[AS3] Response body unmarshal failed: %v\n", err)
+		if postMgr.LogResponse {
+			log.Errorf("[AS3] Raw response from Big-IP: %v", string(body))
+		}
 		return nil, nil
 	}
 	return httpResp, response


### PR DESCRIPTION
Problem: 1. Low visibility of AS3 response error due to JSON unmarshal failed.
2. Override issue with default http and tcp profile of virtual server

Solution: Logging AS3 response error body.
Removing of default HTTP and TCP profile from AS3 declaration (virtual server).

Affected branch: master