### PR TITLE
Fix NginxCisConnector resource type issue

### DIFF
--- a/pkg/crmanager/nccWorker.go
+++ b/pkg/crmanager/nccWorker.go
@@ -226,7 +226,7 @@ func (crMgr *CRManager) syncNginxCisConnector(
 
 		rsCfg := &ResourceConfig{}
 		rsCfg.Virtual.Partition = crMgr.Partition
-		rsCfg.MetaData.ResourceType = NginxCisConnector
+		rsCfg.MetaData.ResourceType = VirtualServer
 		rsCfg.Virtual.Enabled = true
 		rsCfg.Virtual.Name = rsName
 		rsCfg.Virtual.SNAT = DEFAULT_SNAT


### PR DESCRIPTION
When referring to Resource Type, it is with respect to BIG-IP, so the resource type should be VirtualServer, but not NginxCisConnector.

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>