### PR TITLE
Support for caCertificate in TLS Edge termination route

### DIFF
--- a/pkg/agent/as3/as3Common.go
+++ b/pkg/agent/as3/as3Common.go
@@ -534,11 +534,21 @@ func createUpdateCABundle(prof CustomProfile, caBundleName string, sharedApp as3
 
 func createCertificateDecl(prof CustomProfile, sharedApp as3Application) {
 	if "" != prof.Cert && "" != prof.Key {
-		cert := &as3Certificate{
-			Class:       "Certificate",
-			Certificate: prof.Cert,
-			PrivateKey:  prof.Key,
-			ChainCA:     prof.CAFile,
+		var cert *as3Certificate
+		if prof.PeerCertMode == PeerCertRequired {
+			cert = &as3Certificate{
+				Class:       "Certificate",
+				Certificate: prof.Cert,
+				PrivateKey:  prof.Key,
+				ChainCA:     prof.CAFile,
+			}
+		} else {
+			cert = &as3Certificate{
+				Class:       "Certificate",
+				Certificate: prof.Cert,
+				PrivateKey:  prof.Key,
+				ChainCA:     prof.ChainCA,
+			}
 		}
 
 		sharedApp[as3FormattedString(prof.Name, deriveResourceTypeFromAS3Value(prof.Name))] = cert

--- a/pkg/resource/resourceConfig.go
+++ b/pkg/resource/resourceConfig.go
@@ -2407,6 +2407,7 @@ func NewCustomProfile(
 	sni bool,
 	peerCertMode,
 	caFile string,
+	chainCA string,
 ) CustomProfile {
 	cp := CustomProfile{
 		Name:         profile.Name,
@@ -2417,6 +2418,7 @@ func NewCustomProfile(
 		ServerName:   serverName,
 		SNIDefault:   sni,
 		PeerCertMode: peerCertMode,
+		ChainCA:      chainCA,
 	}
 	if peerCertMode == PeerCertRequired {
 		cp.CAFile = caFile

--- a/pkg/resource/resourceConfig_test.go
+++ b/pkg/resource/resourceConfig_test.go
@@ -758,6 +758,7 @@ var _ = Describe("Resource Config Tests", func() {
 					"srver",
 					false,
 					PeerCertDefault,
+					"",
 					"")
 				refs := virtual.ReferencesProfile(cprof)
 				Expect(refs).To(BeFalse())
@@ -780,6 +781,7 @@ var _ = Describe("Resource Config Tests", func() {
 						"srver",
 						false,
 						PeerCertDefault,
+						"",
 						"")
 					refs := virtual.ReferencesProfile(cprof)
 					Expect(refs).To(BeTrue())
@@ -791,6 +793,7 @@ var _ = Describe("Resource Config Tests", func() {
 						"srver",
 						false,
 						PeerCertDefault,
+						"",
 						"")
 					refs := virtual.ReferencesProfile(cprof)
 					Expect(refs).To(BeFalse())

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -253,6 +253,7 @@ type (
 		SNIDefault   bool   `json:"sniDefault,omitempty"`
 		PeerCertMode string `json:"peerCertMode,omitempty"`
 		CAFile       string `json:"caFile,omitempty"`
+		ChainCA      string `json:"chainCA,onitempty"`
 	}
 
 	// Used to unmarshal ConfigMap data


### PR DESCRIPTION
Problem: OpenShift-Route Parameter "caCertificate" is ignored by CIS.

Solution:  CIS is able to support `caCertificate` param from OpenShift edge termination Routes using AS3 `ChainCA`.

Signed-off-by: : Amit Gupta amitg2812@gmail.com
