### PR TITLE
Add post delay time

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -113,6 +113,7 @@ var (
 	credsDir           *string
 	as3Validation      *bool
 	sslInsecure        *bool
+	as3PostDelay       *int
 	trustedCertsCfgmap *string
 	agent              *string
 	logAS3Response     *bool
@@ -189,6 +190,8 @@ func _init() {
 		"Optional, when set to false, disables as3 template validation on the controller.")
 	sslInsecure = bigIPFlags.Bool("insecure", false,
 		"Optional, when set to true, enable insecure SSL communication to BIGIP.")
+	as3PostDelay = bigIPFlags.Int("as3-post-delay", 0,
+		"Optional, time (in seconds) that CIS waits to post the available AS3 declaration.")
 	logAS3Response = bigIPFlags.Bool("log-as3-response", false,
 		"Optional, when set to true, add the body of AS3 API response in Controller logs.")
 	trustedCertsCfgmap = bigIPFlags.String("trusted-certs-cfgmap", "",
@@ -767,6 +770,7 @@ func main() {
 		BIGIPURL:      *bigIPURL,
 		TrustedCerts:  appMgr.GetBIGIPTrustedCerts(),
 		SSLInsecure:   *sslInsecure,
+		AS3PostDelay:  *as3PostDelay,
 		LogResponse:   *logAS3Response,
 		RouteClientV1: appMgrParms.RouteClientV1,
 	}

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -19,7 +19,6 @@ package appmanager
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/F5Networks/k8s-bigip-ctlr/pkg/postmanager"
 	"net"
 	"reflect"
 	"sort"
@@ -28,6 +27,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/F5Networks/k8s-bigip-ctlr/pkg/postmanager"
 	bigIPPrometheus "github.com/F5Networks/k8s-bigip-ctlr/pkg/prometheus"
 	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
 	"github.com/F5Networks/k8s-bigip-ctlr/pkg/writer"


### PR DESCRIPTION
Problem: Continuously posting new declaration to BIG-IP without much delay leading to 503 response from BIG-IP as AS3 is busy in performing earlier requests

Solution: Delay the post call to BIG-IP with given number of seconds through CIS config parameter, let the CIS to produce all the declarations with out blocking for BIG-IP response and after the delay ends pick up the latest declaration produced and post, so that CIS will not do many post calls.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>