### PR TITLE
Fixing the issue where TransportServer assigns wrong pool/service

### DIFF
--- a/pkg/crmanager/backend.go
+++ b/pkg/crmanager/backend.go
@@ -904,10 +904,7 @@ func createTransportServiceDecl(cfg *ResourceConfig, sharedApp as3Application) {
 		svc.VirtualAddresses = va
 		svc.VirtualPort = port
 	}
-	for _, pool := range cfg.Pools {
-		svc.Pool = pool.Name
-	}
-
+	svc.Pool = cfg.Virtual.PoolName
 	if cfg.Virtual.AllowVLANs != nil {
 		for _, vlan := range cfg.Virtual.AllowVLANs {
 			vlans := as3ResourcePointer{BigIP: vlan}

--- a/pkg/crmanager/resourceConfig.go
+++ b/pkg/crmanager/resourceConfig.go
@@ -1685,7 +1685,6 @@ func (crMgr *CRManager) prepareRSConfigFromTransportServer(
 ) error {
 
 	var pools Pools
-	var poolExist bool
 	var monitors []Monitor
 	var snat string
 	snat = DEFAULT_SNAT
@@ -1700,16 +1699,6 @@ func (crMgr *CRManager) prepareRSConfigFromTransportServer(
 		ServiceName:     vs.Spec.Pool.Service,
 		ServicePort:     vs.Spec.Pool.ServicePort,
 		NodeMemberLabel: vs.Spec.Pool.NodeMemberLabel,
-	}
-	for _, p := range pools {
-		if pool.Name == p.Name {
-			poolExist = true
-			break
-		}
-	}
-	if poolExist {
-		poolExist = false
-		return nil
 	}
 
 	if vs.Spec.Pool.Monitor.Type != "" {
@@ -1728,6 +1717,7 @@ func (crMgr *CRManager) prepareRSConfigFromTransportServer(
 	}
 	pools = append(pools, pool)
 	rsCfg.Virtual.Mode = vs.Spec.Mode
+	rsCfg.Virtual.PoolName = pool.Name
 	rsCfg.Pools = append(rsCfg.Pools, pools...)
 	rsCfg.Monitors = append(rsCfg.Monitors, monitors...)
 	// set the SNAT policy to auto is it's not defined by end user

--- a/pkg/crmanager/worker.go
+++ b/pkg/crmanager/worker.go
@@ -957,7 +957,7 @@ func (crMgr *CRManager) syncTransportServers(
 	// In the event of deletion, exclude the deleted VirtualServer
 	log.Debugf("Process all the Virtual Servers which share same VirtualServerAddress")
 	for _, vrt := range allVirtuals {
-		if vrt.Spec.VirtualServerAddress == virtual.Spec.VirtualServerAddress &&
+		if vrt.Spec.VirtualServerAddress == virtual.Spec.VirtualServerAddress && vrt.Spec.VirtualServerPort == virtual.Spec.VirtualServerPort &&
 			!isTSDeleted {
 			virtuals = append(virtuals, vrt)
 		}


### PR DESCRIPTION
Problem: TransportServer assigns wrong pool/service when same IP address is used with two transport server as mentioned in [Github-1671](https://github.com/F5Networks/k8s-bigip-ctlr/issues/1671).
Solution: Added the logic for checking the combination of transport server's address and port are unique and the corresponding services are attached properly.