### PR TITLE
Ignoring Reencrypt CRDs with httpTraffic as ALLOW

### DIFF
--- a/pkg/crmanager/resourceConfig.go
+++ b/pkg/crmanager/resourceConfig.go
@@ -561,6 +561,11 @@ func (crMgr *CRManager) handleVirtualServerTLS(
 					PassthroughHostsDgName,
 				)
 			case TLSReencrypt:
+				if vs.Spec.HTTPTraffic == TLSAllowInsecure {
+					log.Errorf("Error in processing Virtual '%s' using TLSProfile '%s' as httpTraffic is configured as ALLOW for reencrypt Termination",
+						vsName, tlsName)
+					return false
+				}
 				updateDataGroupOfDgName(
 					crMgr.intDgMap,
 					vs,


### PR DESCRIPTION
Problem:
CIS currently accepting Reencrypt TLS CRDs with httpTraffic as "allow"

Solution:
Ignoring Reencrypt TLS CRD with httpTraffic as "allow".

DockerImage:
nandakishoref5/k8s-bigip-ctlr:reencrypt_allow_block_v1