### PR TITLE
Fix unnecessary creation of HTTP VirtulServer in case of No HTTP traffic

### DIFF
--- a/pkg/crmanager/worker.go
+++ b/pkg/crmanager/worker.go
@@ -480,10 +480,18 @@ func (crMgr *CRManager) syncVirtualServers(
 				portStruct.port,
 			)
 		}
-		if len(virtuals) == 0 {
+
+		// Delete rsCfg if no corresponding virtuals exist
+		// Delete rsCfg if it is HTTP rsCfg and the CR VirtualServer does not have
+		// TLSAllowInsecure or TLSRedirectInsecure as HTTPTraffic
+		if (len(virtuals) == 0) ||
+			(portStruct.protocol == "http" &&
+				!(virtual.Spec.HTTPTraffic == TLSAllowInsecure ||
+					virtual.Spec.HTTPTraffic == TLSRedirectInsecure)) {
 			crMgr.resources.deleteVirtualServer(rsName)
 			continue
 		}
+
 		rsCfg := &ResourceConfig{}
 		rsCfg.Virtual.Partition = crMgr.Partition
 		rsCfg.MetaData.ResourceType = VirtualServer


### PR DESCRIPTION
Problem: Empty HTTP virtual server is being created in case of no HTTP traffic cases associated with HTTPS virtual server

Solution: Create a HTTP virtual server if HTTPS server has TLSAllowInsecure or TLSRedirectInsecure configured.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>