### PR TITLE
Remove Header in Release Notes

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,13 +1,10 @@
 Release Notes for BIG-IP Controller for Kubernetes
 ==================================================
 
-Next Release
-------------
-
 1.13.0
-------------
+------
 Added Functionality
-`````````````````````
+```````````````````
 * CIS supports Kubernetes 1.16.2.
     - | Update CIS deployment, `apiVersion` to `apps/v1` and add `spec.selector.matchLabels.app` to match `spec.template.metadata.labels.app`.
 * Added new command-line options:


### PR DESCRIPTION
**Problem:** [1.13 Release notes](https://clouddocs.f5.com/products/connectors/k8s-bigip-ctlr/v1.13/RELEASE-NOTES.html) is carrying "next release" header.

**Solution:** Removed excess header.

**Affected Branches:** 1.13-stable

**Signed-off-by:** Surendhar <surendhar@ymail.com>