### PR TITLE
CRD: Eliminate Https VS for unsecured VirtualServer CR

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -21,6 +21,7 @@ type VirtualServerSpec struct {
 	Host                 string `json:"host"`
 	VirtualServerAddress string `json:"virtualServerAddress"`
 	Pools                []Pool `json:"pools"`
+	TLS                  bool   `json:"tls"`
 }
 
 // Pool defines a pool object in BIG-IP.

--- a/pkg/crmanager/resourceConfig.go
+++ b/pkg/crmanager/resourceConfig.go
@@ -124,27 +124,36 @@ func (crMgr *CRManager) virtualPorts(vs *cisapiv1.VirtualServer) []portStruct {
 
 	// TODO ==> This will change as we will support custom ports.
 	const DEFAULT_HTTP_PORT int32 = 80
-	const DEFAULT_HTTPS_PORT int32 = 443
+	//const DEFAULT_HTTPS_PORT int32 = 443
 	var httpPort int32
-	var httpsPort int32
+	// var httpsPort int32
 	httpPort = DEFAULT_HTTP_PORT
-	httpsPort = DEFAULT_HTTPS_PORT
+	// httpsPort = DEFAULT_HTTPS_PORT
 
 	http := portStruct{
 		protocol: "http",
 		port:     httpPort,
 	}
+	// Support TLS Type, Create both HTTP and HTTPS
+	/**
 	https := portStruct{
 		protocol: "https",
 		port:     httpsPort,
-	}
+	}**/
 	var ports []portStruct
 
-	// TODO  ==> This will change when we implement TLS and unsecured model.
-	// For TLS we need both https and http VirtualServers
-	// while for unsecured we just need http VirtualServer.
+	// Support TLS Type, Create both HTTP and HTTPS
+	/**
+	if len(vs.Spec.TLS) > 0 {
+		// 2 virtual servers needed, both HTTP and HTTPS
+		ports = append(ports, http)
+		ports = append(ports, https)
+	} else {
+		// HTTP only
+		ports = append(ports, http)
+	}**/
+
 	ports = append(ports, http)
-	ports = append(ports, https)
 
 	return ports
 }
@@ -154,15 +163,13 @@ func formatVirtualServerName(ip string, port int32) string {
 	// Strip any bracket characters; replace special characters ". : /"
 	// with "-" and "%" with ".", for naming purposes
 	ip = strings.Trim(ip, "[]")
-	var replacer = strings.NewReplacer(".", "_", ":", "_", "/", "_", "%", ".", "-", "_")
-	ip = replacer.Replace(ip)
+	ip = AS3NameFormatter(ip)
 	return fmt.Sprintf("f5_crd_virtualserver_%s_%d", ip, port)
 }
 
 // format the pool name for an VirtualServer
 func formatVirtualServerPoolName(namespace, svc string) string {
-	var replacer = strings.NewReplacer(".", "_", ":", "_", "/", "_", "-", "_")
-	svc = replacer.Replace(svc)
+	svc = AS3NameFormatter(svc)
 	return fmt.Sprintf("%s_%s", namespace, svc)
 }
 
@@ -880,7 +887,7 @@ func (rcs ResourceConfigs) GetAllPoolMembers() []Member {
 
 // AS3NameFormatter formarts resources names according to AS3 convention
 // TODO: Should we use this? Or this will be done in agent?
-func (crMgr *CRManager) AS3NameFormatter(name string) string {
+func AS3NameFormatter(name string) string {
 	replacer := strings.NewReplacer(".", "_", ":", "_", "/", "_", "%", ".", "-", "_")
 	name = replacer.Replace(name)
 	return name

--- a/pkg/crmanager/routing.go
+++ b/pkg/crmanager/routing.go
@@ -100,8 +100,8 @@ func formatVirtualServerRuleName(host, path, pool string) string {
 		path = strings.Replace(path, "/", "_", -1)
 		rule = fmt.Sprintf("vs_%s_%s_%s", host, path, pool)
 	}
-	var replacer = strings.NewReplacer(".", "_", ":", "_", "/", "_", "-", "_")
-	rule = replacer.Replace(rule)
+
+	rule = AS3NameFormatter(rule)
 	return rule
 }
 
@@ -114,8 +114,7 @@ func createRule(uri, poolName, partition, ruleName string) (*Rule, error) {
 		return nil, err
 	}
 	requiredPool := partition + "_" + poolName
-	var replacer = strings.NewReplacer(".", "_", ":", "_", "/", "_", "-", "_")
-	requiredPool = replacer.Replace(requiredPool)
+	requiredPool = AS3NameFormatter(requiredPool)
 
 	a := action{
 		Forward: true,


### PR DESCRIPTION
problem:
CRD:  CIS in custom resource mode should not create HTTPS Virtual Server for unsecured custom resource.

Solution:
Since we do not support TLS for now, Just create HTTP.
// TODO: We will support TLS feature for CRD in coming releases. With TLS, we will create both HTTP and HTTPS VS.

- Abhishek Veeramalla