### PR TITLE
Adding TLSv1.3 support to TLS_Server profile

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -106,19 +106,22 @@ var (
 	manageIngressClassOnly *bool
 	ingressClass           *string
 
-	bigIPURL           *string
-	bigIPUsername      *string
-	bigIPPassword      *string
-	bigIPPartitions    *[]string
-	credsDir           *string
-	as3Validation      *bool
-	sslInsecure        *bool
-	as3PostDelay       *int
-	trustedCertsCfgmap *string
-	agent              *string
-	logAS3Response     *bool
-	overrideAS3Decl    *string
-	filterTenants      *bool
+	bigIPURL                  *string
+	bigIPUsername             *string
+	bigIPPassword             *string
+	bigIPPartitions           *[]string
+	credsDir                  *string
+	as3Validation             *bool
+	sslInsecure               *bool
+	enableTLS                 *string
+	tls13CipherGroupReference *string
+	ciphers                   *string
+	as3PostDelay              *int
+	trustedCertsCfgmap        *string
+	agent                     *string
+	logAS3Response            *bool
+	overrideAS3Decl           *string
+	filterTenants             *bool
 
 	vxlanMode        string
 	openshiftSDNName *string
@@ -194,6 +197,11 @@ func _init() {
 		"Optional, time (in seconds) that CIS waits to post the available AS3 declaration.")
 	logAS3Response = bigIPFlags.Bool("log-as3-response", false,
 		"Optional, when set to true, add the body of AS3 API response in Controller logs.")
+	enableTLS = bigIPFlags.String("tls-version", "1.2",
+		"Optional, Configure TLS version to be enabled on BIG-IP. TLS1.3 is only supported in tmos version 14.0+.")
+	tls13CipherGroupReference = bigIPFlags.String("cipher-group", "/Common/f5-default",
+		"Optional, Configures a Cipher Group in BIG-IP and reference it here. cipher-group and ciphers are mutually exclusive, only use one.")
+	ciphers = bigIPFlags.String("ciphers", "DEFAULT", "Optional, Configures a ciphersuite selection string. cipher-group and ciphers are mutually exclusive, only use one.")
 	trustedCertsCfgmap = bigIPFlags.String("trusted-certs-cfgmap", "",
 		"Optional, when certificates are provided, adds them to controller’s trusted certificate store.")
 	// TODO: Rephrase agent functionality
@@ -663,25 +671,28 @@ func main() {
 	}
 
 	var appMgrParms = appmanager.Params{
-		ConfigWriter:           configWriter,
-		UseNodeInternal:        *useNodeInternal,
-		IsNodePort:             isNodePort,
-		RouteConfig:            routeConfig,
-		NodeLabelSelector:      *nodeLabelSelector,
-		ResolveIngress:         *resolveIngNames,
-		DefaultIngIP:           *defaultIngIP,
-		VsSnatPoolName:         *vsSnatPoolName,
-		UseSecrets:             *useSecrets,
-		ManageConfigMaps:       *manageConfigMaps,
-		ManageIngress:          *manageIngress,
-		ManageIngressClassOnly: *manageIngressClassOnly,
-		IngressClass:           *ingressClass,
-		SchemaLocal:            *schemaLocal,
-		AS3Validation:          *as3Validation,
-		TrustedCertsCfgmap:     *trustedCertsCfgmap,
-		OverrideAS3Decl:        *overrideAS3Decl,
-		Agent:                  *agent,
-		FilterTenants:          *filterTenants,
+		ConfigWriter:              configWriter,
+		UseNodeInternal:           *useNodeInternal,
+		IsNodePort:                isNodePort,
+		RouteConfig:               routeConfig,
+		NodeLabelSelector:         *nodeLabelSelector,
+		ResolveIngress:            *resolveIngNames,
+		DefaultIngIP:              *defaultIngIP,
+		VsSnatPoolName:            *vsSnatPoolName,
+		UseSecrets:                *useSecrets,
+		ManageConfigMaps:          *manageConfigMaps,
+		ManageIngress:             *manageIngress,
+		ManageIngressClassOnly:    *manageIngressClassOnly,
+		IngressClass:              *ingressClass,
+		SchemaLocal:               *schemaLocal,
+		AS3Validation:             *as3Validation,
+		EnableTLS:                 *enableTLS,
+		TLS13CipherGroupReference: *tls13CipherGroupReference,
+		Ciphers:                   *ciphers,
+		TrustedCertsCfgmap:        *trustedCertsCfgmap,
+		OverrideAS3Decl:           *overrideAS3Decl,
+		Agent:                     *agent,
+		FilterTenants:             *filterTenants,
 	}
 
 	// If running with Flannel, create an event channel that the appManager

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -146,10 +146,13 @@ type Manager struct {
 
 // AS3Manager holds all the AS3 orchestration specific Data
 type AS3Manager struct {
-	as3Members         map[Member]struct{}
-	as3Validation      bool
-	sslInsecure        bool
-	trustedCertsCfgmap string
+	as3Members                map[Member]struct{}
+	as3Validation             bool
+	sslInsecure               bool
+	enableTLS                 string
+	tls13CipherGroupReference string
+	ciphers                   string
+	trustedCertsCfgmap        string
 	// Active User Defined ConfigMap details
 	as3ActiveConfig AS3Config
 	// List of Watched Endpoints for user-defined AS3
@@ -208,21 +211,24 @@ type Params struct {
 	UseSecrets        bool
 	EventChan         chan interface{}
 	// Package local for unit testing only
-	restClient             rest.Interface
-	steadyState            bool
-	broadcasterFunc        NewBroadcasterFunc
-	SchemaLocal            string
-	ManageConfigMaps       bool
-	ManageIngress          bool
-	ManageIngressClassOnly bool
-	IngressClass           string
-	AS3Validation          bool
-	SSLInsecure            bool
-	TrustedCertsCfgmap     string
-	Agent                  string
-	OverrideAS3Decl        string
-	SchemaLocalPath        string
-	FilterTenants          bool
+	restClient                rest.Interface
+	steadyState               bool
+	broadcasterFunc           NewBroadcasterFunc
+	SchemaLocal               string
+	ManageConfigMaps          bool
+	ManageIngress             bool
+	ManageIngressClassOnly    bool
+	IngressClass              string
+	AS3Validation             bool
+	SSLInsecure               bool
+	EnableTLS                 string
+	TLS13CipherGroupReference string
+	Ciphers                   string
+	TrustedCertsCfgmap        string
+	Agent                     string
+	OverrideAS3Decl           string
+	SchemaLocalPath           string
+	FilterTenants             bool
 }
 
 // Configuration options for Routes in OpenShift
@@ -278,15 +284,18 @@ func NewManager(params *Params) *Manager {
 		Agent:                  getValidAgent(params.Agent),
 		rsrcSSLCtxt:            make(map[string]*v1.Secret),
 		AS3Manager: AS3Manager{
-			as3Members:         make(map[Member]struct{}, 0),
-			as3Validation:      params.AS3Validation,
-			sslInsecure:        params.SSLInsecure,
-			trustedCertsCfgmap: params.TrustedCertsCfgmap,
-			OverrideAS3Decl:    params.OverrideAS3Decl,
-			intF5Res:           make(map[string]InternalF5Resources),
-			SchemaLocalPath:    params.SchemaLocal,
-			RoutesProcessed:    make(RoutesMap),
-			FilterTenants:      params.FilterTenants,
+			as3Members:                make(map[Member]struct{}, 0),
+			as3Validation:             params.AS3Validation,
+			sslInsecure:               params.SSLInsecure,
+			enableTLS:                 params.EnableTLS,
+			tls13CipherGroupReference: params.TLS13CipherGroupReference,
+			ciphers:                   params.Ciphers,
+			trustedCertsCfgmap:        params.TrustedCertsCfgmap,
+			OverrideAS3Decl:           params.OverrideAS3Decl,
+			intF5Res:                  make(map[string]InternalF5Resources),
+			SchemaLocalPath:           params.SchemaLocal,
+			RoutesProcessed:           make(RoutesMap),
+			FilterTenants:             params.FilterTenants,
 		},
 	}
 	if nil != manager.kubeClient && nil == manager.restClientv1 {

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -893,7 +893,7 @@ func (appMgr *Manager) processCustomProfilesForAS3(sharedApp as3Application) {
 		if svcName == "" {
 			continue
 		}
-		if ok := createUpdateTLSServer(prof, svcName, sharedApp); ok {
+		if ok := appMgr.createUpdateTLSServer(prof, svcName, sharedApp); ok {
 			// Create Certificate only if the corresponding TLSServer is created
 			createCertificateDecl(prof, sharedApp)
 		} else {
@@ -1423,7 +1423,7 @@ func createCertificateDecl(prof CustomProfile, sharedApp as3Application) {
 }
 
 // createUpdateTLSServer creates a new TLSServer instance or updates if one exists already
-func createUpdateTLSServer(prof CustomProfile, svcName string, sharedApp as3Application) bool {
+func (appMgr *Manager) createUpdateTLSServer(prof CustomProfile, svcName string, sharedApp as3Application) bool {
 	// A TLSServer profile needs to carry both Certificate and Key
 	if "" != prof.Cert && "" != prof.Key {
 		svc := sharedApp[svcName].(*as3Service)
@@ -1448,6 +1448,14 @@ func createUpdateTLSServer(prof CustomProfile, svcName string, sharedApp as3Appl
 				Certificate: certName,
 			},
 		)
+		if appMgr.enableTLS == "1.2" {
+			tlsServer.Ciphers = appMgr.ciphers
+		} else if appMgr.enableTLS == "1.3" {
+			tlsServer.Tls1_3Enabled = true
+			tlsServer.CipherGroup = &as3ResourcePointer{
+				BigIP: appMgr.tls13CipherGroupReference,
+			}
+		}
 		return true
 	}
 	return false

--- a/pkg/appmanager/as3Types.go
+++ b/pkg/appmanager/as3Types.go
@@ -183,8 +183,11 @@ type (
 
 	// as3TLSServer maps to TLS_Server in AS3 Resources
 	as3TLSServer struct {
-		Class        string                     `json:"class,omitempty"`
-		Certificates []as3TLSServerCertificates `json:"certificates,omitempty"`
+		Class         string                     `json:"class,omitempty"`
+		Certificates  []as3TLSServerCertificates `json:"certificates,omitempty"`
+		Ciphers       string                     `json:"ciphers,omitempty"`
+		CipherGroup   *as3ResourcePointer        `json:"cipherGroup,omitempty"`
+		Tls1_3Enabled bool                       `json:"tls1_3Enabled,omitempty"`
 	}
 
 	// as3TLSServerCertificates maps to TLS_Server_certificates in AS3 Resources


### PR DESCRIPTION
Feature: Adding TLSv1.3 support to TLS_Server profile using AS3
Created 3 deployment flag to support TLS 1.3 and for TLS 1.2 gave provision to set ciphers.
1. --tls-version=<1.2 or 1.3>
2. --cipher-group=/Common/f5-default
3. --ciphers=ECDHE_ECDSA:ECDHE
For TLS 1.3 need to set cipher-group 
For TLS 1.2 need to set ciphers
Note:  - AS3 only supports TLS 1.3 in tmos version 14.0+.
           - ciphers and cipher-group are mutually exclusive, only use one.

affected-branch: master
Signed-off-by: Amit Gupta amit0658@gmail.com