### PR TITLE
Allow vlans support for TransportServer CRD

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -30,7 +30,7 @@ type VirtualServerSpec struct {
 	SNAT                   string   `json:"snat,omitempty"`
 	WAF                    string   `json:"waf,omitempty"`
 	RewriteAppRoot         string   `json:"rewriteAppRoot,omitempty"`
-	AllowVlans             []string `json:"allowVlans,omitempty"`
+	AllowVLANs             []string `json:"allowVlans,omitempty"`
 }
 
 // Pool defines a pool object in BIG-IP.
@@ -145,12 +145,13 @@ type TransportServer struct {
 
 // TransportServerSpec is the spec of the VirtualServer resource.
 type TransportServerSpec struct {
-	VirtualServerAddress string `json:"virtualServerAddress"`
-	VirtualServerPort    int32  `json:"virtualServerPort"`
-	VirtualServerName    string `json:"virtualServerName"`
-	Mode                 string `json:"mode"`
-	SNAT                 string `json:"snat"`
-	Pool                 Pool   `json:"pool"`
+	VirtualServerAddress string   `json:"virtualServerAddress"`
+	VirtualServerPort    int32    `json:"virtualServerPort"`
+	VirtualServerName    string   `json:"virtualServerName"`
+	Mode                 string   `json:"mode"`
+	SNAT                 string   `json:"snat"`
+	Pool                 Pool     `json:"pool"`
+	AllowVLANs           []string `json:"allowVlans,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/docs/_static/config_examples/crd/CustomResource.md
+++ b/docs/_static/config_examples/crd/CustomResource.md
@@ -241,6 +241,7 @@ Known Issues:
 | virtualServerName | String | Optional | NA | Custom name of BIG-IP Virtual Server |
 | mode | String | Required | NA |  "standard" or "performance". A Standard mode transport server processes connections using the full proxy architecture. A Performance mode transport server uses FastL4 packet-by-packet TCP behavior. |
 | snat | String | Optional | auto |  |
+| allowVlans | List of Vlans | Optional | Allow traffic from all VLANS | list of Vlan objects to allow traffic from |
 
 **Pool Components**
 

--- a/docs/_static/config_examples/crd/TransportServer/transport-server.yaml
+++ b/docs/_static/config_examples/crd/TransportServer/transport-server.yaml
@@ -11,6 +11,7 @@ spec:
   virtualServerName: my-ts
   mode: standard
   snat: auto
+  allowVlans: ["/Common/devtraffic"]
   pool:
     service: svc-1
     servicePort: 8181

--- a/operator/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-customresourcedefinitions.yml
+++ b/operator/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-customresourcedefinitions.yml
@@ -166,6 +166,11 @@ spec:
             spec:
               type: object
               properties:
+                allowVlans:
+                  type: array
+                  items:
+                    type: string
+                    pattern: '^[\/][A-Za-z0-9-_]+[\/][A-Za-z0-9-_]+$'
                 virtualServerAddress:
                   type: string
                   pattern: '^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$'

--- a/pkg/crmanager/backend.go
+++ b/pkg/crmanager/backend.go
@@ -488,7 +488,7 @@ func createServiceDecl(cfg *ResourceConfig, sharedApp as3Application) {
 	}
 	//Attach allowVlans if exist.
 	var vlans []as3ResourcePointer
-	for _, va := range cfg.Virtual.AllowVlans {
+	for _, va := range cfg.Virtual.AllowVLANs {
 		vlans = append(
 			vlans,
 			as3ResourcePointer{
@@ -496,7 +496,7 @@ func createServiceDecl(cfg *ResourceConfig, sharedApp as3Application) {
 			},
 		)
 	}
-	svc.AllowVlans = vlans
+	svc.AllowVLANs = vlans
 	svc.Class = "Service_HTTP"
 
 	virtualAddress, port := extractVirtualAddressAndPort(cfg.Virtual.Destination)
@@ -900,6 +900,13 @@ func createTransportServiceDecl(cfg *ResourceConfig, sharedApp as3Application) {
 	}
 	for _, pool := range cfg.Pools {
 		svc.Pool = pool.Name
+	}
+
+	if cfg.Virtual.AllowVLANs != nil {
+		for _, vlan := range cfg.Virtual.AllowVLANs {
+			vlans := as3ResourcePointer{BigIP: vlan}
+			svc.AllowVLANs = append(svc.AllowVLANs, vlans)
+		}
 	}
 	//process irules for crd
 	processIrulesForCRD(cfg, svc)

--- a/pkg/crmanager/resourceConfig.go
+++ b/pkg/crmanager/resourceConfig.go
@@ -427,7 +427,7 @@ func (crMgr *CRManager) prepareRSConfigFromVirtualServer(
 		rsCfg.Virtual.WAF = vs.Spec.WAF
 	}
 	//Attach allowVlans.
-	rsCfg.Virtual.AllowVlans = vs.Spec.AllowVlans
+	rsCfg.Virtual.AllowVLANs = vs.Spec.AllowVLANs
 
 	// Do not Create Virtual Server L7 Forwarding policies if HTTPTraffic is set to None or Redirect
 	if len(vs.Spec.TLSProfileName) > 0 &&
@@ -1732,5 +1732,7 @@ func (crMgr *CRManager) prepareRSConfigFromTransportServer(
 	} else {
 		rsCfg.Virtual.SNAT = vs.Spec.SNAT
 	}
+	//set allowed VLAN's per TS config
+	rsCfg.Virtual.AllowVLANs = vs.Spec.AllowVLANs
 	return nil
 }

--- a/pkg/crmanager/types.go
+++ b/pkg/crmanager/types.go
@@ -147,7 +147,7 @@ type (
 		TranslateServerAddress bool                  `json:"translateServerAddress"`
 		TranslateServerPort    bool                  `json:"translateServerPort"`
 		Source                 string                `json:"source,omitempty"`
-		AllowVlans             []string              `json:"allowVlans,omitempty"`
+		AllowVLANs             []string              `json:"allowVlans,omitempty"`
 	}
 	// Virtuals is slice of virtuals
 	Virtuals []Virtual
@@ -549,7 +549,7 @@ type (
 		Pool                   string               `json:"pool,omitempty"`
 		WAF                    as3MultiTypeParam    `json:"policyWAF,omitempty"`
 		ProfileL4              string               `json:"profileL4,omitempty"`
-		AllowVlans             []as3ResourcePointer `json:"allowVlans,omitempty"`
+		AllowVLANs             []as3ResourcePointer `json:"allowVlans,omitempty"`
 	}
 
 	// as3Monitor maps to the following in AS3 Resources


### PR DESCRIPTION
Add allowVlans support for TransportServer resource

https://github.com/F5Networks/k8s-bigip-ctlr/issues/1621

https://github.com/F5Networks/k8s-bigip-ctlr/issues/1592 

TS yaml files now suppport below spec parameter : 

`allowVlans: ["/Common/devtraffic"] `