### PR TITLE
Allow user to leverage IPAM

### DIFF
--- a/pkg/crmanager/worker.go
+++ b/pkg/crmanager/worker.go
@@ -585,8 +585,10 @@ func (crMgr *CRManager) syncVirtualServers(
 
 	var ip string
 	if crMgr.ipamCli != nil {
-		if isVSDeleted && len(virtuals) == 0 {
+		if isVSDeleted && len(virtuals) == 0 && virtual.Spec.VirtualServerAddress == "" {
 			ip = crMgr.releaseIP(virtual.Spec.Cidr, virtual.Spec.Host)
+		} else if virtual.Spec.VirtualServerAddress != "" {
+			ip = virtual.Spec.VirtualServerAddress
 		} else {
 			ip = crMgr.requestIP(cidr, virtual.Spec.Host)
 			log.Debugf("[ipam] requested IP for host %v is: %v", virtual.Spec.Host, ip)


### PR DESCRIPTION
**Description**:  Allow user to leverage IPAM Controller or specify a VirtualServer Address.

**Changes Proposed in PR**: 
We need to provide more flexibility
        if a VirtualServer Address is specified in the resource, don't leverage the IPAM Controller even if a cidr parameter is specified
        if No VirtualServer Address is specified in the resource and a cidr parameter is specified, leverage the IPAM Controller

## General Checklist
- [x] Updated the documentation
