### PR TITLE
Added namespace label support for AS3 ConfigMaps in CIS

### DIFF
--- a/pkg/agent/as3/as3ConfigMap.go
+++ b/pkg/agent/as3/as3ConfigMap.go
@@ -115,7 +115,7 @@ func (c *AS3Config) prepareAS3OverrideDeclaration(data string) {
 }
 
 // Method to perform deletion operation on userdefined-as3-cfgmap
-func (am AS3Manager) prepareDeleteUserDefinedAS3(cm AS3ConfigMap) (bool, string) {
+func (am AS3Manager) prepareDeleteUserDefinedAS3(cm *AS3ConfigMap) (bool, string) {
 	log.Debugf("[AS3] Deleting User Defined Configmap: %v", cm.Name)
 	// Fetch all tenants of userdefined-as3-cfgmap
 	if tntList := getTenants(cm.Data); tntList != nil {
@@ -127,6 +127,7 @@ func (am AS3Manager) prepareDeleteUserDefinedAS3(cm AS3ConfigMap) (bool, string)
 			}
 		}
 	}
+	cm.Data = ""
 	cm.Reset()
 	return true, ""
 }
@@ -151,6 +152,9 @@ func (am *AS3Manager) processAS3ConfigMap(cm AgentCfgMap, cfg *AS3Config) {
 	case "overrideAS3":
 		if name == cfg.overrideConfigmap.Name {
 			cfg.prepareAS3OverrideDeclaration(data)
+			if cfg.overrideConfigmap.State == cmActive {
+				am.as3ActiveConfig.overrideConfigmap = cfg.overrideConfigmap
+			}
 			return
 		}
 	case "as3":
@@ -242,7 +246,7 @@ func (am *AS3Manager) processAS3CfgMapDelete(name, namespace string, cfg *AS3Con
 	if name == cfg.configmap.Name && namespace == cfg.configmap.Namespace {
 		am.as3ActiveConfig.configmap.Reset()
 		am.as3ActiveConfig.configmap.Data = ""
-		return am.prepareDeleteUserDefinedAS3(cfg.configmap)
+		return am.prepareDeleteUserDefinedAS3(&cfg.configmap)
 	}
 	return true, ""
 }

--- a/pkg/agent/as3/as3Manager.go
+++ b/pkg/agent/as3/as3Manager.go
@@ -171,7 +171,7 @@ func (am *AS3Manager) postAS3Declaration(rsReq ResourceRequest) (bool, string) {
 	if am.ResourceRequest.AgentCfgmap != nil {
 		for _, cfgMap := range am.ResourceRequest.AgentCfgmap {
 			// Perform delete operation for cfgMap
-			if cfgMap.Data == "" {
+			if cfgMap.Operation == OprTypeDelete {
 				// Empty data is treated as delete operation for cfgMaps
 				if ok, event := am.processAS3CfgMapDelete(cfgMap.Name, cfgMap.Namespace, &as3Config); !ok {
 					log.Errorf("[AS3] Failed to perform delete cfgMap with name: %s and namespace %s",
@@ -225,7 +225,6 @@ func (cfg *AS3Config) updateConfig(newAS3Cfg AS3Config) {
 	cfg.adc = newAS3Cfg.adc
 	cfg.unifiedDeclaration = newAS3Cfg.unifiedDeclaration
 	cfg.configmap = newAS3Cfg.configmap
-	cfg.overrideConfigmap = newAS3Cfg.overrideConfigmap
 }
 
 func (am *AS3Manager) getUnifiedDeclaration(cfg *AS3Config) as3Declaration {

--- a/pkg/agent/as3/as3Manager_test.go
+++ b/pkg/agent/as3/as3Manager_test.go
@@ -88,7 +88,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			Expect(as3Config.configmap.State).To(Equal(cmActive), "UserDefinedCfgMap created.")
 			Expect(string(as3Config.configmap.Data)).NotTo(Equal(""), "Should have data.")
 			// Empty agent configMap Data
-			agentCM.Data = ""
+			agentCM.Operation = OprTypeDelete
 			as3Config = mockMgr.as3Mgr.as3ActiveConfig
 			mockMgr.as3Mgr.processAS3CfgMapDelete(agentCM.Name, agentCM.Namespace, &as3Config)
 			Expect(as3Config.configmap.State).To(Equal(cmInit),
@@ -105,7 +105,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			Expect(as3Config.configmap.State).To(Equal(cmActive), "UserDefinedCfgMap created.")
 			Expect(string(as3Config.configmap.Data)).NotTo(Equal(""), "Should have data.")
 			// Empty agent configMap Data
-			agentCM.Data = ""
+			agentCM.Operation = OprTypeDelete
 			agentCM.Name = "invalid"
 			mockMgr.as3Mgr.processAS3CfgMapDelete(agentCM.Name, agentCM.Namespace, &as3Config)
 			Expect(as3Config.configmap.State).To(Equal(cmActive),
@@ -122,7 +122,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			Expect(as3Config.configmap.State).To(Equal(cmActive), "UserDefinedCfgMap created.")
 			Expect(string(as3Config.configmap.Data)).NotTo(Equal(""), "Should have data.")
 			// Empty agent configMap Data
-			agentCM.Data = ""
+			agentCM.Operation = OprTypeDelete
 			agentCM.Namespace = "invalid"
 			mockMgr.as3Mgr.processAS3CfgMapDelete(agentCM.Name, agentCM.Namespace, &as3Config)
 			Expect(as3Config.configmap.State).To(Equal(cmActive),
@@ -199,7 +199,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			Expect(as3Config.configmap.State).To(Equal(cmActive), "UserDefinedCfgMap created.")
 			Expect(string(as3Config.configmap.Data)).NotTo(Equal(""), "Should have data.")
 			// Empty agent configMap Data
-			agentCM.Data = ""
+			agentCM.Operation = OprTypeDelete
 			as3Config = mockMgr.as3Mgr.as3ActiveConfig
 			mockMgr.as3Mgr.processAS3CfgMapDelete(agentCM.Name, agentCM.Namespace, &as3Config)
 			Expect(as3Config.configmap.State).To(Equal(cmInit),
@@ -215,7 +215,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			Expect(as3Config.configmap.State).To(Equal(cmActive), "UserDefinedCfgMap created.")
 			Expect(string(as3Config.configmap.Data)).NotTo(Equal(""), "Should have data.")
 			// Empty agent configMap Data
-			agentCM.Data = ""
+			agentCM.Operation = OprTypeDelete
 			agentCM.Name = "invalid"
 			mockMgr.as3Mgr.processAS3CfgMapDelete(agentCM.Name, agentCM.Namespace, &as3Config)
 			Expect(as3Config.configmap.State).To(Equal(cmActive),
@@ -231,7 +231,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			Expect(as3Config.configmap.State).To(Equal(cmActive), "UserDefinedCfgMap created.")
 			Expect(string(as3Config.configmap.Data)).NotTo(Equal(""), "Should have data.")
 			// Empty agent configMap Data
-			agentCM.Data = ""
+			agentCM.Operation = OprTypeDelete
 			agentCM.Namespace = "invalid"
 			mockMgr.as3Mgr.processAS3CfgMapDelete(agentCM.Name, agentCM.Namespace, &as3Config)
 			Expect(as3Config.configmap.State).To(Equal(cmActive),
@@ -306,7 +306,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			Expect(as3Config.overrideConfigmap.State).To(Equal(cmActive), "Override CfgMap created.")
 			Expect(string(as3Config.overrideConfigmap.Data)).NotTo(Equal(""), "Should have data.")
 			// Empty agent configMap Data
-			agentCM.Data = ""
+			agentCM.Operation = OprTypeDelete
 			as3Config = mockMgr.as3Mgr.as3ActiveConfig
 			mockMgr.as3Mgr.processAS3CfgMapDelete(agentCM.Name, agentCM.Namespace, &as3Config)
 			Expect(as3Config.overrideConfigmap.State).To(Equal(cmInit),
@@ -323,7 +323,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			Expect(as3Config.overrideConfigmap.State).To(Equal(cmActive), "Override CfgMap created.")
 			Expect(string(as3Config.overrideConfigmap.Data)).NotTo(Equal(""), "Should have data.")
 			// Empty agent configMap Data
-			agentCM.Data = ""
+			agentCM.Operation = OprTypeDelete
 			agentCM.Name = "invalid"
 			mockMgr.as3Mgr.processAS3CfgMapDelete(agentCM.Name, agentCM.Namespace, &as3Config)
 			Expect(as3Config.overrideConfigmap.State).To(Equal(cmActive),
@@ -340,7 +340,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			Expect(as3Config.overrideConfigmap.State).To(Equal(cmActive), "Override CfgMap created.")
 			Expect(string(as3Config.overrideConfigmap.Data)).NotTo(Equal(""), "Should have data.")
 			// Empty agent configMap Data
-			agentCM.Data = ""
+			agentCM.Operation = OprTypeDelete
 			agentCM.Namespace = "invalid"
 			mockMgr.as3Mgr.processAS3CfgMapDelete(agentCM.Name, agentCM.Namespace, &as3Config)
 			Expect(as3Config.overrideConfigmap.State).To(Equal(cmActive),
@@ -394,7 +394,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			Expect(as3Config.overrideConfigmap.State).To(Equal(cmActive), "Override CfgMap created.")
 			Expect(string(as3Config.overrideConfigmap.Data)).NotTo(Equal(""), "Should have data.")
 			// Empty agent configMap Data
-			agentCM.Data = ""
+			agentCM.Operation = OprTypeDelete
 			as3Config = mockMgr.as3Mgr.as3ActiveConfig
 			mockMgr.as3Mgr.processAS3CfgMapDelete(agentCM.Name, agentCM.Namespace, &as3Config)
 			Expect(as3Config.overrideConfigmap.State).To(Equal(cmInit),
@@ -410,7 +410,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			Expect(as3Config.overrideConfigmap.State).To(Equal(cmActive), "Override CfgMap created.")
 			Expect(string(as3Config.overrideConfigmap.Data)).NotTo(Equal(""), "Should have data.")
 			// Empty agent configMap Data
-			agentCM.Data = ""
+			agentCM.Operation = OprTypeDelete
 			agentCM.Name = "invalid"
 			mockMgr.as3Mgr.processAS3CfgMapDelete(agentCM.Name, agentCM.Namespace, &as3Config)
 			Expect(as3Config.overrideConfigmap.State).To(Equal(cmActive),
@@ -426,7 +426,7 @@ var _ = Describe("AS3Manager Tests", func() {
 			Expect(as3Config.overrideConfigmap.State).To(Equal(cmActive), "Override CfgMap created.")
 			Expect(string(as3Config.overrideConfigmap.Data)).NotTo(Equal(""), "Should have data.")
 			// Empty agent configMap Data
-			agentCM.Data = ""
+			agentCM.Operation = OprTypeDelete
 			agentCM.Namespace = "invalid"
 			mockMgr.as3Mgr.processAS3CfgMapDelete(agentCM.Name, agentCM.Namespace, &as3Config)
 			Expect(as3Config.overrideConfigmap.State).To(Equal(cmActive),

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -390,6 +390,7 @@ type (
 	}
 
 	AgentCfgMap struct {
+		Operation    string
 		GetEndpoints func(string) []Member
 		Data         string
 		Name         string


### PR DESCRIPTION
Problem: CIS does not update the big-ip object if the namespace label is removed for ConfigMaps.

Solution: Added the support for the management of namespace labels on AS3 Config Maps in CIS.