### PR TITLE
Interval based post AS3 declaration to bigip.

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -113,6 +113,7 @@ var (
 	credsDir           *string
 	as3Validation      *bool
 	sslInsecure        *bool
+	as3PostInterval    *int
 	trustedCertsCfgmap *string
 	agent              *string
 	logAS3Response     *bool
@@ -189,6 +190,8 @@ func _init() {
 		"Optional, when set to false, disables as3 template validation on the controller.")
 	sslInsecure = bigIPFlags.Bool("insecure", false,
 		"Optional, when set to true, enable insecure SSL communication to BIGIP.")
+	as3PostInterval = bigIPFlags.Int("as3-post-interval", 0,
+		"Optional, interval (in seconds) at which to post the AS3 declaration.")
 	logAS3Response = bigIPFlags.Bool("log-as3-response", false,
 		"Optional, when set to true, add the body of AS3 API response in Controller logs.")
 	trustedCertsCfgmap = bigIPFlags.String("trusted-certs-cfgmap", "",
@@ -675,6 +678,7 @@ func main() {
 		IngressClass:           *ingressClass,
 		SchemaLocal:            *schemaLocal,
 		AS3Validation:          *as3Validation,
+		AS3PostInterval:        *as3PostInterval,
 		TrustedCertsCfgmap:     *trustedCertsCfgmap,
 		OverrideAS3Decl:        *overrideAS3Decl,
 		Agent:                  *agent,
@@ -762,13 +766,14 @@ func main() {
 
 	// Create PostManager to POST configuration to BIG-IP using AS3
 	var postMgrParams = postmanager.Params{
-		BIGIPUsername: *bigIPUsername,
-		BIGIPPassword: *bigIPPassword,
-		BIGIPURL:      *bigIPURL,
-		TrustedCerts:  appMgr.GetBIGIPTrustedCerts(),
-		SSLInsecure:   *sslInsecure,
-		LogResponse:   *logAS3Response,
-		RouteClientV1: appMgrParms.RouteClientV1,
+		BIGIPUsername:   *bigIPUsername,
+		BIGIPPassword:   *bigIPPassword,
+		BIGIPURL:        *bigIPURL,
+		TrustedCerts:    appMgr.GetBIGIPTrustedCerts(),
+		SSLInsecure:     *sslInsecure,
+		AS3PostInterval: *as3PostInterval,
+		LogResponse:     *logAS3Response,
+		RouteClientV1:   appMgrParms.RouteClientV1,
 	}
 	appMgr.PostManager = postmanager.NewPostManager(postMgrParams)
 

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -19,7 +19,6 @@ package appmanager
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/F5Networks/k8s-bigip-ctlr/pkg/postmanager"
 	"net"
 	"reflect"
 	"sort"
@@ -27,6 +26,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/F5Networks/k8s-bigip-ctlr/pkg/postmanager"
 
 	bigIPPrometheus "github.com/F5Networks/k8s-bigip-ctlr/pkg/prometheus"
 	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
@@ -148,6 +149,7 @@ type AS3Manager struct {
 	as3Members         map[Member]struct{}
 	as3Validation      bool
 	sslInsecure        bool
+	as3PostInterval    int
 	trustedCertsCfgmap string
 	// Active User Defined ConfigMap details
 	as3ActiveConfig AS3Config
@@ -217,6 +219,7 @@ type Params struct {
 	IngressClass           string
 	AS3Validation          bool
 	SSLInsecure            bool
+	AS3PostInterval        int
 	TrustedCertsCfgmap     string
 	Agent                  string
 	OverrideAS3Decl        string
@@ -280,6 +283,7 @@ func NewManager(params *Params) *Manager {
 			as3Members:         make(map[Member]struct{}, 0),
 			as3Validation:      params.AS3Validation,
 			sslInsecure:        params.SSLInsecure,
+			as3PostInterval:    params.AS3PostInterval,
 			trustedCertsCfgmap: params.TrustedCertsCfgmap,
 			OverrideAS3Decl:    params.OverrideAS3Decl,
 			intF5Res:           make(map[string]InternalF5Resources),


### PR DESCRIPTION
Problem:  New feature added. We have a configurable and optional interval (in seconds) after which to post the AS3 declaration. 
Resolved: CIS is blocked when multiple resources change happens that causes multiple declarations posting to BIG-IP

Solution: Implemented configurable interval-based post mechanism to post declaration and changed post manager goroutine unbuffered channel to buffered channel.  

 New flags added: 
  - --as3-post-interval=<int>. : Optional, interval (in seconds) at which to post AS3 declaration.
                

Affected branch: master

Image: amit49g/k8s-bigip-ctlr:as3PostInterval