### PR TITLE
Add support to TLSProfile Informer AddEventHandler(UpdateFunc)

### DIFF
--- a/pkg/crmanager/crManager.go
+++ b/pkg/crmanager/crManager.go
@@ -36,6 +36,8 @@ const (
 	DefaultCustomResourceLabel = "f5cr in (true)"
 	// VirtualServer is a F5 Custom Resource Kind.
 	VirtualServer = "VirtualServer"
+	// TLSProfile is a F5 Custom Resource Kind
+	TLSProfile = "TLSProfile"
 	// Service is a k8s native Service Resource.
 	Service = "Service"
 	// Endpoints is a k8s native Endpoint Resource.

--- a/pkg/crmanager/informers.go
+++ b/pkg/crmanager/informers.go
@@ -148,6 +148,14 @@ func (crMgr *CRManager) addEventHandlers(crInf *CRInformer) {
 		},
 	)
 
+	crInf.tsInformer.AddEventHandler(
+		&cache.ResourceEventHandlerFuncs{
+			// AddFunc:    func(obj interface{}) { crMgr.enqueueTLSServer(obj) },
+			UpdateFunc: func(old, cur interface{}) { crMgr.enqueueTLSServer(cur) },
+			// DeleteFunc: func(obj interface{}) { crMgr.enqueueTLSServer(obj) },
+		},
+	)
+
 	crInf.svcInformer.AddEventHandler(
 		&cache.ResourceEventHandlerFuncs{
 			// Ignore AddFunc for service as we dont bother about services until they are
@@ -203,6 +211,19 @@ func (crMgr *CRManager) enqueueDeletedVirtualServer(obj interface{}) {
 		rscName:   vs.ObjectMeta.Name,
 		rsc:       obj,
 		rscDelete: true,
+	}
+
+	crMgr.rscQueue.Add(key)
+}
+
+func (crMgr *CRManager) enqueueTLSServer(obj interface{}) {
+	tls := obj.(*cisapiv1.TLSProfile)
+	log.Infof("Enqueueing TLSProfile: %v", tls)
+	key := &rqKey{
+		namespace: tls.ObjectMeta.Namespace,
+		kind:      TLSProfile,
+		rscName:   tls.ObjectMeta.Name,
+		rsc:       obj,
 	}
 
 	crMgr.rscQueue.Add(key)


### PR DESCRIPTION
Feature:
Add support to TLSProfile Informer AddEventHandler(UpdateFunc)

When a TLSProfile is updated by the User, All the Virtual Servers referencing it should sync for the changes with TLSProfile.
AddFunc and DeleteFunc are not handled in this PR.

Affected Branches:
- master

Regards,
Abhishek Veeramalla