### PR TITLE
Handle Invalid CIS Deployment Parameter

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -177,12 +177,12 @@ var (
 )
 
 func _init() {
-	flags = pflag.NewFlagSet("main", pflag.ContinueOnError)
-	globalFlags = pflag.NewFlagSet("Global", pflag.ContinueOnError)
-	bigIPFlags = pflag.NewFlagSet("BigIP", pflag.ContinueOnError)
-	kubeFlags = pflag.NewFlagSet("Kubernetes", pflag.ContinueOnError)
-	vxlanFlags = pflag.NewFlagSet("VXLAN", pflag.ContinueOnError)
-	osRouteFlags = pflag.NewFlagSet("OpenShift Routes", pflag.ContinueOnError)
+	flags = pflag.NewFlagSet("main", pflag.PanicOnError)
+	globalFlags = pflag.NewFlagSet("Global", pflag.PanicOnError)
+	bigIPFlags = pflag.NewFlagSet("BigIP", pflag.PanicOnError)
+	kubeFlags = pflag.NewFlagSet("Kubernetes", pflag.PanicOnError)
+	vxlanFlags = pflag.NewFlagSet("VXLAN", pflag.PanicOnError)
+	osRouteFlags = pflag.NewFlagSet("OpenShift Routes", pflag.PanicOnError)
 
 	// Flag wrapping
 	var err error
@@ -692,6 +692,11 @@ func initCustomResourceManager(
 }
 
 func main() {
+	defer func() {
+		if r := recover(); r != nil {
+			flags.Usage()
+		}
+	}()
 	err := flags.Parse(os.Args)
 	if nil != err {
 		os.Exit(1)

--- a/cmd/k8s-bigip-ctlr/main_test.go
+++ b/cmd/k8s-bigip-ctlr/main_test.go
@@ -595,16 +595,18 @@ var _ = Describe("Main Tests", func() {
 			}
 
 			flags.SetOutput(MockOut{})
+			defer func() {
+				Expect(called).To(BeTrue())
+			}()
 			defer flags.SetOutput(os.Stderr)
-
+			defer func() {
+				if r := recover(); r != nil {
+					flags.Usage()
+				}
+			}()
 			err := flags.Parse(os.Args)
 			Expect(err).ToNot(BeNil())
-			// This implementation changed in spf13 v1.0.3.
-			// Usage() is not called as ContinueOnError is set for unit tests.
-			// So we adopted to the new behaviour introduced.
-			// Refer --> FlagSet.failf() in flag.go
-			Expect(called).To(BeFalse())
-			Expect(len(*openshiftSDNName)).To(Equal(0))
+
 		})
 
 		It("sets up watches for all namespaces", func() {


### PR DESCRIPTION
Bug: Unable to debug when given invalid CIS deployment parameter

Solution: Provided fix to handle invalid deployment parameter in CIS

Affected branch: master

Signed-off-by: Nitin Srivastav srivastavnitin24@gmail.com