### PR TITLE
Handle Issues with as3 Override functionality

### DIFF
--- a/pkg/agent/as3/as3ConfigMap.go
+++ b/pkg/agent/as3/as3ConfigMap.go
@@ -64,12 +64,14 @@ func (am *AS3Manager) prepareResourceAS3ConfigMaps() (
 			as3Cfgmaps = append(as3Cfgmaps, cfgmap)
 
 		case OverrideAS3Label:
-			if rscCfgMap.Operation != OprTypeDelete {
+			if rscCfgMap.Operation == OprTypeDelete {
+				// In the event of deletion config of overriderAS3Cfgmap stays empty
+				// So that nothing gets overridden
+				log.Debugf("Setting overriderAS3CfgmapData to Empty")
+				overriderAS3CfgmapData = ""
+			} else {
 				overriderAS3CfgmapData = rscCfgMap.Data
 			}
-			// In the event of deletion config of overriderAS3Cfgmap stays empty
-			// So that nothing gets overridden
-			overriderAS3CfgmapData = ""
 		}
 	}
 	return as3Cfgmaps, overriderAS3CfgmapData
@@ -79,7 +81,7 @@ func (am *AS3Manager) isValidConfigmap(cfgmap *AgentCfgMap) (string, bool) {
 	if val, ok := cfgmap.Label[F5TypeLabel]; ok && val == VSLabel {
 		if val, ok := cfgmap.Label[OverrideAS3Label]; ok && val == TrueLabel {
 			overriderName := cfgmap.Namespace + "/" + cfgmap.Name
-			if am.OverriderCfgMapName != overriderName {
+			if len(am.OverriderCfgMapName) > 0 && (am.OverriderCfgMapName != overriderName) {
 				log.Errorf("[AS3] Invalid overrider cfgMap: %v", am.OverriderCfgMapName)
 				return "", false
 			}


### PR DESCRIPTION
Problem:
AS3 Override was not working with the changes made to support Multiple AS3 Configmaps

Solution:
Fixed Issues. Override Configmap now works fine along with the changes made to support Multiple AS3 Configmaps.

Regards,
Abhishek Veeramalla