### PR TITLE
Removing the trailing slash created for datagroup entries

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1520,6 +1520,7 @@ func (appMgr *Manager) syncRoutes(
 					hostName := route.Spec.Host
 					path := route.Spec.Path
 					sslPath := hostName + path
+					sslPath = strings.TrimSuffix(sslPath, "/")
 					updateDataGroup(dgMap, edgeServerSslDgName,
 						DEFAULT_PARTITION, sKey.Namespace, sslPath, serverSsl)
 
@@ -1532,6 +1533,7 @@ func (appMgr *Manager) syncRoutes(
 					hostName := route.Spec.Host
 					path := route.Spec.Path
 					sslPath := hostName + path
+					sslPath = strings.TrimSuffix(sslPath, "/")
 					if "" != serverSsl {
 						updateDataGroup(dgMap, reencryptServerSslDgName,
 							DEFAULT_PARTITION, sKey.Namespace, sslPath, serverSsl)

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -602,7 +602,6 @@ func (appMgr *Manager) sslPassthroughIRule() string {
 		when CLIENTSSL_DATA {
             set sslpath [lindex [SSL::payload] 1]
             set routepath ""
-	    set dflt_pool ""
             
             if { [info exists tls_servername] } {
 				set servername_lower [string tolower $tls_servername]
@@ -773,6 +772,7 @@ func updateDataGroupForReencryptRoute(
 	hostName := route.Spec.Host
 	path := route.Spec.Path
 	routePath := hostName + path
+	routePath = strings.TrimSuffix(routePath, "/")
 	svcName := getRouteCanonicalServiceName(route)
 	poolName := formatRoutePoolName(route.ObjectMeta.Namespace, svcName)
 	updateDataGroup(dgMap, reencryptHostsDgName,
@@ -792,6 +792,7 @@ func updateDataGroupForEdgeRoute(
 	hostName := route.Spec.Host
 	path := route.Spec.Path
 	routePath := hostName + path
+	routePath = strings.TrimSuffix(routePath, "/")
 	svcName := getRouteCanonicalServiceName(route)
 	poolName := formatRoutePoolName(route.ObjectMeta.Namespace, svcName)
 	updateDataGroup(dgMap, edgeHostsDgName,


### PR DESCRIPTION
Problem:
CIS fails to send traffic for edge routes with path "/". 

Steps to reproduce:
Create a route resource with host some foo.com and path as "/" for "service: svc-1" as shown below. Try the below URL --> https://foo.com/<something> 

```
oc get routes
NAME                  HOST/PORT   PATH     SERVICES          PORT    TERMINATION     WILDCARD
example-route-1      example.com     /              svc-1                <all>   edge/Redirect   None
```

CIS fails to send to send traffic to backend with svc-1

The reason for this is, CIS creates datagroup entry for foo.com/ for pool --> svc-1 but Irule looks at datagroup for entry foo.com.

Solution:
Removing the trailing slash created for datagroup entries

Affected Branches:
master