### PR TITLE
Fix Delete AS3 partition declaration schema validation failure

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -776,11 +776,11 @@ func main() {
 	}
 	appMgr.PostManager = postmanager.NewPostManager(postMgrParams)
 
-	// Delete as3 managed partition when switching back to agent cccl from as3
-	appMgr.DeleteCISManagedPartition()
-
 	// AS3 schema validation using latest AS3 version
 	fetchAS3Schema(appMgr)
+
+	// Delete as3 managed partition when switching back to agent cccl from as3
+	appMgr.DeleteCISManagedPartition()
 
 	GetNamespaces(appMgr)
 	intervalFactor := time.Duration(*nodePollInterval)


### PR DESCRIPTION
Problem: CIS is unable to delete AS3 partition when deployed in CCCL due to schema validation is failing for the AS3 declaration

Root Cause: AS3 schema is not fetched by the time as3 delete partition is triggered.

Solution: Fetch AS3 schema before triggering delete as3 partition.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>