### PR TITLE
Fix for HTTP/2 traffic is blocked when http-2 profile is applied.

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,6 +1,16 @@
 Release Notes for Container Ingress Services for Kubernetes & OpenShift
 =======================================================================
 
+Next Release
+-------------
+* :issues:`1457` Each Client request will be logged on BIG-IP when http2-profile is associated to VS
+* :issues:`1498` In iRule openshift_passthrough_irule the variable "$dflt_pool" could not be set correctly when http/2-profile is linked to VS
+
+Limitations
+```````````
+* For AB routes HTTP2 traffic does not distribute properly when http2-profile is associated to VS
+
+
 2.2.3
 -------------
 Bug Fix

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -569,7 +569,10 @@ func (appMgr *Manager) sslPassthroughIRule() string {
                 # Handle requests sent to unknown hosts.
                 # For valid hosts, Send the request to respective pool.
                 if { not [info exists dflt_pool] } then {
-                	 reject ; event disable all; return;
+                	 # Allowing HTTP2 traffic to be handled by policies and closing the connection for HTTP/1.1 unknown hosts.
+                	 if { not ([SSL::payload] starts_with "PRI * HTTP/2.0") } {
+                	    reject ; event disable all; return;
+                    }
                 } else {
                 	pool $dflt_pool
                 }

--- a/pkg/crmanager/routing.go
+++ b/pkg/crmanager/routing.go
@@ -838,7 +838,10 @@ func (crMgr *CRManager) sslPassthroughIRule(rsVSName string) string {
                 # Handle requests sent to unknown hosts.
                 # For valid hosts, Send the request to respective pool.
                 if { not [info exists dflt_pool] } then {
-                	 reject ; event disable all; return; 
+                	 # Allowing HTTP2 traffic to be handled by policies and closing the connection for HTTP/1.1 unknown hosts.
+                	 if { not ([SSL::payload] starts_with "PRI * HTTP/2.0") } {
+                	    reject ; event disable all; return;
+                    }
                 } else {
                 	pool $dflt_pool
                 }


### PR DESCRIPTION
**Description**:  
In CIS 2.1.0 Release :- We were logging the error(<CLIENTSSL_DATA>: Unable to find pool for) in openshift_passthrough_irule  and  traffic for unknown host and HTTP2 request was being handled by policy.
In CIS 2.2.x Release:- We removed the error log (<CLIENTSSL_DATA>: Unable to find pool for) from openshift_passthrough_irule  and drops the connection in openshift_passthrough_irule , Hence traffic for unknown host and HTTP2 request is blocked by openshift_passthrough_irule .

**Changes Proposed in PR**: 
In this PR,  We are removing the error logs (<CLIENTSSL_DATA>: Unable to find pool for) from openshift_passthrough_irule  and drops the connection in openshift_passthrough_irule  only for HTTP1.1 traffic for unknown host. If HTTP2 traffic is received we are not dropping the connection in openshift_passthrough_irule and it will be handled by policies.

**Fixes**:
[GITHUB-1457](https://github.com/F5Networks/k8s-bigip-ctlr/issues/1457) 
[GITHUB-1457](https://github.com/F5Networks/k8s-bigip-ctlr/issues/1498) 

## General Checklist
- [x] Updated bug fix in release notes
