### PR TITLE
fix httpsredirect for ingress with noHostSpec

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -3,6 +3,9 @@ Release Notes for BIG-IP Controller for Kubernetes
 
 Next Release
 ------------
+Bug Fixes
+`````````
+* :issues: `1160` k8s ingress without spec.rules causing ssl-redirect irule to fail to redirect.
 
 1.13.0
 ------------

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -359,9 +359,15 @@ func httpRedirectIRule(port int32) string {
 	// The data is a list of paths for the host delimited by '|' or '/' for all.
 	iRuleCode := fmt.Sprintf(`
 		when HTTP_REQUEST {
-			# Look for exact match for combination of host name and path
 			set host [HTTP::host]
+			# Check If the request is for ingress with no hostSpec 
+			#    redirect to https when [HTTP::host] is virtualserver address.
+			# This does not apply for routes as routes cannot be created with no hostSpec.
+			if { [IP::local_addr] equals $host } {
+			    HTTP::redirect https://[getfield [HTTP::host] ":" 1]:443[HTTP::uri]
+			}
 			set path [HTTP::path]
+			# Check for the combination of host and path.
 			append host $path
 			# Find the number of "/" in the hostpath
 			set rc 0


### PR DESCRIPTION
The ssl-redirect irule would fail to do http to https redirect

https://github.com/F5Networks/k8s-bigip-ctlr/issues/1160

```
apiVersion: extensions/v1beta1
kind: Ingress
metadata:
name: f5ingress
namespace: default
annotations:
#nginx.ingress.kubernetes.io/rewrite-target: /
kubernetes.io/ingress.class: "f5"
virtual-server.f5.com/ip: "controller-default" # mgmt network
virtual-server.f5.com/partition: "k8s"
virtual-server.f5.com/balance: "least-connections-node"
virtual-server.f5.com/serverssl: 'Common/serverssl'
ingress.kubernetes.io/ssl-redirect: "true"
ingress.kubernetes.io/allow-http: "false"
virtual-server.f5.com/health: '[

{"path": "nginx.cluster.example.com/", "send": "GET /test_check HTTP/1.1\r\nHost: nginx.cluster.example.com\r\n\r\n", "interval": 5, "timeout": 10}

]'
virtual-server.f5.com/https-port: "443"
virtual-server.f5.com/http-port: "80"
#ingress.kubernetes.io/allow-https: "true"
spec:
tls:
secretName: /Common/example1
backend:
serviceName: nginx
servicePort: 443
```

curl -kD - 'https://3.X.X.X/' -H "Host: echo.example.com" -vv (this works)
curl -kD - 'http://3.X.X.X/' -H "Host: echo.example.com" -vv (this returns a 400 instead of a 302 that you would expect for a http redirect.)
curl 'https://3.X.X.X/ (this works from the connectivity side)
curl 'http://3.X.X.X/' (this throws a 400 error as well
