### PR TITLE
Fix configmap serviceport value for nodeport mode #1602

### DIFF
--- a/pkg/agent/as3/as3ConfigMap.go
+++ b/pkg/agent/as3/as3ConfigMap.go
@@ -171,7 +171,7 @@ func (am *AS3Manager) processCfgMap(rscCfgMap *AgentCfgMap) (
 				var ips []string
 				var port int32
 				for _, v := range eps {
-					if int(v.Port) == int(poolMem["servicePort"].(float64)) {
+					if int(v.SvcPort) == int(poolMem["servicePort"].(float64)) {
 						ips = append(ips, v.Address)
 						members = append(members, v)
 						port = v.Port

--- a/pkg/agent/as3/as3Manager_test.go
+++ b/pkg/agent/as3/as3Manager_test.go
@@ -34,8 +34,8 @@ func newMockAS3Manager(params *Params) *mockAS3Manager {
 }
 
 func mockGetEndPoints(string, string) []Member {
-	return []Member{{Address: "1.1.1.1", Port: 80},
-		{Address: "2.2.2.2", Port: 80}}
+	return []Member{{Address: "1.1.1.1", Port: 80, SvcPort: 80},
+		{Address: "2.2.2.2", Port: 80, SvcPort: 80}}
 }
 
 func (m *mockAS3Manager) shutdown() error {

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1954,7 +1954,7 @@ func (appMgr *Manager) updatePoolMembersForNodePort(
 					svcKey, portSpec.NodePort)
 				rsCfg.MetaData.Active = true
 				rsCfg.Pools[index].Members =
-					appMgr.getEndpointsForNodePort(portSpec.NodePort)
+					appMgr.getEndpointsForNodePort(portSpec.NodePort, portSpec.Port)
 			}
 		}
 		return true, "", ""
@@ -2317,6 +2317,7 @@ func (appMgr *Manager) getEndpointsForCluster(
 						member := Member{
 							Address: addr.IP,
 							Port:    p.Port,
+							SvcPort: p.Port,
 							Session: "user-enabled",
 						}
 						members = append(members, member)
@@ -2329,7 +2330,7 @@ func (appMgr *Manager) getEndpointsForCluster(
 }
 
 func (appMgr *Manager) getEndpointsForNodePort(
-	nodePort int32,
+	nodePort, port int32,
 ) []Member {
 	nodes := appMgr.getNodesFromCache()
 	var members []Member
@@ -2337,6 +2338,7 @@ func (appMgr *Manager) getEndpointsForNodePort(
 		member := Member{
 			Address: v.Addr,
 			Port:    nodePort,
+			SvcPort: port,
 			Session: "user-enabled",
 		}
 		members = append(members, member)
@@ -2574,7 +2576,7 @@ func (m *Manager) getEndpoints(selector, namespace string) []Member {
 		} else { // Controller is in NodePort mode.
 			if service.Spec.Type == v1.ServiceTypeNodePort {
 				for _, port := range service.Spec.Ports {
-					members = m.getEndpointsForNodePort(port.NodePort)
+					members = m.getEndpointsForNodePort(port.NodePort, port.Port)
 				}
 			} /* else {
 				msg := fmt.Sprintf("[CORE] Requested service backend '%+v' not of NodePort type", service.Name)

--- a/pkg/crmanager/backend.go
+++ b/pkg/crmanager/backend.go
@@ -27,7 +27,6 @@ import (
 
 	"github.com/F5Networks/k8s-bigip-ctlr/pkg/writer"
 
-	rsc "github.com/F5Networks/k8s-bigip-ctlr/pkg/resource"
 	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
 )
 
@@ -133,12 +132,12 @@ func (agent *Agent) PostConfig(config ResourceConfigWrapper) {
 	allPoolMembers := config.rsCfgs.GetAllPoolMembers()
 
 	// Convert allPoolMembers to appmanger.Members so that vxlan Manger accepts
-	var allPoolMems []rsc.Member
+	var allPoolMems []Member
 
 	for _, poolMem := range allPoolMembers {
 		allPoolMems = append(
 			allPoolMems,
-			rsc.Member(poolMem),
+			Member(poolMem),
 		)
 	}
 	if agent.EventChan != nil {
@@ -662,7 +661,7 @@ func processTLSProfilesForAS3(virtual *Virtual, svc *as3Service, profileName str
 	as3ServerSuffix := "_tls_server"
 	for _, profile := range virtual.Profiles {
 		switch profile.Context {
-		case rsc.CustomProfileClient:
+		case CustomProfileClient:
 			// Profile is stored in a k8s secret
 			if profile.Partition == "" {
 				// Incoming traffic (clientssl) from a web client will be handled by ServerTLS in AS3
@@ -677,7 +676,7 @@ func processTLSProfilesForAS3(virtual *Virtual, svc *as3Service, profileName str
 				}
 			}
 			updateVirtualToHTTPS(svc)
-		case rsc.CustomProfileServer:
+		case CustomProfileServer:
 			// Profile is stored in a k8s secret
 			if profile.Partition == "" {
 				// Outgoing traffic (serverssl) to BackEnd Servers from BigIP will be handled by ClientTLS in AS3

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -103,6 +103,7 @@ type (
 	Member struct {
 		Address string `json:"address"`
 		Port    int32  `json:"port"`
+		SvcPort int32  `json:"svcPort"`
 		Session string `json:"session,omitempty"`
 	}
 

--- a/pkg/test/configs/oneSvcOneNodeConfigExp.json
+++ b/pkg/test/configs/oneSvcOneNodeConfigExp.json
@@ -33,6 +33,7 @@
             {
               "address":"127.0.0.3",
               "port":37001,
+              "svcPort": 80,
               "session":"user-enabled"
             }
           ]

--- a/pkg/test/configs/oneSvcTwoPodsConfigExp.json
+++ b/pkg/test/configs/oneSvcTwoPodsConfigExp.json
@@ -33,11 +33,13 @@
             {
               "address":"10.2.96.0",
               "port":80,
+              "svcPort":80,
               "session":"user-enabled"
             },
             {
               "address":"10.2.96.3",
               "port":80,
+              "svcPort":80,
               "session":"user-enabled"
             }
           ]

--- a/pkg/test/configs/twoSvcTwoPodsConfigExp.json
+++ b/pkg/test/configs/twoSvcTwoPodsConfigExp.json
@@ -55,11 +55,13 @@
             {
               "address":"10.2.96.0",
               "port":80,
+              "svcPort":80,
               "session":"user-enabled"
             },
             {
               "address":"10.2.96.3",
               "port":80,
+              "svcPort":80,
               "session":"user-enabled"
             }
           ]
@@ -71,11 +73,13 @@
             {
               "address":"10.2.96.1",
               "port":8080,
+              "svcPort": 8080,
               "session":"user-enabled"
             },
             {
               "address":"10.2.96.2",
               "port":8080,
+              "svcPort": 8080,
               "session":"user-enabled"
             }
           ]

--- a/pkg/test/configs/twoSvcsFourPortsFourNodesConfigExp.json
+++ b/pkg/test/configs/twoSvcsFourPortsFourNodesConfigExp.json
@@ -99,21 +99,25 @@
               {
                 "address":"127.0.0.0",
                 "port":37001,
+                "svcPort": 80,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.1",
                 "port":37001,
+                "svcPort": 80,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.2",
                 "port":37001,
+                "svcPort": 80,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.3",
                 "port":37001,
+                "svcPort": 80,
                 "session":"user-enabled"
               }
             ],
@@ -126,21 +130,25 @@
               {
                 "address":"127.0.0.0",
                 "port":30001,
+                "svcPort": 80,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.1",
                 "port":30001,
+                "svcPort": 80,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.2",
                 "port":30001,
+                "svcPort": 80,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.3",
                 "port":30001,
+                "svcPort": 80,
                 "session":"user-enabled"
               }
             ],
@@ -155,21 +163,25 @@
               {
                 "address":"127.0.0.0",
                 "port":38001,
+                "svcPort": 8080,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.1",
                 "port":38001,
+                "svcPort": 8080,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.2",
                 "port":38001,
+                "svcPort": 8080,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.3",
                 "port":38001,
+                "svcPort": 8080,
                 "session":"user-enabled"
               }
             ],
@@ -182,21 +194,25 @@
               {
                 "address":"127.0.0.0",
                 "port":39001,
+                "svcPort": 9090,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.1",
                 "port":39001,
+                "svcPort": 9090,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.2",
                 "port":39001,
+                "svcPort": 9090,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.3",
                 "port":39001,
+                "svcPort": 9090,
                 "session":"user-enabled"
               }
             ],

--- a/pkg/test/configs/twoSvcsFourPortsThreeNodesConfigExp.json
+++ b/pkg/test/configs/twoSvcsFourPortsThreeNodesConfigExp.json
@@ -99,16 +99,19 @@
             {
               "address":"127.0.0.1",
               "port":37001,
+              "svcPort": 80,
               "session":"user-enabled"
             },
             {
               "address":"127.0.0.2",
               "port":37001,
+              "svcPort": 80,
               "session":"user-enabled"
             },
             {
               "address":"127.0.0.3",
               "port":37001,
+              "svcPort": 80,
               "session":"user-enabled"
             }
           ],
@@ -121,16 +124,19 @@
             {
               "address":"127.0.0.1",
               "port":30001,
+              "svcPort": 80,
               "session":"user-enabled"
             },
             {
               "address":"127.0.0.2",
               "port":30001,
+              "svcPort": 80,
               "session":"user-enabled"
             },
             {
               "address":"127.0.0.3",
               "port":30001,
+              "svcPort": 80,
               "session":"user-enabled"
             }
           ],
@@ -145,16 +151,19 @@
             {
               "address":"127.0.0.1",
               "port":38001,
+              "svcPort": 8080,
               "session":"user-enabled"
             },
             {
               "address":"127.0.0.2",
               "port":38001,
+              "svcPort": 8080,
               "session":"user-enabled"
             },
             {
               "address":"127.0.0.3",
               "port":38001,
+              "svcPort": 8080,
               "session":"user-enabled"
             }
           ],
@@ -167,16 +176,19 @@
             {
               "address":"127.0.0.1",
               "port":39001,
+              "svcPort": 9090,
               "session":"user-enabled"
             },
             {
               "address":"127.0.0.2",
               "port":39001,
+              "svcPort": 9090,
               "session":"user-enabled"
             },
             {
               "address":"127.0.0.3",
               "port":39001,
+              "svcPort": 9090,
               "session":"user-enabled"
             }
           ],

--- a/pkg/test/configs/twoSvcsOneNodeConfigExp.json
+++ b/pkg/test/configs/twoSvcsOneNodeConfigExp.json
@@ -60,6 +60,7 @@
             {
               "address":"127.0.0.3",
               "port":37001,
+              "svcPort":80,
               "session":"user-enabled"
             }
           ]
@@ -71,6 +72,7 @@
             {
               "address":"127.0.0.3",
               "port":30001,
+              "svcPort":80,
               "session":"user-enabled"
             }
           ],

--- a/pkg/test/configs/twoSvcsThreeNodesConfigExp.json
+++ b/pkg/test/configs/twoSvcsThreeNodesConfigExp.json
@@ -60,16 +60,19 @@
               {
                 "address":"127.0.0.0",
                 "port":37001,
+                "svcPort": 80,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.1",
                 "port":37001,
+                "svcPort": 80,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.2",
                 "port":37001,
+                "svcPort": 80,
                 "session":"user-enabled"
               }
             ]
@@ -81,16 +84,19 @@
               {
                 "address":"127.0.0.0",
                 "port":30001,
+                "svcPort": 80,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.1",
                 "port":30001,
+                "svcPort": 80,
                 "session":"user-enabled"
               },
               {
                 "address":"127.0.0.2",
                 "port":30001,
+                "svcPort": 80,
                 "session":"user-enabled"
               }
             ],

--- a/pkg/test/configs/twoSvcsTwoNodesConfigExp.json
+++ b/pkg/test/configs/twoSvcsTwoNodesConfigExp.json
@@ -60,11 +60,13 @@
             {
               "address":"127.0.0.1",
               "port":37001,
+              "svcPort": 80,
               "session":"user-enabled"
             },
             {
               "address":"127.0.0.2",
               "port":37001,
+              "svcPort": 80,
               "session":"user-enabled"
             }
           ]
@@ -76,11 +78,13 @@
             {
               "address":"127.0.0.1",
               "port":30001,
+              "svcPort": 80,
               "session":"user-enabled"
             },
             {
               "address":"127.0.0.2",
               "port":30001,
+              "svcPort": 80,
               "session":"user-enabled"
             }
           ],


### PR DESCRIPTION
Problem : With multiport service support enabled from 2.2.1, while running CIS in nodeport mode, user has to provide service's nodeport value in the configmap servicePort.

Solution: Fix made to map service port to corresponding service's nodeport so that config maps are compatible for 2.2.0 and 2.2.1

Ref: 
https://github.com/F5Networks/k8s-bigip-ctlr/pull/1564 
https://github.com/F5Networks/k8s-bigip-ctlr/issues/1602 