### PR TITLE
ip address range for service type lb

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -175,6 +175,7 @@ var (
 	eventChan          chan interface{}
 	configWriter       writer.Writer
 	k8sVersion         string
+	externalIPAddress  *string
 )
 
 func _init() {
@@ -257,6 +258,8 @@ func _init() {
 	userDefinedAS3Decl = bigIPFlags.String("userdefined-as3-declaration", "", userDefinedCfgMapStr)
 	filterTenants = kubeFlags.Bool("filter-tenants", false,
 		"Optional, specify whether or not to use tenant filtering API for AS3 declaration")
+	externalIPAddress = bigIPFlags.String("external-ip-address", "",
+		"Optional, to provide external ip address range to create a free ip pool for usage in service LB")
 	bigIPFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  BigIP:\n%s\n", bigIPFlags.FlagUsagesWrapped(width))
 	}
@@ -933,6 +936,7 @@ func getAppManagerParams() appmanager.Params {
 		AgRspChan:              agRspChan,
 		SchemaLocal:            *schemaLocal,
 		ProcessAgentLabels:     getProcessAgentLabelFunc(),
+		ExternalIP:             *externalIPAddress,
 	}
 }
 


### PR DESCRIPTION
Feature: Add IP address range (for IPV4 and IPV6) to support service of a type load balancer.

Description:
The scope of this PR is to provide a new deployment parameter to generate **20 external IP's** within a given range of IP's to be used for service type load balancer.

Parameter format :  **--external-ip-address=<start_range>-<end_range>,/<subnet>**

Example for both are given below:

**IPv4**
--external-ip-address=192.168.123.0-192.168.123.50,/16

**IPv6**
--external-ip-address=fd34:fe56:7891:2f3a::1-fd34:fe56:7891:2f3a::50/64


Regards,
Nitin Srivastav