### PR TITLE
Set pip version in Docker images to 20.0.2

### DIFF
--- a/build-tools/Dockerfile.debian.builder
+++ b/build-tools/Dockerfile.debian.builder
@@ -62,7 +62,7 @@ WORKDIR $GOPATH
 COPY entrypoint.builder.sh /entrypoint.sh
 COPY requirements.txt /tmp/requirements.txt
 COPY requirements.docs.txt /tmp/requirements.docs.txt
-RUN pip install --no-cache-dir --upgrade pip && \
+RUN pip install --no-cache-dir --upgrade pip==20.0.2 && \
     pip install --no-cache-dir setuptools flake8 virtualenv && \
 	pip install --no-cache-dir -r /tmp/requirements.txt && \
 	pip install --no-cache-dir -r /tmp/requirements.docs.txt && \

--- a/build-tools/Dockerfile.debian.runtime
+++ b/build-tools/Dockerfile.debian.runtime
@@ -13,7 +13,7 @@ COPY requirements.txt /tmp/requirements.txt
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
     && apt-get upgrade -y \
-    && pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir --upgrade pip==20.0.2 \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
     && apt-get remove -y git
 

--- a/build-tools/Dockerfile.debug.runtime
+++ b/build-tools/Dockerfile.debug.runtime
@@ -18,7 +18,7 @@ COPY requirements.txt /tmp/requirements.txt
 RUN apt-get update && apt-get install -y --no-install-recommends \
         git \
     && apt-get upgrade -y \
-    && pip install --no-cache-dir --upgrade pip \
+    && pip install --no-cache-dir --upgrade pip==20.0.2 \
     && pip install --no-cache-dir -r /tmp/requirements.txt \
     && apt-get remove -y git
 

--- a/build-tools/Dockerfile.rhel7.builder
+++ b/build-tools/Dockerfile.rhel7.builder
@@ -55,7 +55,7 @@ COPY requirements.txt /tmp/requirements.txt
 COPY requirements.docs.txt /tmp/requirements.docs.txt
 
 RUN source scl_source enable rh-python36 && \
-	pip install --no-cache-dir --upgrade pip && \
+	pip install --no-cache-dir --upgrade pip==20.0.2 && \
 	pip install --no-cache-dir setuptools flake8 && \
 	pip install --no-cache-dir --ignore-installed -r /tmp/requirements.txt && \
 	pip install --no-cache-dir -r /tmp/requirements.docs.txt && \

--- a/build-tools/Dockerfile.rhel7.runtime
+++ b/build-tools/Dockerfile.rhel7.runtime
@@ -30,7 +30,7 @@ RUN microdnf --enablerepo=rhel-7-server-rpms --enablerepo=rhel-7-server-optional
     microdnf --enablerepo=rhel-7-server-rpms update nss-tools nss-softokn nss-util && \
     go-md2man -in /tmp/help.md -out /help.1 && rm -f /tmp/help.md && \
     source scl_source enable rh-python36 && \
-    pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir --upgrade pip==20.0.2 && \
     pip install --no-cache-dir -r /tmp/requirements.txt && \
     python -m pip uninstall -y pip && \
     adduser ctlr && \


### PR DESCRIPTION
Problem: Pip version 20.1 has changes related to internal req module, which is leading to build failures as f5-ctrl-agent setup is dependent on pip internal req module.

Solution: As a workaround restrict pip version to 20.0.2 in docker images.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>