### PR TITLE
Add error handler for code 404

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -9,8 +9,9 @@ Added Functionality
 * Added new command-line options:
   - `--manage-ingress-class-only`: A flag whether to handle Ingresses that do not have the class annotation and with annotation `kubernetes.io/ingress.class` set to `f5`. When set to `true`, process ingress resources with `kubernetes.io/ingress.class` set to `f5` or custom ingress class.
   - `--ingress-class` to define custom ingress class to watch.
-  - Controller now pushes configuration after 3 seconds when encounters http response with code 503 from busy BIG-IP.
-  - Controller now complies with BIG-IP to filter out tenants, with `--filter-tenants` option.
+* Controller now pushes configuration after 3 seconds when encounters http response with code 503 from busy BIG-IP.
+* Controller now complies with BIG-IP to filter out tenants, with `--filter-tenants` option.
+* Controller now does not push configuration if it encounters response code 404 from BIG-IP
 
 Bug Fixes
 `````````

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -19,12 +19,12 @@ package appmanager
 import (
 	"encoding/json"
 	"fmt"
-	routeapi "github.com/openshift/api/route/v1"
 	"strconv"
 	"strings"
 	"time"
 
 	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
+	routeapi "github.com/openshift/api/route/v1"
 	"github.com/xeipuuv/gojsonschema"
 	v1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"

--- a/pkg/postmanager/postManager.go
+++ b/pkg/postmanager/postManager.go
@@ -166,6 +166,8 @@ func (postMgr *PostManager) postConfig(cfg config) bool {
 		return postMgr.handleResponseStatusOK(responseMap, cfg)
 	case http.StatusServiceUnavailable:
 		return postMgr.handleResponseStatusServiceUnavailable(cfg)
+	case http.StatusNotFound:
+		return postMgr.handleResponseStatusNotFound(responseMap)
 	default:
 		return postMgr.handleResponseOthers(responseMap, cfg)
 	}
@@ -213,6 +215,14 @@ func (postMgr *PostManager) handleResponseStatusOK(responseMap map[string]interf
 func (postMgr *PostManager) handleResponseStatusServiceUnavailable(cfg config) bool {
 	log.Debugf("[AS3] Response from BIG-IP: BIG-IP is busy, waiting %v seconds and re-posting the declaration", timeoutSmall)
 	return postMgr.postOnEventOrTimeout(timeoutSmall, cfg)
+}
+
+func (postMgr *PostManager) handleResponseStatusNotFound(responseMap map[string]interface{}) bool {
+	log.Errorf("[AS3] Big-IP Responded with error code: %v", responseMap["code"])
+	if postMgr.LogResponse {
+		log.Errorf("[AS3] Raw response from Big-IP: %v ", responseMap)
+	}
+	return true
 }
 
 func (postMgr *PostManager) handleResponseOthers(responseMap map[string]interface{}, cfg config) bool {


### PR DESCRIPTION
Problem: Controller pushes config to BIG-IP after 30 seconds if encounters 404 code on previous request. 

Solution: Controller does not push configuration if it encounters code 404 on previous request.
Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>