### PR TITLE
Update CR Manager to use single partition in BIG-IP for both LTM and NET Configurations

### DIFF
--- a/pkg/crmanager/backend.go
+++ b/pkg/crmanager/backend.go
@@ -50,7 +50,7 @@ const (
 var DEFAULT_PARTITION string
 
 func NewAgent(params AgentParams) *Agent {
-	DEFAULT_PARTITION = params.Partition + "_AS3"
+	DEFAULT_PARTITION = params.Partition
 	postMgr := NewPostManager(params.PostParams)
 	configWriter, err := writer.NewConfigWriter()
 	if nil != err {
@@ -82,6 +82,7 @@ func NewAgent(params AgentParams) *Agent {
 		LogLevel:       params.LogLevel,
 		VerifyInterval: params.VerifyInterval,
 		VXLANPartition: vxlanPartition,
+		DisableLTM:     true,
 	}
 	bs := bigIPSection{
 		BigIPUsername:   params.PostParams.BIGIPUsername,

--- a/pkg/crmanager/resourceConfig.go
+++ b/pkg/crmanager/resourceConfig.go
@@ -187,7 +187,7 @@ func (crMgr *CRManager) createRSConfigFromVirtualServer(
 	var rules *Rules
 	var plcy *Policy
 
-	cfg.Virtual.Partition = crMgr.Partition + "_AS3"
+	cfg.Virtual.Partition = crMgr.Partition
 
 	if vs.Spec.VirtualServerAddress == "" {
 		// Virtual Server IP is not given, exit with error log.

--- a/pkg/crmanager/types.go
+++ b/pkg/crmanager/types.go
@@ -253,6 +253,7 @@ type (
 		LogLevel       string `json:"log-level,omitempty"`
 		VerifyInterval int    `json:"verify-interval,omitempty"`
 		VXLANPartition string `json:"vxlan-partition,omitempty"`
+		DisableLTM     bool   `json:"disable-ltm,omitempty"`
 	}
 
 	bigIPSection struct {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/f5devcentral/f5-ctlr-agent.git@29e8a032b89fad442c4c4f1d5b6465d3d6578f34#egg=f5-ctlr-agent
+-e git+https://github.com/f5devcentral/f5-ctlr-agent.git@2fd5393a29ae9ec35de8c5c7dc6389f15e989668#egg=f5-ctlr-agent
 -e git+https://github.com/f5devcentral/f5-cccl.git@f2498ad9e72e430005f66e5f9747498ce057ead7#egg=f5-cccl


### PR DESCRIPTION
Problem: CIS uses Two partitions of BIG-IP, one for LTM and another for NET configurations.
Need to use only one partition for both LTM and NET configurations.

Solution: Disable LTM manager in f5-ctlr-agent and push both configurations to same partition which is configured by user.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>