### PR TITLE
Flooding of logs  "Overwriting existing entry for backend" multi routes

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -19,6 +19,7 @@ Bug Fixes
 * Controller disables mid-stream renegotiation for custom ClientSSL profiles.
 * SR - Multiple ClientSSL support for BIG-IP ClientSSL profiles.
 * :issues:`1233` Controller handles clientSSL annotation and cert/key logging issues.
+* Controller handles posting of 'Overwriting existing entry for backend' frequently when different routes configured in different namespaces.
 
 1.14.0
 ------------
@@ -67,7 +68,7 @@ Bug Fixes
 * :issues:`1014` Fixed performance problem with large number of ingress resources.
 * SR - High CPU load in BIG-IP with CIS. CIS doesn’t post data to BIG-IP when there is no change in resources.
 * SR - K8S AS3-declaration errors when using TCP-profile. CIS allows TCP profile update using Override ConfigMap.
- 
+
 
 1.12.0
 ------------

--- a/pkg/agent/as3/as3Common.go
+++ b/pkg/agent/as3/as3Common.go
@@ -118,7 +118,6 @@ func (am *AS3Manager) processDataGroupForAS3(sharedApp as3Application) {
 					sharedApp[as3FormatedString(dg.Name, "")].(*as3DataGroup).Records = append(dataGroupRecord.(*as3DataGroup).Records, rec)
 				}
 			}
-
 		}
 	}
 }

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1965,7 +1965,7 @@ func (appMgr *Manager) saveVirtualServer(
 			// not changed, don't trigger a config write
 			return false
 		}
-		log.Warningf("[CORE] Overwriting existing entry for backend %+v", sKey)
+		log.Warningf("[CORE] Overwriting existing entry for backend %+v and resource %+v", sKey, rsName)
 	}
 	appMgr.resources.Assign(sKey, rsName, newRsCfg)
 	return true

--- a/pkg/appmanager/profiles.go
+++ b/pkg/appmanager/profiles.go
@@ -230,7 +230,7 @@ func (appMgr *Manager) handleServerSslProfileAnnotation(
 	route *routeapi.Route,
 	prof string,
 ) (string, bool) {
-	if nil != route.Spec.TLS {
+	if nil != route.Spec.TLS && ("" != route.Spec.TLS.Certificate && "" != route.Spec.TLS.Key) {
 		log.Infof("[CORE] Both serverssl annotation and CA cert provided for Route: %s, "+
 			"using annotation.", route.ObjectMeta.Name)
 		profRef := MakeRouteServerSSLProfileRef(

--- a/pkg/resource/resourceConfig.go
+++ b/pkg/resource/resourceConfig.go
@@ -121,6 +121,7 @@ func (slice ProfileRefs) Swap(i, j int) {
 
 func (v *Virtual) AddOrUpdateProfile(prof ProfileRef) bool {
 	// The profiles are maintained as a sorted array.
+	// The profiles are maintained as a sorted array.
 	keyFunc := func(i int) bool {
 		return ((v.Profiles[i].Partition > prof.Partition) ||
 			(v.Profiles[i].Partition == prof.Partition &&
@@ -131,7 +132,7 @@ func (v *Virtual) AddOrUpdateProfile(prof ProfileRef) bool {
 	if i < profCt && v.Profiles[i].Partition == prof.Partition &&
 		v.Profiles[i].Name == prof.Name {
 		// found, look for data changed
-		if v.Profiles[i] == prof {
+		if v.Profiles[i].Context == prof.Context {
 			// unchanged
 			return false
 		}


### PR DESCRIPTION
Problem: Observed dump of "Overwriting existing entry for backend" logs when routes configured in different namespaces

Solution: Consider profile context along with name and partition while adding or updating profile context.