### PR TITLE
Remove Docker volume as part of clean up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,7 @@ godep-save: check-gopath
 clean:
 	rm -rf _docker_workspace
 	rm -rf _build
+	docker volume rm -f workspace_vol
 	@echo "Did not clean local go workspace"
 
 info:


### PR DESCRIPTION
Problem: Docker volume is not being removed in case of build failure, which is leading to build environment corruption.
Solution: Remove the volume as part of clean up with make clean.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>