### PR TITLE
Support Route Domain for AS3 managed partition.

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -174,6 +174,7 @@ var (
 	eventChan          chan interface{}
 	configWriter       writer.Writer
 	k8sVersion         string
+	defaultRouteDomain *int
 )
 
 func _init() {
@@ -256,6 +257,7 @@ func _init() {
 	userDefinedAS3Decl = bigIPFlags.String("userdefined-as3-declaration", "", userDefinedCfgMapStr)
 	filterTenants = kubeFlags.Bool("filter-tenants", false,
 		"Optional, specify whether or not to use tenant filtering API for AS3 declaration")
+	defaultRouteDomain = bigIPFlags.Int("default-route-domain", 0, "Default 0. Default Route Domain for this Controller")
 	bigIPFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  BigIP:\n%s\n", bigIPFlags.FlagUsagesWrapped(width))
 	}
@@ -726,7 +728,6 @@ func main() {
 	}
 
 	log.Infof("[INIT] Starting: Container Ingress Services - Version: %s, BuildInfo: %s", version, buildInfo)
-
 	resource.DEFAULT_PARTITION = (*bigIPPartitions)[0]
 	dgPath = resource.DEFAULT_PARTITION
 	if strings.ToLower(*agent) == "as3" {
@@ -995,6 +996,7 @@ func getAS3Params() *as3.Params {
 		LogResponse:               *logAS3Response,
 		RspChan:                   agRspChan,
 		UserAgent:                 getUserAgentInfo(),
+		DefaultRouteDomain:        *defaultRouteDomain,
 	}
 }
 

--- a/pkg/agent/as3/as3Manager.go
+++ b/pkg/agent/as3/as3Manager.go
@@ -49,6 +49,7 @@ const (
 	as3SupportedVersion  = 3.18
 	as3tenant            = "Tenant"
 	as3class             = "class"
+	as3routedomain       = "defaultRouteDomain"
 	as3SharedApplication = "Shared"
 	as3application       = "Application"
 	as3shared            = "shared"
@@ -126,6 +127,7 @@ type Params struct {
 	LogResponse bool
 	RspChan     chan interface{}
 	UserAgent   string
+	DefaultRouteDomain int
 }
 
 // Create and return a new app manager that meets the Manager interface
@@ -158,6 +160,7 @@ func NewAS3Manager(params *Params) *AS3Manager {
 	as3Manager.as3ActiveConfig.configmap.Init()
 
 	as3Manager.fetchAS3Schema()
+	DEFAULT_ROUTE_DOMAIN = params.DefaultRouteDomain
 
 	return &as3Manager
 }

--- a/pkg/agent/as3/as3Types.go
+++ b/pkg/agent/as3/as3Types.go
@@ -20,6 +20,8 @@ import (
 	. "github.com/F5Networks/k8s-bigip-ctlr/pkg/resource"
 )
 
+var DEFAULT_ROUTE_DOMAIN int = 0
+
 type (
 	as3Template    string
 	as3Declaration string

--- a/pkg/agent/as3/as3Utils.go
+++ b/pkg/agent/as3/as3Utils.go
@@ -366,6 +366,7 @@ func (t as3Tenant) initDefault() {
 	app := as3Application{}
 	app.initDefault()
 	t[as3class] = as3tenant
+	t[as3routedomain] = DEFAULT_ROUTE_DOMAIN
 	t[as3SharedApplication] = app
 }
 


### PR DESCRIPTION
Problem:

CIS doen't support Route Domain while creating AS3 managed partition.

Solution:

New CIS deployment config option `--default-route-domain`
is introduced. This option support only Routes and Ingress resources.

Notes:

- For userDefined AS3 configMap configure `defaultRouteDomain` in AS3 `Tenant`.

- Only pre-configured Route Domain IDs in BIG-IP are supported.

- Update of Route Domain ID is not supported due to issue https://github.com/F5Networks/f5-appsvcs-extension/issues/271

- To update Route Domain ID for AS3 Managed partition, stop the controller, delete the AS3 managed partition and start controller.

JIRA: CONTCNTR-1751

Affected-branches: master