### PR TITLE
Handle Service and Endpoint changes for Custom Resources.

### DIFF
--- a/pkg/crmanager/informers.go
+++ b/pkg/crmanager/informers.go
@@ -138,7 +138,10 @@ func (crMgr *CRManager) addEventHandlers(crInf *CRInformer) {
 
 	crInf.svcInformer.AddEventHandler(
 		&cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { crMgr.enqueueService(obj) },
+			// Ignore AddFunc for service as we dont bother about services until they are
+			// mapped to VirtualServer. Any new service added and mapped to a VirtualServer
+			// will be handled in the VirtualServer Informer AddFunc.
+			// AddFunc:    func(obj interface{}) { crMgr.enqueueService(obj) },
 			UpdateFunc: func(obj, cur interface{}) { crMgr.enqueueService(cur) },
 			DeleteFunc: func(obj interface{}) { crMgr.enqueueService(obj) },
 		},
@@ -146,7 +149,10 @@ func (crMgr *CRManager) addEventHandlers(crInf *CRInformer) {
 
 	crInf.epsInformer.AddEventHandler(
 		&cache.ResourceEventHandlerFuncs{
-			AddFunc:    func(obj interface{}) { crMgr.enqueueEndpoints(obj) },
+			// Ignore AddFunc for endpoint as we dont bother about endpoints until they are
+			// mapped to VirtualServer. Any new endpoint added and mapped to a Service
+			// will be handled in the Service Informer AddFunc.
+			// AddFunc:    func(obj interface{}) { crMgr.enqueueEndpoints(obj) },
 			UpdateFunc: func(obj, cur interface{}) { crMgr.enqueueEndpoints(cur) },
 			DeleteFunc: func(obj interface{}) { crMgr.enqueueEndpoints(obj) },
 		},


### PR DESCRIPTION
Features:

1.  Ignore AddFunc for service as we dont bother about services until they are mapped to one or many VirtualServer. Any new service added and mapped to a VirtualServer will be handled in the VirtualServer Informer AddFunc.

2. Process Service and Endpoint Changes. Services and Endpoints changed will indirectly trigger the effected VirtualServer/s. 

3. Input custom resource obj instead of rqkey structure to syncVirtualServer, syncService and synEndpoint. This will not only improve the performance but will also maintain a symmetry between multiple functions.

4. Introducing checkValidVirtualServer, VirtualServers identified from services or picked from the queue should pass the checks within checkValidVirtualServer. This will be enhanced in stages to achieve utmost out of this feature.

- Abhishek Veeramalla