### PR TITLE
Allow CN certificate in Routes and CRD

### DIFF
--- a/build-tools/Dockerfile.debian.runtime
+++ b/build-tools/Dockerfile.debian.runtime
@@ -25,6 +25,9 @@ COPY as3-schema-3.25.0-3-cis.json $APPPATH/vendor/src/f5/schemas/
 COPY k8s-bigip-ctlr $APPPATH/bin
 COPY VERSION_BUILD.json $APPPATH/vendor/src/f5/
 
+# Enable CN Certificate validation 
+ENV GODEBUG x509ignoreCN=0
+
 USER ctlr
 
 # Run the run application in the projects bin directory.

--- a/build-tools/Dockerfile.debug.runtime
+++ b/build-tools/Dockerfile.debug.runtime
@@ -31,6 +31,9 @@ COPY k8s-bigip-ctlr $APPPATH/bin
 COPY VERSION_BUILD.json $APPPATH/vendor/src/f5/
 COPY --from=builder /go/bin/dlv /app/bin
 
+# Enable CN Certificate validation 
+ENV GODEBUG x509ignoreCN=0
+
 USER ctlr
 EXPOSE 40000
 # Run the run application in the projects bin directory.

--- a/build-tools/Dockerfile.rhel7.runtime
+++ b/build-tools/Dockerfile.rhel7.runtime
@@ -49,6 +49,9 @@ RUN echo $'#!/bin/sh\n\
 	  exec $APPPATH/bin/k8s-bigip-ctlr.real "$@"' > $APPPATH/bin/k8s-bigip-ctlr && \
     chmod +x $APPPATH/bin/k8s-bigip-ctlr
 
+# Enable CN Certificate validation 
+ENV GODEBUG x509ignoreCN=0
+
 USER ctlr
 
 # Run the run application in the projects bin directory.

--- a/pkg/appmanager/validateResources.go
+++ b/pkg/appmanager/validateResources.go
@@ -277,7 +277,10 @@ func (appMgr *Manager) checkValidRoute(
 		// Not watching this namespace
 		return false, nil
 	}
-	if nil != route.Spec.TLS {
+
+	_, sslAnnotation := route.ObjectMeta.Annotations[F5ClientSslProfileAnnotation]
+	// Validate hostname if certificate is not provided in SSL annotations
+	if nil != route.Spec.TLS && !sslAnnotation {
 		ok := checkCertificateHost(route.Spec.Host, route.Spec.TLS.Certificate, route.Spec.TLS.Key)
 		if !ok {
 			//Invalid certificate and key

--- a/pkg/crmanager/worker.go
+++ b/pkg/crmanager/worker.go
@@ -1240,11 +1240,7 @@ func checkCertificateHost(res *v1.Secret, host string) bool {
 	}
 	ok := x509cert.VerifyHostname(host)
 	if ok != nil {
-		//TODO: Fix x509ignoreCN issue if not set.
-		if strings.Contains(ok.Error(), "GODEBUG=x509ignoreCN=0") {
-			return true
-		}
-		log.Errorf("host in virtualserver... does not match certificate name: %v", ok)
+		log.Errorf("Hostname in virtualserver does not match with certificate hostname: %v", ok)
 		return false
 	}
 	return true


### PR DESCRIPTION
`Failed to validate TLS cert and key: tls: failed to find any PEM data in certificate input`

Rootcause : certificate input via annotations were ignored 

Fix : If SSLAnnotations are present, hostname validation in certificates is skipped. As the certificate resides in BIGIP machine. 

`Hostname in route does not match with certificate hostname: x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching with GODEBUG=x509ignoreCN=0` 

Rootcause : 
 By default, crypto library used in vendor package for certificate validation, rejects certificates with CommonName (CN) mentioned in Certificate. It expects an env variable to be set GODEBUG=x509ignoreCN=0 to consider validating CommonName certificates. Note: SAN is recommended over CN and CN would also be soon deprecated as mentioned in https://tools.ietf.org/html/rfc2818.

Fix : As BIGIP currently supports both CN and SAN based certificates, CIS wants to support CN certificates. So the fix is to enable environment flag to consider CN certificates and library would validate the hostname. 
