### PR TITLE
Sort Servername and ServerSSL DataGroup record items

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -21,6 +21,7 @@ Bug Fixes
 * :issues:`1233` Controller handles clientSSL annotation and cert/key logging issues.
 * Controller handles posting of 'Overwriting existing entry for backend' frequently when different routes configured in different namespaces.
 * Controller updates ServerTLS with unique BIG-IP pointers.
+* Controller sorts ServerName and ServerSSL DataGroups records before posting AS3 declaration to BIG-IP.
 
 1.14.0
 ------------

--- a/pkg/agent/as3/as3Common.go
+++ b/pkg/agent/as3/as3Common.go
@@ -18,6 +18,7 @@ package as3
 
 import (
 	"fmt"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -104,6 +105,8 @@ func (am *AS3Manager) processDataGroupForAS3(sharedApp as3Application) {
 					}
 					dgMap.Records = append(dgMap.Records, rec)
 				}
+				// sort above create dgMap records.
+				sort.Slice(dgMap.Records, func(i, j int) bool { return (dgMap.Records[i].Key < dgMap.Records[j].Key) })
 				sharedApp[as3FormatedString(dg.Name, "")] = dgMap
 			} else {
 				for _, record := range dg.Records {
@@ -117,6 +120,12 @@ func (am *AS3Manager) processDataGroupForAS3(sharedApp as3Application) {
 					}
 					sharedApp[as3FormatedString(dg.Name, "")].(*as3DataGroup).Records = append(dataGroupRecord.(*as3DataGroup).Records, rec)
 				}
+				// sort above created
+				sort.Slice(sharedApp[as3FormatedString(dg.Name, "")].(*as3DataGroup).Records,
+					func(i, j int) bool {
+						return (sharedApp[as3FormatedString(dg.Name, "")].(*as3DataGroup).Records[i].Key <
+							sharedApp[as3FormatedString(dg.Name, "")].(*as3DataGroup).Records[j].Key)
+					})
 			}
 		}
 	}


### PR DESCRIPTION
Problem: Records in ServerName and ServerSSL DataGroups are
toggled during verify interval which leads to posting AS3
declaration to BIG-IP though there is no change in monitored
resources.

Solution: Always sort the order of records being posted so that
controller post only when there is a change is resources being
monitored.

Bug: CONTCNTR-1806

Affected-branches: master