### PR TITLE
CIS Crash When Modified The f5label of Virtual Server

### DIFF
--- a/pkg/crmanager/backend.go
+++ b/pkg/crmanager/backend.go
@@ -628,6 +628,9 @@ func processCustomProfilesForAS3(customProfiles *CustomProfileStore, sharedApp a
 func createUpdateTLSServer(prof CustomProfile, svcName string, sharedApp as3Application) bool {
 	// A TLSServer profile needs to carry both Certificate and Key
 	if "" != prof.Cert && "" != prof.Key {
+		if sharedApp[svcName] == nil {
+			return false
+		}
 		svc := sharedApp[svcName].(*as3Service)
 		tlsServerName := fmt.Sprintf("%s_tls_server", svcName)
 		certName := prof.Name


### PR DESCRIPTION
Bug: CIS crash when modified the f5label of CRD virtual server

Solution: Provided a nil check for svcName

Affected branch: master

Signed-off-by: Nitin Srivastav srivastavnitin24@gmail.com