### PR TITLE
Handle duplicate ClientSSL profiles added to AS3 ServerTLS object.

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -7,19 +7,20 @@ Next Release
 Added Functionality
 `````````````````````
 * AS3 as default agent.
-* Controller supports TEEM feature from AS3.
-* Support for Informer based Override and User defined AS3.
+* Controller supports TEEM feature with AS3.
+* Support for Informer based Override and User defined AS3 ConfigMaps.
 * Support AS3 3.18 as mandatory version for 2.0.
 * Code refactor to accommodate Agent architecture.
-* Added new option --userdefined-as3-declaration for processing userdefined-as3-cfgMap in the CIS watched namespace.
+* Added new option `--userdefined-as3-declaration` for processing user defined AS3 Config Map in Controller watched namespace.
+* Multiple ClientSSL support for BIG-IP ClientSSL profiles.
 
 Bug Fixes
 `````````
 * Controller handles requests sent to unknown hosts for Routes using debug messages.
 * Controller disables mid-stream renegotiation for custom ClientSSL profiles.
-* SR - Multiple ClientSSL support for BIG-IP ClientSSL profiles.
 * :issues:`1233` Controller handles clientSSL annotation and cert/key logging issues.
 * Controller handles posting of 'Overwriting existing entry for backend' frequently when different routes configured in different namespaces.
+* Controller updates ServerTLS with unique BIG-IP pointers.
 
 1.14.0
 ------------

--- a/pkg/agent/as3/as3Resource.go
+++ b/pkg/agent/as3/as3Resource.go
@@ -109,7 +109,13 @@ func processIngressTLSProfilesForAS3(virtual *Virtual, svc *as3Service) {
 
 func processRouteTLSProfilesForAS3(metadata *MetaData, svc *as3Service) {
 	var serverTLS []as3ResourcePointer
+	existingProfile := map[string]struct{}{}
+	// handle duplicate BIGIP pointers
 	for key, val := range metadata.RouteProfs {
+		if _, ok := existingProfile[val]; ok {
+			continue
+		}
+		existingProfile[val] = struct{}{}
 		switch key.Context {
 		case CustomProfileClient:
 			// Incoming traffic (clientssl) from a web client will be handled by ServerTLS in AS3


### PR DESCRIPTION
Problem: With Multiple ClientSSL profiles support from AS3 3.18,
ServerTLS object being a list, profiles are being added as per route profiles
in metadata. Though multiple routes are using same BIGIP pointer ClientSSL
profiles, the List is being populated with duplicates.

Solution: Make BIGIP pointer references in ServerTLS object for VS
unique.

Bug: CONTCNTR-1805

Affected branches: master