### PR TITLE
Fix for multiple ingress message requests to BIG-IP

### DIFF
--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -2716,7 +2716,7 @@ var _ = Describe("AppManager Tests", func() {
 					serviceKey{"foo", 80, "default"}, formatIngressVSName("1.2.3.4", 80))
 				Expect(len(rs.Policies[0].Rules)).To(Equal(2))
 				events = mockMgr.getFakeEvents(namespace)
-				Expect(len(events)).To(Equal(7))
+				Expect(len(events)).To(Equal(8))
 
 				mockMgr.deleteIngress(ingress5)
 				Expect(resources.VirtualCount()).To(Equal(1))

--- a/pkg/appmanager/profiles.go
+++ b/pkg/appmanager/profiles.go
@@ -657,7 +657,7 @@ func (appMgr *Manager) checkProfile(
 		*referenced = true
 		// May reference a secret that no longer exists
 		if appMgr.useSecrets {
-			secret := appMgr.IngressSSLCtxt[testName]
+			secret := appMgr.rsrcSSLCtxt[testName]
 			if secret == nil && !strings.ContainsAny(secretName, "/") {
 				// No secret with this name, and name does not
 				// contain "/", meaning it isn't a valid BIG-IP profile

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -1692,7 +1692,7 @@ func (appMgr *Manager) handleIngressTls(
 		for _, tls := range ing.Spec.TLS {
 			// Check if profile is contained in a Secret
 			if appMgr.useSecrets {
-				secret := appMgr.IngressSSLCtxt[tls.SecretName]
+				secret := appMgr.rsrcSSLCtxt[tls.SecretName]
 				if secret == nil {
 					// No secret, so we assume the profile is a BIG-IP default
 					log.Debugf("No Secret with name '%s' in namespace '%s', "+


### PR DESCRIPTION
Problem: Multiple messages are posted to BIG-IP while ingress resources deployed

Solution: This is introduced as part if the performance specific changes, this issue is fixed after reverting specific code in performance feature

Build-Image: snatra27/k8s-bigip-ctlr:v1.13.0_rel_build_3 
