### PR TITLE
Fix issue in populating resource config with pl members and policies.

### DIFF
--- a/docs/_static/config_examples/crd/basic/example-single-pool-virtual.yml
+++ b/docs/_static/config_examples/crd/basic/example-single-pool-virtual.yml
@@ -2,7 +2,8 @@ apiVersion: "cis.f5.com/v1"
 kind: VirtualServer
 metadata:
   name: my-new-virtual-server
-  f5cr: true
+  labels:
+    f5cr: "true"
 spec:
   host: cafe.example.com
   virtualServerAddress: "172.16.3.4"


### PR DESCRIPTION
Problem:
Fix issues in populating resource config structure for virtual server. CIS in custom resourcemode was not able to populate the poolmembers of a pool as it was not able to fetch the node details.

Solution:
Integrate the node polling capabilities in to CIS CRD mode. This will help custom resources resource config to fetch the pool members endpoints. 


- Abhishek Veeramalla