### PR TITLE
Validate TLSProfile CRD for Required SSL Parameters

### DIFF
--- a/pkg/crmanager/worker.go
+++ b/pkg/crmanager/worker.go
@@ -334,6 +334,12 @@ func (crMgr *CRManager) getTLSProfileForVirtualServer(vs *cisapiv1.VirtualServer
 		return nil
 	}
 
+	// validate TLSProfile
+	validation := validateTLSProfile(obj.(*cisapiv1.TLSProfile))
+	if validation == false {
+		return nil
+	}
+
 	// TLSProfile Object
 	return obj.(*cisapiv1.TLSProfile)
 }


### PR DESCRIPTION
Problem:
Validate TLSProfile CRD for Required SSL Parameters

Solution:
Validates TLSProfile CRD for Required SSL Parameters, This includes valid parameters for the type of termination(edge, re-encrypt and Pass-through).

Regards,
Abhishek Veeramalla