### PR TITLE
Fix Route Admit Status issue

### DIFF
--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
-	routeapi "github.com/openshift/api/route/v1"
 	"github.com/xeipuuv/gojsonschema"
 	v1 "k8s.io/api/core/v1"
 	metaV1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -434,19 +433,20 @@ func (appMgr *Manager) postAS3Config(tempAS3Config AS3Config) {
 	appMgr.as3ActiveConfig.updateConfig(tempAS3Config)
 
 	var tenants []string = nil
-	var routes []*routeapi.Route
+	routesMap := make(RoutesMap)
 	if appMgr.FilterTenants {
 		tenants = appMgr.getTenants(unifiedDecl)
 	}
 	if appMgr.routeClientV1 != nil {
-		for _, route := range appMgr.RoutesProcessed {
-			routes = append(routes, route)
+		// Send a copy of RoutesProcessed to PostManager as appMgr.RoutesProcessed might change before postmanager processes it
+		for k, v := range appMgr.RoutesProcessed {
+			routesMap[k] = v
 		}
 	}
 	appMgr.PostManager.Write(
 		string(unifiedDecl),
 		tenants,
-		routes,
+		routesMap,
 	)
 }
 

--- a/pkg/postmanager/postManager.go
+++ b/pkg/postmanager/postManager.go
@@ -27,7 +27,6 @@ import (
 	"time"
 
 	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
-	routeapi "github.com/openshift/api/route/v1"
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 )
 
@@ -57,7 +56,7 @@ type Params struct {
 
 type config struct {
 	data      string
-	routes    []*routeapi.Route
+	routesMap map[string][]string
 	as3APIURL string
 }
 
@@ -111,11 +110,11 @@ func (postMgr *PostManager) getAS3APIURL(tenants []string) string {
 func (postMgr *PostManager) Write(
 	data string,
 	partitions []string,
-	routes []*routeapi.Route,
+	routesMap map[string][]string,
 ) {
 	activeConfig := config{
 		data:      data,
-		routes:    routes,
+		routesMap: routesMap,
 		as3APIURL: postMgr.getAS3APIURL(partitions),
 	}
 	postMgr.postChan <- activeConfig
@@ -207,7 +206,7 @@ func (postMgr *PostManager) handleResponseStatusOK(responseMap map[string]interf
 		log.Debugf("[AS3] Response from BIG-IP: code: %v --- tenant:%v --- message: %v", v["code"], v["tenant"], v["message"])
 	}
 	if postMgr.RouteClientV1 != nil {
-		postMgr.updateRouteAdmitStatus(cfg.routes)
+		postMgr.updateRouteAdmitStatus(cfg.routesMap)
 	}
 	return true
 }


### PR DESCRIPTION
Problem: Route status is not being updated because of default router updates the status and makes CIS to fail to update the status. And internal DS are being overridden that leads to inconsistent behaviour of Status update.

Solution: Always get routes before updating the status instead of cached ones. Maintain internal DS properly.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>