### PR TITLE
Share nodes implementation for CRD, ingress and routes

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -152,6 +152,7 @@ var (
 	trustedCertsCfgmap     *string
 	agent                  *string
 	logAS3Response         *bool
+	shareNodes             *bool
 	overriderAS3CfgmapName *string
 	filterTenants          *bool
 
@@ -240,6 +241,8 @@ func _init() {
 		"Optional, time (in seconds) that CIS waits to post the available AS3 declaration.")
 	logAS3Response = bigIPFlags.Bool("log-as3-response", false,
 		"Optional, when set to true, add the body of AS3 API response in Controller logs.")
+	shareNodes = bigIPFlags.Bool("share-nodes", false,
+		"Optional, when set to true, node will be shared among partition.")
 	enableTLS = bigIPFlags.String("tls-version", "1.2",
 		"Optional, Configure TLS version to be enabled on BIG-IP. TLS1.3 is only supported in tmos version 14.0+.")
 	tls13CipherGroupReference = bigIPFlags.String("cipher-group", "/Common/f5-default",
@@ -691,6 +694,7 @@ func initCustomResourceManager(
 			NodeLabelSelector: *nodeLabelSelector,
 
 			NginxCISConnectMode: *nginxCISConnectMode,
+			ShareNodes:          *shareNodes,
 		},
 	)
 
@@ -973,6 +977,7 @@ func getAS3Params() *as3.Params {
 		SSLInsecure:               *sslInsecure,
 		AS3PostDelay:              *as3PostDelay,
 		LogResponse:               *logAS3Response,
+		ShareNodes:                *shareNodes,
 		RspChan:                   agRspChan,
 		UserAgent:                 getUserAgentInfo(),
 		ConfigWriter:              getConfigWriter(),

--- a/pkg/agent/as3/as3Common.go
+++ b/pkg/agent/as3/as3Common.go
@@ -60,7 +60,7 @@ func (am *AS3Manager) processResourcesForAS3(sharedApp as3Application) {
 		createMonitorDecl(cfg, sharedApp)
 
 		//Create pools
-		createPoolDecl(cfg, sharedApp)
+		createPoolDecl(cfg, sharedApp, am.shareNodes)
 
 		//Create AS3 Service for virtual server
 		createServiceDecl(cfg, sharedApp)
@@ -252,7 +252,7 @@ func createPoliciesDecl(cfg *ResourceConfig, sharedApp as3Application) {
 }
 
 // Create AS3 Pools for Route
-func createPoolDecl(cfg *ResourceConfig, sharedApp as3Application) {
+func createPoolDecl(cfg *ResourceConfig, sharedApp as3Application, shareNodes bool) {
 	for _, v := range cfg.Pools {
 		pool := &as3Pool{}
 		pool.LoadBalancingMode = v.Balance
@@ -263,6 +263,9 @@ func createPoolDecl(cfg *ResourceConfig, sharedApp as3Application) {
 			member.ServicePort = val.Port
 			member.ServerAddresses = append(member.ServerAddresses, val.Address)
 			pool.Members = append(pool.Members, member)
+			if shareNodes {
+				member.ShareNodes = shareNodes
+			}
 		}
 		for _, val := range v.MonitorNames {
 			var monitor as3ResourcePointer

--- a/pkg/agent/as3/as3Manager.go
+++ b/pkg/agent/as3/as3Manager.go
@@ -109,6 +109,7 @@ type AS3Manager struct {
 	as3Version                string
 	as3Release                string
 	unprocessableEntityStatus bool
+	shareNodes                bool
 }
 
 // Struct to allow NewManager to receive all or only specific parameters.
@@ -133,6 +134,7 @@ type Params struct {
 	EventChan           chan interface{}
 	//Log the AS3 response body in Controller logs
 	LogResponse               bool
+	ShareNodes                bool
 	RspChan                   chan interface{}
 	UserAgent                 string
 	As3Version                string
@@ -155,6 +157,7 @@ func NewAS3Manager(params *Params) *AS3Manager {
 		as3Version:                params.As3Version,
 		as3Release:                params.As3Release,
 		OverriderCfgMapName:       params.OverriderCfgMapName,
+		shareNodes:                params.ShareNodes,
 		l2l3Agent: L2L3Agent{eventChan: params.EventChan,
 			configWriter: params.ConfigWriter},
 		PostManager: NewPostManager(PostParams{

--- a/pkg/agent/as3/as3Types.go
+++ b/pkg/agent/as3/as3Types.go
@@ -121,6 +121,7 @@ type (
 		AddressDiscovery string   `json:"addressDiscovery,omitempty"`
 		ServerAddresses  []string `json:"serverAddresses,omitempty"`
 		ServicePort      int32    `json:"servicePort,omitempty"`
+		ShareNodes       bool     `json:"shareNodes,omitempty"`
 	}
 
 	// as3ResourcePointer maps to following in AS3 Resources

--- a/pkg/crmanager/backend.go
+++ b/pkg/crmanager/backend.go
@@ -164,7 +164,7 @@ func createAS3ADC(config ResourceConfigWrapper) as3ADC {
 	sharedApp["class"] = "Application"
 	sharedApp["template"] = "shared"
 	// Process rscfg to create AS3 Resources
-	processResourcesForAS3(config.rsCfgs, sharedApp)
+	processResourcesForAS3(config.rsCfgs, sharedApp, config.shareNodes)
 
 	// Process CustomProfiles
 	processCustomProfilesForAS3(config.customProfiles, sharedApp)
@@ -272,7 +272,7 @@ func getDGRecordValueForAS3(dgName string, sharedApp as3Application, virtualAddr
 }
 
 //Process for AS3 Resource
-func processResourcesForAS3(rsCfgs ResourceConfigs, sharedApp as3Application) {
+func processResourcesForAS3(rsCfgs ResourceConfigs, sharedApp as3Application, shareNodes bool) {
 	for _, cfg := range rsCfgs {
 		//Create policies
 		createPoliciesDecl(cfg, sharedApp)
@@ -281,7 +281,7 @@ func processResourcesForAS3(rsCfgs ResourceConfigs, sharedApp as3Application) {
 		createMonitorDecl(cfg, sharedApp)
 
 		//Create pools
-		createPoolDecl(cfg, sharedApp)
+		createPoolDecl(cfg, sharedApp, shareNodes)
 
 		switch cfg.MetaData.ResourceType {
 		case VirtualServer:
@@ -324,7 +324,7 @@ func createPoliciesDecl(cfg *ResourceConfig, sharedApp as3Application) {
 }
 
 // Create AS3 Pools for CRD
-func createPoolDecl(cfg *ResourceConfig, sharedApp as3Application) {
+func createPoolDecl(cfg *ResourceConfig, sharedApp as3Application, shareNodes bool) {
 	for _, v := range cfg.Pools {
 		pool := &as3Pool{}
 		// TODO
@@ -335,6 +335,9 @@ func createPoolDecl(cfg *ResourceConfig, sharedApp as3Application) {
 			member.AddressDiscovery = "static"
 			member.ServicePort = val.Port
 			member.ServerAddresses = append(member.ServerAddresses, val.Address)
+			if shareNodes {
+				member.ShareNodes = shareNodes
+			}
 			pool.Members = append(pool.Members, member)
 		}
 		for _, val := range v.MonitorNames {

--- a/pkg/crmanager/crManager.go
+++ b/pkg/crmanager/crManager.go
@@ -82,6 +82,7 @@ func NewCRManager(params Params) *CRManager {
 		dgPath:          strings.Join([]string{DEFAULT_PARTITION, "Shared"}, "/"),
 
 		NginxCISConnectMode: params.NginxCISConnectMode,
+		shareNodes:          params.ShareNodes,
 	}
 
 	log.Debug("Custom Resource Manager Created")

--- a/pkg/crmanager/types.go
+++ b/pkg/crmanager/types.go
@@ -61,6 +61,7 @@ type (
 		dgPath    string
 
 		NginxCISConnectMode bool
+		shareNodes          bool
 	}
 	// Params defines parameters
 	Params struct {
@@ -76,6 +77,7 @@ type (
 		NodeLabelSelector string
 
 		NginxCISConnectMode bool
+		ShareNodes          bool
 	}
 	// CRInformer defines the structure of Custom Resource Informer
 	CRInformer struct {
@@ -165,6 +167,7 @@ type (
 		iRuleMap       IRulesMap
 		intDgMap       InternalDataGroupMap
 		customProfiles *CustomProfileStore
+		shareNodes     bool
 	}
 
 	// Pool config
@@ -462,6 +465,7 @@ type (
 		AddressDiscovery string   `json:"addressDiscovery,omitempty"`
 		ServerAddresses  []string `json:"serverAddresses,omitempty"`
 		ServicePort      int32    `json:"servicePort,omitempty"`
+		ShareNodes       bool     `json:"shareNodes,omitempty"`
 	}
 
 	// as3ResourcePointer maps to following in AS3 Resources

--- a/pkg/crmanager/worker.go
+++ b/pkg/crmanager/worker.go
@@ -171,8 +171,8 @@ func (crMgr *CRManager) processResource() bool {
 			iRuleMap:       crMgr.irulesMap,
 			intDgMap:       crMgr.intDgMap,
 			customProfiles: crMgr.customProfiles,
+			shareNodes:     crMgr.shareNodes,
 		}
-
 		crMgr.Agent.PostConfig(config)
 		crMgr.initState = false
 		crMgr.resources.updateOldConfig()


### PR DESCRIPTION
Share node implementation for CRD, ingress and routes
Implementation of global share nodes flag(--share-nodes=true) which shares node across tenants.

Signed-off-by: Amit Kumar Gupta amitg2812@gmail.com
