### PR TITLE
Sort TLS_Server certificate record names

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -21,7 +21,7 @@ Bug Fixes
 * :issues:`1233` Controller handles clientSSL annotation and cert/key logging issues.
 * Controller handles posting of 'Overwriting existing entry for backend' frequently when different routes configured in different namespaces.
 * Controller updates ServerTLS with unique BIG-IP pointers.
-* Controller sorts ServerName and ServerSSL DataGroups records before posting AS3 declaration to BIG-IP.
+* Controller sorts ServerName/ServerSSL DataGroups records and TLS Server records before posting AS3 declaration to BIG-IP.
 
 1.14.0
 ------------

--- a/pkg/agent/as3/as3Common.go
+++ b/pkg/agent/as3/as3Common.go
@@ -565,7 +565,12 @@ func (am *AS3Manager) createUpdateTLSServer(prof CustomProfile, svcName string, 
 				Certificate: certName,
 			},
 		)
-
+		if len(tlsServer.Certificates) != 0 {
+			sort.Slice(tlsServer.Certificates,
+				func(i, j int) bool {
+					return (tlsServer.Certificates[i].Certificate < tlsServer.Certificates[j].Certificate)
+				})
+		}
 		if am.enableTLS == "1.2" {
 			tlsServer.Ciphers = am.ciphers
 		} else if am.enableTLS == "1.3" {


### PR DESCRIPTION
Problem: Records in TLS_Server class are
toggled during verify interval which leads to posting AS3
declaration to BIG-IP though there is no change in monitored
resources.

Solution: Always sort the order of records being posted so that
controller post only when there is a change is resources being
monitored.

JIRA: CONTCNTR-1822

Affected-branches: master