### PR TITLE
Deleting the warning message

### DIFF
--- a/pkg/appmanager/profiles.go
+++ b/pkg/appmanager/profiles.go
@@ -73,14 +73,13 @@ func (appMgr *Manager) setClientSslProfile(
 	// Now handle the profile from the Route.
 	// If annotation is set, use that profile instead of Route profile.
 	if prof, ok := route.ObjectMeta.Annotations[F5ClientSslProfileAnnotation]; ok {
+		var profRef ProfileRef
 		if nil != route.Spec.TLS && ("" != route.Spec.TLS.Certificate && "" != route.Spec.TLS.Key) {
-			log.Warningf("[CORE] Both clientssl annotation and cert/key provided for Route: %s, "+
-				"using annotation.", route.ObjectMeta.Name)
+			// Delete existing Route profile if it exists
+			profRef = MakeRouteClientSSLProfileRef(
+				rsCfg.Virtual.Partition, sKey.Namespace, route.ObjectMeta.Name)
+			rsCfg.Virtual.RemoveProfile(profRef)
 		}
-		// Delete existing Route profile if it exists
-		profRef := MakeRouteClientSSLProfileRef(
-			rsCfg.Virtual.Partition, sKey.Namespace, route.ObjectMeta.Name)
-		rsCfg.Virtual.RemoveProfile(profRef)
 		profRef = ConvertStringToProfileRef(prof, CustomProfileClient, sKey.Namespace)
 		if add := rsCfg.Virtual.AddOrUpdateProfile(profRef); add {
 			// Store this annotated profile in the metadata for future reference


### PR DESCRIPTION
Deleting the warning message "Both clientssl annotation and cert/key provided for Route" as we need to document for preference for both annotations and TLS spec certs used. 