### PR TITLE
Process CRD TLSProfile with BIG-IP reference SSL Profiles

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -22,6 +22,7 @@ type VirtualServerSpec struct {
 	VirtualServerAddress string `json:"virtualServerAddress"`
 	Pools                []Pool `json:"pools"`
 	TLSProfileName       string `json:"tlsProfileName"`
+	HTTPTraffic          string `json:"httpTraffic,omitempty"`
 }
 
 // Pool defines a pool object in BIG-IP.

--- a/pkg/crmanager/crManager.go
+++ b/pkg/crmanager/crManager.go
@@ -18,6 +18,7 @@ package crmanager
 
 import (
 	"fmt"
+	v1 "k8s.io/api/core/v1"
 	"time"
 
 	"github.com/F5Networks/k8s-bigip-ctlr/config/client/clientset/versioned"
@@ -56,6 +57,10 @@ func NewCRManager(params Params) *CRManager {
 		ControllerMode:  params.ControllerMode,
 		UseNodeInternal: params.UseNodeInternal,
 		initState:       true,
+		SSLContext:      make(map[string]*v1.Secret),
+		customProfiles:  NewCustomProfiles(),
+		irulesMap:       make(IRulesMap),
+		intDgMap:        make(InternalDataGroupMap),
 	}
 
 	log.Debug("Custom Resource Manager Created")

--- a/pkg/crmanager/profile.go
+++ b/pkg/crmanager/profile.go
@@ -1,0 +1,74 @@
+package crmanager
+
+import (
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	"reflect"
+)
+
+// Creates a default SNI profile (if needed) and a new profile from a Secret
+func (crMgr *CRManager) createSecretSslProfile(
+	rsCfg *ResourceConfig,
+	secret *v1.Secret,
+) (error, bool) {
+	if _, ok := secret.Data["tls.crt"]; !ok {
+		err := fmt.Errorf("Invalid Secret '%v': 'tls.crt' field not specified.",
+			secret.ObjectMeta.Name)
+		return err, false
+	}
+	if _, ok := secret.Data["tls.key"]; !ok {
+		err := fmt.Errorf("Invalid Secret '%v': 'tls.key' field not specified.",
+			secret.ObjectMeta.Name)
+		return err, false
+	}
+
+	// Create Default for SNI profile
+	skey := SecretKey{
+		Name:         fmt.Sprintf("default-clientssl-%s", rsCfg.GetName()),
+		ResourceName: rsCfg.GetName(),
+	}
+	sni := ProfileRef{
+		Name:      skey.Name,
+		Partition: rsCfg.Virtual.Partition,
+		Context:   CustomProfileClient,
+	}
+	if _, ok := crMgr.customProfiles.Profs[skey]; !ok {
+		// This is just a basic profile, so we don't need all the fields
+		cp := NewCustomProfile(sni, "", "", "", true, "", "")
+		crMgr.customProfiles.Profs[skey] = cp
+	}
+	rsCfg.Virtual.AddOrUpdateProfile(sni)
+
+	// Now add the resource profile
+	profRef := ProfileRef{
+		Name:      secret.ObjectMeta.Name,
+		Partition: rsCfg.Virtual.Partition,
+		Context:   CustomProfileClient,
+		Namespace: secret.ObjectMeta.Namespace,
+	}
+	cp := NewCustomProfile(
+		profRef,
+		string(secret.Data["tls.crt"]),
+		string(secret.Data["tls.key"]),
+		"",    // serverName
+		false, // sni
+		"",    // peerCertMode
+		"",    // caFile
+	)
+	skey = SecretKey{
+		Name:         cp.Name,
+		ResourceName: rsCfg.GetName(),
+	}
+	crMgr.customProfiles.Lock()
+	defer crMgr.customProfiles.Unlock()
+	if prof, ok := crMgr.customProfiles.Profs[skey]; ok {
+		if !reflect.DeepEqual(prof, cp) {
+			crMgr.customProfiles.Profs[skey] = cp
+			return nil, true
+		} else {
+			return nil, false
+		}
+	}
+	crMgr.customProfiles.Profs[skey] = cp
+	return nil, false
+}


### PR DESCRIPTION
Feature:
Process CRD TLSProfile with BIG-IP reference SSL Profiles

Description:
The scope of this PR is to process the TLSProfile CRD with BIG-IP reference client and server SSL. Example shown below.

```
apiVersion: cis.f5.com/v1
kind: TLSProfile
metadata:
  name: reencrypt-tls
  labels:
    f5cr: "true"
spec:
  tls:
    termination: reencrypt
    clientSSL: /common/clientssl
    serverSSL: /common/serverssl
    reference: bigip
  hosts:
  - foo.example.com
``` 

The behaviour of the http VirtualServer can be handled using httpTraffic object of VirtualServer CustomResource.
```
// -----------------------------------------------------------------
// httpTraffic = allow -> Allows HTTP
// httpTraffic = none  -> Only HTTPS
// httpTraffic = redirect -> redirects HTTP to HTTPS
// -----------------------------------------------------------------
```

Regards,
Abhishek Veeramalla
