### PR TITLE
CIS Tenant Names in Sync with Actual Configuration

### DIFF
--- a/pkg/agent/as3/as3ConfigMap.go
+++ b/pkg/agent/as3/as3ConfigMap.go
@@ -76,7 +76,7 @@ func (am *AS3Manager) prepareResourceAS3ConfigMaps() (
 				overriderAS3CfgmapData = rscCfgMap.Data
 			}
 		case StagingAS3Label:
-			tenants := getTenants(as3Declaration(rscCfgMap.Data))
+			tenants := getTenants(as3Declaration(rscCfgMap.Data), true)
 			cfgmap := &AS3ConfigMap{
 				Name:      rscCfgMap.Name,
 				Namespace: rscCfgMap.Namespace,

--- a/pkg/agent/as3/as3Manager.go
+++ b/pkg/agent/as3/as3Manager.go
@@ -206,7 +206,7 @@ func (am *AS3Manager) postAS3Config(tempAS3Config AS3Config) (bool, string) {
 	var tenants []string = nil
 
 	if am.FilterTenants {
-		tenants = getTenants(unifiedDecl)
+		tenants = getTenants(unifiedDecl, true)
 	}
 
 	return am.PostManager.postConfig(string(unifiedDecl), tenants)
@@ -300,7 +300,7 @@ func (am *AS3Manager) getTenantObjects(partitions []string) string {
 }
 
 func (am *AS3Manager) getDeletedTenants(curTenantMap map[string]interface{}) []string {
-	prevTenants := getTenants(am.as3ActiveConfig.unifiedDeclaration)
+	prevTenants := getTenants(am.as3ActiveConfig.unifiedDeclaration, false)
 	var deletedTenants []string
 
 	for _, tnt := range prevTenants {
@@ -372,7 +372,7 @@ func (am *AS3Manager) postOnEventOrTimeout(timeout time.Duration) (bool, string)
 	case <-time.After(timeout):
 		var tenants []string = nil
 		if am.FilterTenants {
-			tenants = getTenants(am.as3ActiveConfig.unifiedDeclaration)
+			tenants = getTenants(am.as3ActiveConfig.unifiedDeclaration, true)
 		}
 		unifiedDeclaration := string(am.as3ActiveConfig.unifiedDeclaration)
 		return am.PostManager.postConfig(unifiedDeclaration, tenants)

--- a/pkg/agent/as3/as3Utils.go
+++ b/pkg/agent/as3/as3Utils.go
@@ -163,7 +163,7 @@ func DeepEqualAS3ArbitraryJsonObject(obj1, obj2 map[string]interface{}) bool {
 	return reflect.DeepEqual(obj1, obj2)
 }
 
-func getTenants(decl as3Declaration) []string {
+func getTenants(decl as3Declaration, includeEmptyTenant bool) []string {
 
 	var tmpl interface{}
 	if decl != "" {
@@ -195,7 +195,10 @@ func getTenants(decl as3Declaration) []string {
 		if tnt["class"] != "Tenant" {
 			continue
 		}
-
+		//To delete a parttion we should not consider previously deleted partitions
+		if !includeEmptyTenant && len(tnt) < 2 {
+			continue
+		}
 		tenants = append(tenants, tn)
 	}
 


### PR DESCRIPTION
Bug: CIS's copy of tenant names are not in sync with actual configuration and showing improper tenants logs

Solution: We should not consider previously deleted partitions and keep the tenant names in sync with actual configuration

Affected branch: master

Signed-off-by: Nitin Srivastav srivastavnitin24@gmail.com