### PR TITLE
Mid-stream renegotiation must be disabled for custom ClientSSL profiles

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -4,6 +4,10 @@ Release Notes for BIG-IP Controller for Kubernetes
 Next Release
 ------------
 
+Bug Fixes
+`````````
+* Mid-stream renegotiation is disabled for Custom ClientSSL profiles. This helps fix vulnerability CVE-2009-3555.
+
 
 1.14.0
 ------------

--- a/pkg/appmanager/as3Manager.go
+++ b/pkg/appmanager/as3Manager.go
@@ -1446,7 +1446,9 @@ func (appMgr *Manager) createUpdateTLSServer(prof CustomProfile, svcName string,
 				Class:        "TLS_Server",
 				Certificates: []as3TLSServerCertificates{},
 			}
-
+			// RenegotiationEnabled MUST be disabled/false to handle CVE-2009-3555.
+			boolFalse := false
+			tlsServer.RenegotiationEnabled = &boolFalse
 			sharedApp[tlsServerName] = tlsServer
 			svc.ServerTLS = tlsServerName
 			updateVirtualToHTTPS(svc)

--- a/pkg/appmanager/as3Types.go
+++ b/pkg/appmanager/as3Types.go
@@ -183,11 +183,12 @@ type (
 
 	// as3TLSServer maps to TLS_Server in AS3 Resources
 	as3TLSServer struct {
-		Class         string                     `json:"class,omitempty"`
-		Certificates  []as3TLSServerCertificates `json:"certificates,omitempty"`
-		Ciphers       string                     `json:"ciphers,omitempty"`
-		CipherGroup   *as3ResourcePointer        `json:"cipherGroup,omitempty"`
-		Tls1_3Enabled bool                       `json:"tls1_3Enabled,omitempty"`
+		Class                string                     `json:"class,omitempty"`
+		RenegotiationEnabled *bool                       `json:"renegotiationEnabled,omitempty"`
+		Certificates         []as3TLSServerCertificates `json:"certificates,omitempty"`
+		Ciphers              string                     `json:"ciphers,omitempty"`
+		CipherGroup          *as3ResourcePointer        `json:"cipherGroup,omitempty"`
+		Tls1_3Enabled        bool                       `json:"tls1_3Enabled,omitempty"`
 	}
 
 	// as3TLSServerCertificates maps to TLS_Server_certificates in AS3 Resources


### PR DESCRIPTION
    Problem: Mid-strem negotiation is not disabled for custom clientssl profiles.

    Solution: Disable renegotiation for all Custom ClientSSL profiles.
    This solves a vulnerability - http://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2009-3555
    In BIG-IP this Renegotiation is disabled by default for clienssl-secure profile.

    Build: somanchit/k8s-bigip-ctlr:disable_reneg

    Branches affected: 1.x-maintenace