### PR TITLE
Fix FlipFlop of Policy with AB deployment Routes

### DIFF
--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -432,7 +432,15 @@ func (appMgr *Manager) createRSConfigFromRoute(
 	}
 	// Create the rule
 	uri := route.Spec.Host + route.Spec.Path
-	rule, err := CreateRule(uri, pool.Name, pool.Partition, FormatRouteRuleName(route))
+
+	var rule *Rule
+	if IsABServiceOfRoute(route, svcName) {
+		poolName := FormatRoutePoolName(route.ObjectMeta.Namespace, route.Spec.To.Name)
+		rule, err = CreateRule(uri, poolName, pool.Partition, FormatRouteRuleName(route))
+	} else {
+		rule, err = CreateRule(uri, pool.Name, pool.Partition, FormatRouteRuleName(route))
+	}
+
 	if nil != err {
 		err = fmt.Errorf("Error configuring rule for Route %s: %v", route.ObjectMeta.Name, err)
 		return &rsCfg, err, Pool{}

--- a/pkg/resource/resourceConfig.go
+++ b/pkg/resource/resourceConfig.go
@@ -311,6 +311,16 @@ func ExistsRouteServiceName(route *routeapi.Route, expSvcName string) bool {
 	return false
 }
 
+// Verify if the service is associated with the route as AlternateBackend
+func IsABServiceOfRoute(route *routeapi.Route, expSvcName string) bool {
+	for _, svc := range route.Spec.AlternateBackends {
+		if expSvcName == svc.Name {
+			return true
+		}
+	}
+	return false
+}
+
 func IsRouteABDeployment(route *routeapi.Route) bool {
 	return route.Spec.AlternateBackends != nil && len(route.Spec.AlternateBackends) > 0
 }


### PR DESCRIPTION
Problem: When a route is deployed with Alternate Backend, policy is getting updated with each service one at a time alternatively, causing config to be being pushed to BIG-IP for every periodic check.

Solution: When a route is deployed with Alternate Backend, policy will have only the actual backend service all the time, as Alternate Backend Pool will be selected by iRule.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>