### PR TITLE
Fixed the multiport support for nodeport

### DIFF
--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -2577,7 +2577,7 @@ func (m *Manager) getEndpoints(selector, namespace string) []Member {
 		} else { // Controller is in NodePort mode.
 			if service.Spec.Type == v1.ServiceTypeNodePort {
 				for _, port := range service.Spec.Ports {
-					members = m.getEndpointsForNodePort(port.NodePort, port.Port)
+					members = append(members, m.getEndpointsForNodePort(port.NodePort, port.Port)...)
 				}
 			} /* else {
 				msg := fmt.Sprintf("[CORE] Requested service backend '%+v' not of NodePort type", service.Name)


### PR DESCRIPTION
Problem : Multiport service support was broken for nodeport mode in CIS 2.2.1 release.

Solution: Fix made to support the multiport service in nodeport mode.