### PR TITLE
Remove reset rule when whitelist range is updated

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -12,6 +12,7 @@ Bug Fixes
 `````````
 * :issues:`1457` Each Client request will be logged on BIG-IP when http2-profile is associated to VS
 * :issues:`1498` In iRule openshift_passthrough_irule the variable "$dflt_pool" could not be set correctly when http/2-profile is linked to VS
+* :issues:`1458` CISv2.1.0 does not delete LTM-Policy reset-rule when OpenShift-annotation for whitelist-source-range will be removed 
 
 Limitations
 ```````````

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1384,9 +1384,6 @@ func (appMgr *Manager) syncIngresses(
 						}
 					}
 				}
-				if dep.Kind == WhitelistDep {
-					rsCfg.DeleteWhitelistCondition(dep.Name)
-				}
 			}
 
 			if ok, found, updated := appMgr.handleConfigForType(
@@ -1598,7 +1595,7 @@ func (appMgr *Manager) syncRoutes(
 					}
 				}
 				if dep.Kind == WhitelistDep {
-					rsCfg.DeleteWhitelistCondition(dep.Name)
+					rsCfg.DeleteWhitelistCondition()
 				}
 			}
 			// Sort the rules

--- a/pkg/resource/resourceConfig.go
+++ b/pkg/resource/resourceConfig.go
@@ -279,23 +279,17 @@ func GetRouteServiceNames(route *routeapi.Route) []string {
 	return svcNames
 }
 
-// Deletes a whitelist Condition if the values match
-func (rsCfg *ResourceConfig) DeleteWhitelistCondition(values string) {
+// Deletes a whitelist reset rule
+func (rsCfg *ResourceConfig) DeleteWhitelistCondition() {
 	for _, pol := range rsCfg.Policies {
-		for _, rl := range pol.Rules {
-			for i, cd := range rl.Conditions {
-				var valueStr string
-				for _, val := range cd.Values {
-					valueStr += val + ","
-				}
-				valueStr = strings.TrimSuffix(valueStr, ",")
-				if valueStr == values {
-					copy(rl.Conditions[i:], rl.Conditions[i+1:])
-					rl.Conditions[len(rl.Conditions)-1] = nil
-					rl.Conditions = rl.Conditions[:len(rl.Conditions)-1]
+		for i, rl := range pol.Rules {
+			if strings.HasSuffix(rl.Name, "-reset") {
+				if !pol.RemoveRuleAt(i) {
+					log.Errorf("Error deleting reset rule for %v", pol.Name)
 				}
 			}
 		}
+		rsCfg.SetPolicy(pol)
 	}
 }
 


### PR DESCRIPTION
**Description**:  
https://github.com/F5Networks/k8s-bigip-ctlr/issues/1458 
Reset rule exists in BIGIP even after deleting a whitelist/source-range annotation

**Changes Proposed in PR**:
Delete reset matching rule from policy and update config

**Fixes**: #1458 

## General Checklist
- [x] updated release notes for bug fix
