### PR TITLE
Fix Ingress SSL redirect when virtual-server.f5.com/http-port is not 80

### DIFF
--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -360,7 +360,7 @@ func httpRedirectIRule(port int32) string {
 	iRuleCode := fmt.Sprintf(`
 		when HTTP_REQUEST {
 			# Look for exact match for combination of host name and path
-			set host [HTTP::host]
+			set host [getfield [HTTP::host] ":" 1]
 			set path [HTTP::path]
 			append host $path
 			# Find the number of "/" in the hostpath


### PR DESCRIPTION
Problem:

when virtual-server.f5.com/http-port is configured with different port
other than port 80, Ingress SSL redirect would fail because httpRedirectIRule
would set host variable in form of www.example.com:8080 for example,
but in datagroup https_redirect_dg, only hostname www.example.com exist,
thus iRule class match would fail and result in no SSL redirect

Example Ingress yaml:
<pre>
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
  name: single-service
  annotations:
     ingress.kubernetes.io/ssl-redirect: "true"
     ingress.kubernetes.io/allow-http: "false"
     ingress.kubernetes.io/allow-https: "true"
     kubernetes.io/ingress.class: f5
     'virtual-server.f5.com/ip': '10.169.72.169'
     'virtual-server.f5.com/http-port': '8080'
spec:
  tls:
  - hosts:
    - www.example.com
    secretName: Common/clientssl
  rules:
   - host: www.example.com
     http:
       paths:
       - path: /
         backend:
            serviceName: nginxservice
            servicePort: 80
</pre>

Example https_redirect_dg
<pre>
ltm data-group internal /k3s_AS3/Shared/https_redirect_dg {
    records {
        www.example.com/ {
            data /
        }
    }
    type string
}
</pre>

Solution:

Host variable in httpRedirectIRule only get host as
www.example.com, not www.example.com:8080