### PR TITLE
Simplify L2/L3 support for AS3 mode

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -854,16 +854,6 @@ func main() {
 		os.Exit(1)
 	}
 	defer appMgr.AgentCIS.DeInit()
-	// Initlize CCCL for L2-L3 if agent is AS3
-	// TODO: this will be removed when L2-L3 support is added in AS3
-	if *agent == cisAgent.AS3Agent {
-		appMgr.AgentCCCL, err = cisAgent.CreateAgent(cisAgent.CCCLAgent)
-		if err = appMgr.AgentCCCL.Init(getAgentParams(cisAgent.CCCLAgent)); err != nil {
-			log.Fatalf("[INIT] Failed to initialize CCCL Agent %v error: err: %+v\n", *agent, err)
-			os.Exit(1)
-		}
-		defer appMgr.AgentCCCL.DeInit()
-	}
 
 	GetNamespaces(appMgr)
 	intervalFactor := time.Duration(*nodePollInterval)
@@ -976,6 +966,8 @@ func getAS3Params() *as3.Params {
 		LogResponse:               *logAS3Response,
 		RspChan:                   agRspChan,
 		UserAgent:                 getUserAgentInfo(),
+		ConfigWriter:              getConfigWriter(),
+		EventChan:                 eventChan,
 	}
 }
 

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -5,9 +5,7 @@ import (
 )
 
 const (
-	MsgTypeSendFDB  = "FDB"
-	MsgTypeSendARP  = "ARP"
-	MsgTypeSendDecl = "L4L7Decleration"
+	MsgTypeSendDecl = "L4L7Declaration"
 )
 
 type CISAgentInterface interface {

--- a/pkg/agent/agentCCCL.go
+++ b/pkg/agent/agentCCCL.go
@@ -22,10 +22,6 @@ func (ag *agentCCCL) Deploy(req interface{}) error {
 	msgReq := req.(resource.MessageRequest)
 	ag.ResourceRequest = msgReq.ResourceRequest
 	switch msgReq.MsgType {
-	case MsgTypeSendFDB:
-		ag.SendFDBEntries()
-	case MsgTypeSendARP:
-		ag.SendARPEntries()
 	case MsgTypeSendDecl:
 		ag.OutputConfigLocked()
 	}

--- a/pkg/agent/as3/as3ConfigMap.go
+++ b/pkg/agent/as3/as3ConfigMap.go
@@ -204,7 +204,7 @@ func (am *AS3Manager) buildAS3Declaration(obj as3Object, template as3Template, c
 				ips := make([]string, 0)
 				for _, v := range eps {
 					ips = append(ips, v.Address)
-					if _, ok := am.ResourceResponse.Members[v]; !ok {
+					if _, ok := am.PoolMembers[v]; !ok {
 						isPoolUpdated = true
 					}
 					members[v] = struct{}{}
@@ -219,7 +219,7 @@ func (am *AS3Manager) buildAS3Declaration(obj as3Object, template as3Template, c
 		}
 	}
 
-	am.ResourceResponse.Members = members
+	am.poolMembers = members
 
 	declaration, err := json.Marshal(templateJSON)
 

--- a/pkg/agent/as3/l2l3agent.go
+++ b/pkg/agent/as3/l2l3agent.go
@@ -1,0 +1,85 @@
+/*-
+ * Copyright (c) 2016-2019, F5 Networks, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package as3
+
+import (
+	"time"
+
+	. "github.com/F5Networks/k8s-bigip-ctlr/pkg/resource"
+	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
+	"github.com/F5Networks/k8s-bigip-ctlr/pkg/writer"
+)
+
+type L2L3Agent struct {
+	configWriter writer.Writer
+	eventChan    chan interface{}
+}
+
+// Create a partition entry in the map if it doesn't exists
+func initPartitionData(resources PartitionMap, partition string) {
+	if _, ok := resources[partition]; !ok {
+		resources[partition] = &BigIPConfig{}
+	}
+}
+
+func (am *AS3Manager) SendARPEntries() {
+	// Get all pool members and write them to VxlanMgr to configure ARP entries
+	resources := PartitionMap{}
+	var allPoolMembers []Member
+
+	// Filter the configs to only those that have active services
+	for _, cfg := range am.Resources.RsCfgs {
+		if cfg.MetaData.Active == true {
+			initPartitionData(resources, cfg.GetPartition())
+			for _, p := range cfg.Pools {
+				resources[p.Partition].Pools = appendPool(resources[p.Partition].Pools, p)
+			}
+		}
+	}
+
+	for _, cfg := range resources {
+		for _, pool := range cfg.Pools {
+			allPoolMembers = append(allPoolMembers, pool.Members...)
+		}
+	}
+
+	if am.l2l3Agent.eventChan != nil {
+		for member := range am.poolMembers {
+			allPoolMembers = append(allPoolMembers, member)
+		}
+
+		select {
+		case am.l2l3Agent.eventChan <- allPoolMembers:
+			log.Debugf("[AS3] AppManager wrote endpoints to VxlanMgr")
+		case <-time.After(3 * time.Second):
+		}
+	}
+}
+
+// Only append to the list if it isn't already in the list
+func appendPool(rsPools []Pool, p Pool) []Pool {
+	for i, rp := range rsPools {
+		if rp.Name == p.Name &&
+			rp.Partition == p.Partition {
+			if len(p.Members) > 0 {
+				rsPools[i].Members = p.Members
+			}
+			return rsPools
+		}
+	}
+	return append(rsPools, p)
+}

--- a/pkg/appmanager/agentRequestHandler.go
+++ b/pkg/appmanager/agentRequestHandler.go
@@ -3,7 +3,6 @@ package appmanager
 import (
 	cisAgent "github.com/F5Networks/k8s-bigip-ctlr/pkg/agent"
 	. "github.com/F5Networks/k8s-bigip-ctlr/pkg/resource"
-	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
 )
 
 // Method to deploy resources on configured agent
@@ -37,40 +36,4 @@ func (appMgr *Manager) deployResource() error {
 		}
 	}
 	return nil
-}
-
-// Method to deploy ARP on L2-L3 agent
-func (appMgr *Manager) deployARP(members map[Member]struct{}) error {
-	log.Debugf("[CORE] Sending ARP entries")
-	agentCIS := appMgr.getL2L3Agent()
-	deployCfg := ResourceRequest{Resources: &AgentResources{RsMap: appMgr.resources.RsMap,
-		RsCfgs: appMgr.resources.GetAllResources()}, PoolMembers: members}
-	// Generate Agent Request
-	agentReq := MessageRequest{MsgType: cisAgent.MsgTypeSendARP, ResourceRequest: deployCfg}
-	// Handle resources to agent and deploy to BIG-IP
-	agentCIS.Deploy(agentReq)
-	return nil
-}
-
-// Method to deploy FDB on L2-L3 agent
-func (appMgr *Manager) deployFDB() error {
-	agentCIS := appMgr.getL2L3Agent()
-	// Generate Agent Request
-	deployCfg := ResourceRequest{Resources: &AgentResources{RsMap: appMgr.resources.RsMap,
-		RsCfgs: appMgr.resources.GetAllResources()}}
-	agentReq := MessageRequest{MsgType: cisAgent.MsgTypeSendFDB, ResourceRequest: deployCfg}
-	// Handle resources to agent and deploy to BIG-IP
-	agentCIS.Deploy(agentReq)
-	return nil
-}
-
-// Method to get L2-L3 agent
-func (appMgr *Manager) getL2L3Agent() cisAgent.CISAgentInterface {
-	// This condition holds good for Agent AS3 for now,
-	// However, agent CCCL doesn't use this method
-	// This can be used and extended by future agents.
-	if appMgr.AgentCIS != nil && appMgr.AgentCCCL != nil {
-		return appMgr.AgentCCCL
-	}
-	return appMgr.AgentCIS
 }

--- a/pkg/appmanager/agentResponseHandler.go
+++ b/pkg/appmanager/agentResponseHandler.go
@@ -131,19 +131,12 @@ func (appMgr *Manager) agentResponseWorker() {
 		// If admit status is set and if routes are configured appManager
 		// would process route admit status, by default appManager would
 		// process ARP handling aloing with Admit Status for both k8s or OSCP
-		if rspMsg.AdmitStatus {
-			appMgr.deployARP(rspMsg.Members)
-			log.Debugf("[CORE] Sending ARP entries")
+		if rspMsg.IsResponseSuccessful == true {
 			// if route is configured in appManager
 			if appMgr.routeClientV1 != nil {
 				log.Debugf("[CORE] Updating Route Admit Status")
 				appMgr.updateRouteAdmitStatus()
 			}
-		}
-
-		// if FDB is set, appManager would send this request to L2-L3 agent
-		if rspMsg.FdbRecords {
-			appMgr.deployFDB()
 		}
 	}
 }

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -125,8 +125,6 @@ type Manager struct {
 	intF5Res           InternalF5ResourcesGroup
 	dgPath             string
 	AgentCIS           cisAgent.CISAgentInterface
-	// Applicable when Agent is AS3 to serve ARP/FDB
-	AgentCCCL cisAgent.CISAgentInterface
 	// Processed routes for updating Admit Status
 	agRspChan          chan interface{}
 	processAgentLabels func(map[string]string, string, string) bool

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -414,9 +414,7 @@ type (
 	}
 
 	ResourceResponse struct {
-		AdmitStatus bool
-		FdbRecords  bool
-		Members     map[Member]struct{}
+		IsResponseSuccessful bool
 	}
 
 	MessageRequest struct {


### PR DESCRIPTION
Problem: When CIS is in AS3 mode, CCCL agent is also initialized
for L2/L3 support. This makes two agents while one agent is configured.

Solution: Remove CCCL init when AS3 is the agent. Extend L2/L3 for AS3 agent.

Affected Branches: master

Fixes issue #1312 partly.