### PR TITLE
Fix AB route issue with combination of another WAF route

### DIFF
--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -3979,7 +3979,7 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(rs).ToNot(BeNil(), "Route should be object.")
 
 					Expect(resources.PoolCount()).To(Equal(1))
-					Expect(len(rs.Policies)).To(Equal(0))
+					Expect(len(rs.Policies)).To(Equal(1))
 
 					// Update to real service
 					route.Spec.To.Name = svc1Name
@@ -3988,7 +3988,7 @@ var _ = Describe("AppManager Tests", func() {
 					Expect(resources.PoolCount()).To(Equal(3))
 					rs, _ = resources.Get(
 						ServiceKey{svc1Name, 80, "default"}, "ose-vserver")
-					Expect(len(rs.Policies)).To(Equal(0))
+					Expect(len(rs.Policies)).To(Equal(1))
 
 					// Remove an alternate service
 					mockMgr.deleteService(bazSvc)

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -532,10 +532,6 @@ func (appMgr *Manager) handleRouteRules(
 	tls := route.Spec.TLS
 	abPathIRuleName := JoinBigipPath(DEFAULT_PARTITION, AbDeploymentPathIRuleName)
 
-	if abDeployment {
-		rc.DeleteRuleFromPolicy(policyName, rule, appMgr.mergedRulesMap)
-	}
-
 	if protocol == "http" {
 		if nil == tls || len(tls.Termination) == 0 {
 			if abDeployment {
@@ -543,6 +539,7 @@ func (appMgr *Manager) handleRouteRules(
 					AbDeploymentPathIRuleName, DEFAULT_PARTITION, appMgr.abDeploymentPathIRule())
 				appMgr.addInternalDataGroup(AbDeploymentDgName, DEFAULT_PARTITION)
 				rc.Virtual.AddIRule(abPathIRuleName)
+				rc.AddRuleToPolicy(policyName, rule)
 			} else {
 				rc.AddRuleToPolicy(policyName, rule)
 				SetAnnotationRulesForRoute(policyName, urlRewriteRule, appRootRules, rc)
@@ -591,6 +588,7 @@ func (appMgr *Manager) handleRouteRules(
 						AbDeploymentPathIRuleName, DEFAULT_PARTITION, appMgr.abDeploymentPathIRule())
 					appMgr.addInternalDataGroup(AbDeploymentDgName, DEFAULT_PARTITION)
 					rc.Virtual.AddIRule(abPathIRuleName)
+					rc.AddRuleToPolicy(policyName, rule)
 				} else {
 					appMgr.addIRule(
 						SslPassthroughIRuleName, DEFAULT_PARTITION, appMgr.sslPassthroughIRule())
@@ -600,6 +598,7 @@ func (appMgr *Manager) handleRouteRules(
 					rc.AddRuleToPolicy(policyName, rule)
 					SetAnnotationRulesForRoute(policyName, urlRewriteRule, appRootRules, rc)
 				}
+				rc.AddRuleToPolicy(policyName, rule)
 			case routeapi.TLSTerminationPassthrough:
 				appMgr.addIRule(
 					SslPassthroughIRuleName, DEFAULT_PARTITION, appMgr.sslPassthroughIRule())
@@ -611,8 +610,8 @@ func (appMgr *Manager) handleRouteRules(
 				appMgr.addInternalDataGroup(ReencryptHostsDgName, DEFAULT_PARTITION)
 				appMgr.addInternalDataGroup(ReencryptServerSslDgName, DEFAULT_PARTITION)
 				rc.Virtual.AddIRule(passThroughIRuleName)
+				rc.AddRuleToPolicy(policyName, rule)
 				if !abDeployment {
-					rc.AddRuleToPolicy(policyName, rule)
 					SetAnnotationRulesForRoute(policyName, urlRewriteRule, appRootRules, rc)
 				}
 			}


### PR DESCRIPTION
Problem: AB route traffic is being dropped with the presence of another route with WAF.

Root cause: Policies are not being added for AB routes, which are required for WAF to allow the traffic.

Solution: Add policies for AB routes, as well.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>