### PR TITLE
CRD: Delete Implementation for VirtualServer and Service

### DIFF
--- a/pkg/crmanager/node_poll_handler.go
+++ b/pkg/crmanager/node_poll_handler.go
@@ -97,6 +97,7 @@ func (crMgr *CRManager) ProcessNodeUpdate(
 						VirtualServer,
 						virtual.ObjectMeta.Name,
 						virtual,
+						false,
 					}
 					crMgr.rscQueue.Add(qKey)
 				}

--- a/pkg/crmanager/resourceConfig.go
+++ b/pkg/crmanager/resourceConfig.go
@@ -96,10 +96,10 @@ func NewObjectDependencies(
 	virtual := obj.(*cisapiv1.VirtualServer)
 	// TODO => dep can be replaced with  internal DS rqkey
 	key := ObjectDependency{
-				Kind:      VirtualServer,
-				Name:      virtual.ObjectMeta.Name,
-				Namespace: virtual.ObjectMeta.Namespace,
-			}
+		Kind:      VirtualServer,
+		Name:      virtual.ObjectMeta.Name,
+		Namespace: virtual.ObjectMeta.Namespace,
+	}
 	dep := ObjectDependency{
 		Kind:      key.Kind,
 		Namespace: key.Namespace,
@@ -111,7 +111,7 @@ func NewObjectDependencies(
 			Kind:      RuleDep,
 			Namespace: virtual.ObjectMeta.Namespace,
 			Name:      virtual.Spec.Host + pool.Path,
-			Service:   pool.Service
+			Service:   pool.Service,
 		}
 		deps[dep]++
 	}
@@ -902,6 +902,12 @@ func (rs *Resources) updateOldConfig() {
 		rs.oldRsMap[k] = &ResourceConfig{}
 		rs.oldRsMap[k].copyConfig(v)
 	}
+}
+
+// Deletes respective VirtualServer resource configuration from
+// resource configs.
+func (rs *Resources) deleteVirtualServer(rsName string) {
+	delete(rs.rsMap, rsName)
 }
 
 // AS3NameFormatter formarts resources names according to AS3 convention

--- a/pkg/crmanager/types.go
+++ b/pkg/crmanager/types.go
@@ -75,6 +75,7 @@ type (
 		kind      string
 		rscName   string
 		rsc       interface{}
+		rscDelete bool
 	}
 
 	metaData struct {

--- a/pkg/crmanager/validate.go
+++ b/pkg/crmanager/validate.go
@@ -39,10 +39,7 @@ func (crMgr *CRManager) checkValidVirtualServer(
 	// Check if the virtual exists and valid for us.
 	_, virtualFound, _ := crInf.vsInformer.GetIndexer().GetByKey(vkey)
 	if !virtualFound {
-		// VirtualServer was deleted. Lets proceed with delete operation.
-		// TODO ==> Delete operation for VirtualServer.
-		//          Typically, we will make a call to some DeleteVirtualServer method.
-		log.Infof("VirtualServer %s Not found, Possibly Deleted", vsName)
+		log.Infof("VirtualServer %s is invalid", vsName)
 		return false
 	}
 


### PR DESCRIPTION
Feature:
Handle deletion of services and virtual server custom resource.

Solution:
VirtualServer:
Get the name of the VirtualServer to be deleted and format it to the way it is stored in resourceconfig map. Use the basic delete operation on map to delete the respective resource config.

Service:
Delete Operation on service is very similar to Update Operation. We populate all the pools(corresponding to this service) with empty pool members(as endpoints are removed). This pool will be completed deleted from BIG-IP when user removes the service configuration from virtualserverspec.