### PR TITLE
K8S BIG-IP Controller support K8S 1.16.x release.

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -10,6 +10,8 @@ Added Functionality
   - `--manage-ingress-class-only`: A flag whether to handle Ingresses that do not have the class annotation and with annotation `kubernetes.io/ingress.class` set to `f5`. When set to `true`, process ingress resources with `kubernetes.io/ingress.class` set to `f5` or custom ingress class.
   - `--ingress-class` to define custom ingress class to watch.
   - Controller now pushes configuration after 3 seconds when encounters http response with code 503 from busy BIG-IP.
+* Controller supports Kubernetes 1.16.x release. K8S Ingress (in extension/v1beta1 API group) uses networking/v1beta1 API.
+
 
 Bug Fixes
 `````````

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -33,7 +33,7 @@ import (
 	"github.com/F5Networks/k8s-bigip-ctlr/pkg/writer"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes"
 
@@ -286,7 +286,7 @@ func NewManager(params *Params) *Manager {
 	}
 	if nil != manager.kubeClient && nil == manager.restClientv1beta1 {
 		// This is the normal production case, but need the checks for unit tests.
-		manager.restClientv1beta1 = manager.kubeClient.ExtensionsV1beta1().RESTClient()
+		manager.restClientv1beta1 = manager.kubeClient.NetworkingV1beta1().RESTClient()
 	}
 	return &manager
 }
@@ -2131,7 +2131,7 @@ func (appMgr *Manager) setIngressStatus(
 	} else if ing.Status.LoadBalancer.Ingress[0].IP != ip {
 		ing.Status.LoadBalancer.Ingress[0] = lbIngress
 	}
-	_, updateErr := appMgr.kubeClient.ExtensionsV1beta1().
+	_, updateErr := appMgr.kubeClient.NetworkingV1beta1().
 		Ingresses(ing.ObjectMeta.Namespace).UpdateStatus(ing)
 	if nil != updateErr {
 		// Multi-service causes the controller to try to update the status multiple times
@@ -2229,7 +2229,7 @@ func (appMgr *Manager) resolveIngressHost(ing *v1beta1.Ingress, namespace string
 		ing.ObjectMeta.Annotations = make(map[string]string)
 	}
 	ing.ObjectMeta.Annotations[f5VsBindAddrAnnotation] = ipAddress
-	_, err = appMgr.kubeClient.ExtensionsV1beta1().Ingresses(namespace).Update(ing)
+	_, err = appMgr.kubeClient.NetworkingV1beta1().Ingresses(namespace).Update(ing)
 	if nil != err {
 		msg := fmt.Sprintf("Error while setting virtual-server IP for Ingress '%s': %s",
 			ing.ObjectMeta.Name, err)

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -31,7 +31,7 @@ import (
 	routeapi "github.com/openshift/api/route/v1"
 	fakeRouteClient "github.com/openshift/client-go/route/clientset/versioned/fake"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -318,7 +318,7 @@ func (m *mockAppManager) addIngress(ing *v1beta1.Ingress) bool {
 	ok, keys := m.appMgr.checkValidIngress(ing)
 	if ok {
 		ns := ing.ObjectMeta.Namespace
-		m.appMgr.kubeClient.ExtensionsV1beta1().Ingresses(ns).Create(ing)
+		m.appMgr.kubeClient.NetworkingV1beta1().Ingresses(ns).Create(ing)
 		appInf, _ := m.appMgr.getNamespaceInformer(ns)
 		appInf.ingInformer.GetStore().Add(ing)
 		for _, vsKey := range keys {
@@ -335,11 +335,11 @@ func (m *mockAppManager) updateIngress(ing *v1beta1.Ingress) bool {
 	ok, keys := m.appMgr.checkValidIngress(ing)
 	if ok {
 		ns := ing.ObjectMeta.Namespace
-		_, err := m.appMgr.kubeClient.ExtensionsV1beta1().Ingresses(ns).Update(ing)
+		_, err := m.appMgr.kubeClient.NetworkingV1beta1().Ingresses(ns).Update(ing)
 		if nil != err {
 			// This can happen when an ingress is ignored by checkValidIngress
 			// before, but now has been updated to be accepted.
-			m.appMgr.kubeClient.ExtensionsV1beta1().Ingresses(ns).Create(ing)
+			m.appMgr.kubeClient.NetworkingV1beta1().Ingresses(ns).Create(ing)
 		}
 		appInf, _ := m.appMgr.getNamespaceInformer(ns)
 		appInf.ingInformer.GetStore().Update(ing)
@@ -358,7 +358,7 @@ func (m *mockAppManager) deleteIngress(ing *v1beta1.Ingress) bool {
 	if ok {
 		name := ing.ObjectMeta.Name
 		ns := ing.ObjectMeta.Namespace
-		m.appMgr.kubeClient.ExtensionsV1beta1().Ingresses(ns).Delete(name, nil)
+		m.appMgr.kubeClient.NetworkingV1beta1().Ingresses(ns).Delete(name, nil)
 		appInf, _ := m.appMgr.getNamespaceInformer(ns)
 		appInf.ingInformer.GetStore().Delete(ing)
 		for _, vsKey := range keys {

--- a/pkg/appmanager/eventNotifier.go
+++ b/pkg/appmanager/eventNotifier.go
@@ -20,7 +20,7 @@ import (
 	"sync"
 
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	corev1 "k8s.io/client-go/kubernetes/typed/core/v1"

--- a/pkg/appmanager/eventNotifier_test.go
+++ b/pkg/appmanager/eventNotifier_test.go
@@ -25,7 +25,7 @@ import (
 
 	fakeRouteClient "github.com/openshift/client-go/route/clientset/versioned/fake"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/pkg/appmanager/healthMonitors.go
+++ b/pkg/appmanager/healthMonitors.go
@@ -24,7 +24,7 @@ import (
 
 	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
 
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 )
 
 func (appMgr *Manager) assignHealthMonitorsByPath(

--- a/pkg/appmanager/healthMonitors_test.go
+++ b/pkg/appmanager/healthMonitors_test.go
@@ -25,7 +25,7 @@ import (
 	routeapi "github.com/openshift/api/route/v1"
 	fakeRouteClient "github.com/openshift/client-go/route/clientset/versioned/fake"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 )

--- a/pkg/appmanager/profiles.go
+++ b/pkg/appmanager/profiles.go
@@ -27,7 +27,7 @@ import (
 
 	routeapi "github.com/openshift/api/route/v1"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 

--- a/pkg/appmanager/profiles_test.go
+++ b/pkg/appmanager/profiles_test.go
@@ -27,7 +27,7 @@ import (
 	routeapi "github.com/openshift/api/route/v1"
 	fakeRouteClient "github.com/openshift/client-go/route/clientset/versioned/fake"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -34,7 +34,7 @@ import (
 	routeapi "github.com/openshift/api/route/v1"
 	"github.com/xeipuuv/gojsonschema"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/tools/cache"
 )

--- a/pkg/appmanager/resourceConfig_test.go
+++ b/pkg/appmanager/resourceConfig_test.go
@@ -25,7 +25,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	routeapi "github.com/openshift/api/route/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -29,7 +29,7 @@ import (
 	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
 
 	routeapi "github.com/openshift/api/route/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 )
 
 const httpRedirectIRuleName = "http_redirect_irule"

--- a/pkg/appmanager/validateResources.go
+++ b/pkg/appmanager/validateResources.go
@@ -21,7 +21,7 @@ import (
 
 	routeapi "github.com/openshift/api/route/v1"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 )
 
 func (appMgr *Manager) checkValidConfigMap(

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -29,7 +29,7 @@ import (
 
 	routeapi "github.com/openshift/api/route/v1"
 	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	"k8s.io/api/networking/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -142,7 +142,7 @@ func NewIngress(id, rv, namespace string,
 	return &v1beta1.Ingress{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Ingress",
-			APIVersion: "extensions/v1beta1",
+			APIVersion: "networking/v1beta1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            id,


### PR DESCRIPTION
Problem: CIS is not compatible with K8S 1.16.x and above release.

Solution: Update CIS to use networking/v1beta1 for extensions/v1beta1.

Branches affected : master

Release: 1.13

Docker build: somanchit/k8s-bigip-ctlr:k8s1162_update