### PR TITLE
Single partition for CIS when configured in AS3 agent

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -13,7 +13,6 @@ const (
 type CISAgentInterface interface {
 	Initializer
 	Deployer
-	Remover
 	DeInitializer
 	IsImplInAgent(string) bool
 }
@@ -26,11 +25,6 @@ type Initializer interface {
 // Deployer is the interface which wraps basic Deploy method
 type Deployer interface {
 	Deploy(req interface{}) error
-}
-
-// Remover is the interface which wraps basic Remove method
-type Remover interface {
-	Remove(partition string) error
 }
 
 // De-Initializer is the interface which wraps basic De-Init method.

--- a/pkg/agent/agentAS3.go
+++ b/pkg/agent/agentAS3.go
@@ -37,12 +37,6 @@ func (ag *agentAS3) Deploy(req interface{}) error {
 	return nil
 }
 
-func (ag *agentAS3) Remove(partition string) error {
-	log.Debugf("[AS3] Removing %v_AS3 Partition", partition)
-	ag.DeleteAS3Partition(partition + "_AS3")
-	return nil
-}
-
 func (ag *agentAS3) DeInit() error {
 	close(ag.RspChan)
 	close(ag.ReqChan)

--- a/pkg/agent/agentCCCL.go
+++ b/pkg/agent/agentCCCL.go
@@ -32,11 +32,6 @@ func (ag *agentCCCL) Deploy(req interface{}) error {
 	return nil
 }
 
-func (ag *agentCCCL) Remove(partition string) error {
-	log.Infof("[CCCL] Removing CCCL Partition %v \n", partition)
-	return nil
-}
-
 func (ag *agentCCCL) DeInit() error {
 	log.Infof("[CCCL] DeInitializing CCCL Agent\n")
 	ag.ConfigWriter().Stop()

--- a/pkg/agent/as3/as3Common.go
+++ b/pkg/agent/as3/as3Common.go
@@ -539,48 +539,49 @@ func createCertificateDecl(prof CustomProfile, sharedApp as3Application) {
 func (am *AS3Manager) createUpdateTLSServer(prof CustomProfile, svcName string, sharedApp as3Application) bool {
 	// A TLSServer profile needs to carry both Certificate and Key
 	if "" != prof.Cert && "" != prof.Key {
-		svc := sharedApp[svcName].(*as3Service)
-		tlsServerName := fmt.Sprintf("%s_tls_server", svcName)
-		certName := as3FormatedString(prof.Name, deriveResourceTypeFromAS3Value(prof.Name))
+		if svc, ok := sharedApp[svcName].(*as3Service); ok {
+			tlsServerName := fmt.Sprintf("%s_tls_server", svcName)
+			tlsServer, ok := sharedApp[tlsServerName].(*as3TLSServer)
+			if !ok {
+				certName := as3FormatedString(prof.Name, deriveResourceTypeFromAS3Value(prof.Name))
 
-		tlsServer, ok := sharedApp[tlsServerName].(*as3TLSServer)
-		if !ok {
-			tlsServer = &as3TLSServer{
-				Class:        "TLS_Server",
-				Certificates: []as3TLSServerCertificates{},
+				tlsServer = &as3TLSServer{
+					Class:        "TLS_Server",
+					Certificates: []as3TLSServerCertificates{},
+				}
+
+				// RenegotiationEnabled MUST be disabled/false to handle CVE-2009-3555.
+				boolFalse := false
+				tlsServer.RenegotiationEnabled = &boolFalse
+
+				sharedApp[tlsServerName] = tlsServer
+				svc.ServerTLS = tlsServerName
+				updateVirtualToHTTPS(svc)
+
+				tlsServer.Certificates = append(
+					tlsServer.Certificates,
+					as3TLSServerCertificates{
+						Certificate: certName,
+					},
+				)
+				if len(tlsServer.Certificates) != 0 {
+					sort.Slice(tlsServer.Certificates,
+						func(i, j int) bool {
+							return (tlsServer.Certificates[i].Certificate < tlsServer.Certificates[j].Certificate)
+						})
+				}
+				if am.enableTLS == "1.2" {
+					tlsServer.Ciphers = am.ciphers
+				} else if am.enableTLS == "1.3" {
+					tlsServer.Tls1_3Enabled = true
+					tlsServer.CipherGroup = &as3ResourcePointer{
+						BigIP: am.tls13CipherGroupReference,
+					}
+				}
+
+				return true
 			}
-
-			// RenegotiationEnabled MUST be disabled/false to handle CVE-2009-3555.
-			boolFalse := false
-			tlsServer.RenegotiationEnabled = &boolFalse
-
-			sharedApp[tlsServerName] = tlsServer
-			svc.ServerTLS = tlsServerName
-			updateVirtualToHTTPS(svc)
 		}
-
-		tlsServer.Certificates = append(
-			tlsServer.Certificates,
-			as3TLSServerCertificates{
-				Certificate: certName,
-			},
-		)
-		if len(tlsServer.Certificates) != 0 {
-			sort.Slice(tlsServer.Certificates,
-				func(i, j int) bool {
-					return (tlsServer.Certificates[i].Certificate < tlsServer.Certificates[j].Certificate)
-				})
-		}
-		if am.enableTLS == "1.2" {
-			tlsServer.Ciphers = am.ciphers
-		} else if am.enableTLS == "1.3" {
-			tlsServer.Tls1_3Enabled = true
-			tlsServer.CipherGroup = &as3ResourcePointer{
-				BigIP: am.tls13CipherGroupReference,
-			}
-		}
-
-		return true
 	}
 	return false
 }

--- a/pkg/agent/as3/as3ConfigMap.go
+++ b/pkg/agent/as3/as3ConfigMap.go
@@ -82,11 +82,10 @@ func (am *AS3Manager) generateUserDefinedAS3Decleration(cm AgentCfgMap) as3Decla
 	}
 
 	_, found := obj[tenantName(DEFAULT_PARTITION)]
-	_, foundNetworkPartition := obj[tenantName(strings.TrimSuffix(DEFAULT_PARTITION, "_AS3"))]
-	if found || foundNetworkPartition {
+	if found {
 		log.Error("[AS3] Error in processing the template")
-		log.Errorf("[AS3] CIS managed partitions <%s> and <%s> should not be used in ConfigMap as Tenants",
-			DEFAULT_PARTITION, strings.TrimSuffix(DEFAULT_PARTITION, "_AS3"))
+		log.Errorf("[AS3] CIS managed partitions <%s> should not be used in ConfigMap as Tenants",
+			DEFAULT_PARTITION)
 		return ""
 	}
 


### PR DESCRIPTION
Problem: When CIS configured as AS3 Agent, CIS will use the defined partition AND create another partition called <partition_name>_AS3. The first partition is used for FDB entries and the other partition is used for AS3 config, Using two different partitions is confusing and there is no real value on relying on two different partitions.

Solution: CIS should only support a single partition and <partition_name>_AS3 must be removed.