### PR TITLE
Added support for irules for virtual server custom resource 

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -31,6 +31,7 @@ type VirtualServerSpec struct {
 	WAF                    string   `json:"waf,omitempty"`
 	RewriteAppRoot         string   `json:"rewriteAppRoot,omitempty"`
 	AllowVLANs             []string `json:"allowVlans,omitempty"`
+	IRules                  []string `json:"iRules,omitempty"`
 }
 
 // Pool defines a pool object in BIG-IP.

--- a/docs/_static/config_examples/crd/Install/customresourcedefinitions.yml
+++ b/docs/_static/config_examples/crd/Install/customresourcedefinitions.yml
@@ -45,6 +45,10 @@ spec:
                     type: string
                     pattern: '^\/([A-z0-9-_+]+\/)*([A-z0-9-_]+\/?)*$'
                   type: array
+                iRules:
+                  type: array
+                  items:
+                    type: string
                 pools:
                   type: array
                   items:

--- a/pkg/crmanager/backend.go
+++ b/pkg/crmanager/backend.go
@@ -402,12 +402,18 @@ func updateVirtualToHTTPS(v *as3Service) {
 
 // Process Irules for CRD
 func processIrulesForCRD(cfg *ResourceConfig, svc *as3Service) {
+	var IRules []interface{}
 	for _, v := range cfg.Virtual.IRules {
 		splits := strings.Split(v, "/")
 		iRuleName := splits[len(splits)-1]
 		matched := false
-		var IRules []interface{}
-		iRuleNoPort := iRuleName[:strings.LastIndex(iRuleName, "_")]
+		var iRuleNoPort string
+		lastIndex := strings.LastIndex(iRuleName, "_")
+		if lastIndex > 0 {
+			iRuleNoPort = iRuleName[:lastIndex]
+		} else {
+			iRuleNoPort = iRuleName
+		}
 		if iRuleNoPort == HttpRedirectIRuleName || iRuleNoPort == HttpRedirectNoHostIRuleName || iRuleName == SslPassthroughIRuleName {
 			matched = true
 		}

--- a/pkg/crmanager/resourceConfig.go
+++ b/pkg/crmanager/resourceConfig.go
@@ -455,6 +455,10 @@ func (crMgr *CRManager) prepareRSConfigFromVirtualServer(
 		rsCfg.SetPolicy(*plcy)
 	}
 
+	// Attach user specified iRules
+	if len(vs.Spec.IRules) > 0 {
+		rsCfg.Virtual.IRules = append(rsCfg.Virtual.IRules, vs.Spec.IRules...)
+	}
 	return nil
 }
 


### PR DESCRIPTION
Problem: Currently virtual server custom resource does not allow to reference iRules created in bigip.
Solution: Added the support for irules in virtual server custom resource as mentioned in [Github-1571](https://github.com/F5Networks/k8s-bigip-ctlr/issues/1571)