### PR TITLE
Fix CIS allows userDefinedConfigmap with CIS managed Partition as Tenant

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -15,6 +15,7 @@ Added Functionality
 Bug Fixes
 `````````
 * Controller handles data group correctly with routes/ingress in multiple namespaces.
+* Controller now does not allow userDefinedConfigmap with contoller managed partitions as tenants.
 
 1.12.0
 ------------

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -78,6 +78,25 @@ func (appMgr *Manager) processUserDefinedAS3(template string) bool {
 		return false
 	}
 
+	_, found := obj[tenantName(DEFAULT_PARTITION)]
+	switch appMgr.Agent {
+	case "as3":
+		_, foundNetworkPartition := obj[tenantName(strings.TrimSuffix(DEFAULT_PARTITION, "_AS3"))]
+		if found || foundNetworkPartition {
+			log.Error("[AS3] Error in processing the template")
+			log.Errorf("[AS3] CIS managed partitions <%s> and <%s> should not be used in ConfigMap as Tenants\n",
+				DEFAULT_PARTITION, strings.TrimSuffix(DEFAULT_PARTITION, "_AS3"))
+			return false
+		}
+	default:
+		if found {
+			log.Error("[AS3] Error in processing the template")
+			log.Errorf("[AS3] CIS managed partition <%s> should not be used in ConfigMap as Tenants\n",
+				DEFAULT_PARTITION)
+			return false
+		}
+	}
+
 	buffer = make(map[Member]struct{}, 0)
 	epbuffer = make(map[string]struct{}, 0)
 


### PR DESCRIPTION
Problem: CIS allows userDefinedConfigmap with CIS managed partition as tenant, which causes declaration to be pushed to Networking partition.

Solution: Do not process userDefinedConfigmap if it has a CIS managed partition as tenant.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>