### PR TITLE
Fix Edge Route Redirect issue with WAF

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1669,7 +1669,8 @@ func (appMgr *Manager) affectedVirtuals(route *routeapi.Route) virtuals {
 	if route.Spec.TLS != nil {
 		v = HTTPS
 
-		if route.Spec.TLS.InsecureEdgeTerminationPolicy == routeapi.InsecureEdgeTerminationPolicyAllow {
+		if route.Spec.TLS.InsecureEdgeTerminationPolicy == routeapi.InsecureEdgeTerminationPolicyAllow ||
+			route.Spec.TLS.InsecureEdgeTerminationPolicy == routeapi.InsecureEdgeTerminationPolicyRedirect {
 			v = HTTPANDS
 		}
 	}

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -2056,6 +2056,8 @@ func (appMgr *Manager) handleRouteRules(
 					}
 					svcFwdRulesMap.AddEntry(route.ObjectMeta.Namespace, route.Spec.To.Name,
 						route.Spec.Host, path)
+					rc.AddRuleToPolicy(policyName, rule)
+					setAnnotationRulesForRoute(policyName, virtualName, poolName, urlRewriteRule, appRootRules, rc, appMgr)
 				}
 			}
 		}


### PR DESCRIPTION
Problem: Edge Redirect Route is not working with combination of Edge Allow Route or insecure Route.

Root Cause: Edge Redirect route doesn't have a policy in http virtual, which is needed by WAF to decide to drop or allow a request to virtual.

Solution: Add a policy to http virtual, in case of Edge Redirect Route, so that the policy will be consumed by WAF later, so that traffic reaches http virtual and eventually gets redirected to https virtual

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>