### PR TITLE
Handle invalid configmap processing

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1111,6 +1111,13 @@ func (appMgr *Manager) syncConfigMaps(
 		}
 
 		if appMgr.AgentCIS.IsImplInAgent(ResourceTypeCfgMap) {
+			//ignore invalid as3 configmaps if found.
+			if sKey.Operation != OprTypeDelete {
+				err := validateConfigJson(cm.Data["template"])
+				if err != nil {
+					continue
+				}
+			}
 			if ok := appMgr.processAgentLabels(cm.Labels, cm.Name, cm.Namespace); ok {
 				agntCfgMap := new(AgentCfgMap)
 				agntCfgMap.Init(cm.Name, cm.Namespace, cm.Data["template"], cm.Labels, appMgr.getEndpoints)


### PR DESCRIPTION
Problem: CIS deletes the previously existing configuration from tenant , if corresponding configmap is edited with invalid config.

Solution: Ignore the invalid config and dont cleanup configuration unless configmap is updated with valid config or deleted.