### PR TITLE
add columns to Transport Server CRD

### DIFF
--- a/operator/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-customresourcedefinitions.yml
+++ b/operator/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-customresourcedefinitions.yml
@@ -211,7 +211,26 @@ spec:
                 - virtualServerAddress
                 - virtualServerPort
                 - pool
-
+      additionalPrinterColumns:
+      - name: virtualServerAddress
+        type: string
+        description: IP address of virtualServer
+        jsonPath: .spec.virtualServerAddress
+      - name: virtualServerPort
+        type: integer
+        description: Port of virtualServer
+        jsonPath: .spec.virtualServerPort
+      - name: pool
+        type: string
+        description: Name of service
+        jsonPath: .spec.pool.service
+      - name: poolPort
+        type: string
+        description: Port of service
+        jsonPath: .spec.pool.servicePort
+      - name: Age
+        type: date
+        jsonPath: .metadata.creationTimestamp
 ---
 apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition


### PR DESCRIPTION
This changes the format to add columns to the output for TransportServers i.e.:

```
$ kubectl get ts -n cluster1
NAME              VIRTUALSERVERADDRESS   VIRTUALSERVERPORT   POOL          POOLPORT   AGE
frontend1         10.1.10.82             8081                frontend1     80         3h20m
frontend2         10.1.10.82             8082                frontend2     80         3h20m
frontend3         10.1.10.82             8083                frontend3     80         3h20m
frontend4         10.1.10.82             8084                frontend4     80         3h20m
frontend5         10.1.10.82             8085                frontend5     80         3h20m
my-frontend-crd   10.1.10.82             8080                my-frontend   80         3h55m
```
this looks nicer than the default of
```
NAME              AGE
frontend1         3h21m
frontend2         3h21m
frontend3         3h21m
frontend4         3h21m
frontend5         3h21m
my-frontend-crd   3h55m
```