### PR TITLE
Fix issues with reading TLSProfile Intermittently

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,6 +1,18 @@
 Release Notes for Container Ingress Services for Kubernetes & OpenShift
 =======================================================================
 
+2.2.0
+-------------
+Added Functionality
+`````````````````````
+
+Bug Fixes
+`````````
+
+Limitations
+```````````
+* CIS fails to read TLSProfile Intermittently, We are working with Kubernetes to fix this `issue <https://github.com/kubernetes/code-generator/issues/116>`_.
+
 2.1.1
 -------------
 Added Functionality

--- a/docs/_static/config_examples/crd/CustomResource.md
+++ b/docs/_static/config_examples/crd/CustomResource.md
@@ -64,6 +64,8 @@ This page is created to document the behaviour of CIS in CRD Mode(ALPHA Release)
     - coffee.example.com
 ```
 
+**Known Issue: CIS fails to read TLSProfile Intermittently, We are working with Kubernetes to fix this [issue](https://github.com/kubernetes/code-generator/issues/116)**
+
 ## VirtualServer with TLSProfile
 
 * VirtualServer with TLSProfile is used to specify the TLS termination. TLS termination relies on SNI. Any non-SNI traffic received on port 443 may result in connection issues. Below example shows how to attach a TLSProfile to a VirtualServer.

--- a/pkg/crmanager/resourceConfig.go
+++ b/pkg/crmanager/resourceConfig.go
@@ -471,7 +471,7 @@ func (crMgr *CRManager) handleVirtualServerTLS(
 
 		// TLSProfile Object
 		tlsName := vs.Spec.TLSProfileName
-		tls := crMgr.getTLSProfileForVirtualServer(vs)
+		tls := crMgr.getTLSProfileForVirtualServer(vs, vsNamespace)
 		if tls == nil {
 			return false
 		}

--- a/pkg/crmanager/routing.go
+++ b/pkg/crmanager/routing.go
@@ -532,7 +532,7 @@ func (crMgr *CRManager) handleVSDeleteForDataGroups(
 		return
 	}
 	namespace := virtual.ObjectMeta.Namespace
-	tls := crMgr.getTLSProfileForVirtualServer(virtual)
+	tls := crMgr.getTLSProfileForVirtualServer(virtual, namespace)
 	if tls == nil {
 		return
 	}

--- a/pkg/crmanager/worker.go
+++ b/pkg/crmanager/worker.go
@@ -325,9 +325,10 @@ func getVirtualServersForTLSProfile(allVirtuals []*cisapiv1.VirtualServer,
 	return result
 }
 
-func (crMgr *CRManager) getTLSProfileForVirtualServer(vs *cisapiv1.VirtualServer) *cisapiv1.TLSProfile {
+func (crMgr *CRManager) getTLSProfileForVirtualServer(
+	vs *cisapiv1.VirtualServer,
+	namespace string) *cisapiv1.TLSProfile {
 	tlsName := vs.Spec.TLSProfileName
-	namespace := vs.ObjectMeta.Namespace
 	tlsKey := fmt.Sprintf("%s/%s", namespace, tlsName)
 
 	// Initialize CustomResource Informer for required namespace


### PR DESCRIPTION
Hi, 

 After a lot of research, we can now conclude that the issue is with the kubernetes code-generator package. However, as per few recommendations made in the community, I have made the below change to CIS which did not eliminate the issue but reduced the frequency of the issue.

Change in CIS ---> Instead of reading the namespace from the ObjectMeta of the TLSProfile Custom Resource... Pass the namespace of the VirtualServer Custom Resource as an argument to function which is trying to read the TLSProfile. 

I have raised the below issue on kubernetes organisation, code-generator repository in GitHub.
https://github.com/kubernetes/code-generator/issues/116


Regards,
Abhishek Veeramalla