### PR TITLE
Adding support for AS3 schema version

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -3,6 +3,12 @@ Release Notes for Container Ingress Services for Kubernetes & OpenShift
 
 Next Release
 -------------
+Added Functionality
+```````````````````
+* Added support for AS3 schema version
+
+Bug Fixes
+`````````
 * :issues:`1457` Each Client request will be logged on BIG-IP when http2-profile is associated to VS
 * :issues:`1498` In iRule openshift_passthrough_irule the variable "$dflt_pool" could not be set correctly when http/2-profile is linked to VS
 

--- a/pkg/agent/as3/as3Manager_test.go
+++ b/pkg/agent/as3/as3Manager_test.go
@@ -48,6 +48,7 @@ var _ = Describe("AS3Manager Tests", func() {
 		mockMgr = newMockAS3Manager(&Params{
 			As3Version: "3.25.0",
 			As3Release: "3.25.0-3",
+			As3SchemaVersion: "3.25.0",
 		})
 	})
 	AfterEach(func() {

--- a/pkg/agent/as3/postManager.go
+++ b/pkg/agent/as3/postManager.go
@@ -159,12 +159,12 @@ func (postMgr *PostManager) postConfig(data string, tenants []string) (bool, str
 	}
 }
 
-func (postMgr *PostManager) GetBigipAS3Version() (string, string, error) {
+func (postMgr *PostManager) GetBigipAS3Version() (string, string, string, error) {
 	url := postMgr.getAS3VersionURL()
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		log.Errorf("[AS3] Creating new HTTP request error: %v ", err)
-		return "", "", err
+		return "", "", "", err
 	}
 
 	log.Debugf("[AS3] posting GET BIGIP AS3 Version request on %v", url)
@@ -172,7 +172,7 @@ func (postMgr *PostManager) GetBigipAS3Version() (string, string, error) {
 
 	httpResp, responseMap := postMgr.httpReq(req)
 	if httpResp == nil || responseMap == nil {
-		return "", "", fmt.Errorf("Internal Error")
+		return "", "", "", fmt.Errorf("Internal Error")
 	}
 
 	switch httpResp.StatusCode {
@@ -180,18 +180,19 @@ func (postMgr *PostManager) GetBigipAS3Version() (string, string, error) {
 		if responseMap["version"] != nil {
 			as3VersionStr := responseMap["version"].(string)
 			as3versionreleaseStr := responseMap["release"].(string)
-			return as3VersionStr, as3versionreleaseStr, nil
+			as3SchemaVersion := responseMap["schemaCurrent"].(string)
+			return as3VersionStr, as3versionreleaseStr, as3SchemaVersion, nil
 		}
 	case http.StatusNotFound:
 		responseMap["code"] = int(responseMap["code"].(float64))
 		if responseMap["code"] == http.StatusNotFound {
-			return "", "", fmt.Errorf("AS3 RPM is not installed on BIGIP,"+
+			return "", "", "", fmt.Errorf("AS3 RPM is not installed on BIGIP,"+
 				" Error response from BIGIP with status code %v", httpResp.StatusCode)
 		}
 		// In case of 503 status code : CIS will exit and auto restart of the
 		// controller might fetch the BIGIP version once BIGIP is available.
 	}
-	return "", "", fmt.Errorf("Error response from BIGIP with status code %v", httpResp.StatusCode)
+	return "", "", "", fmt.Errorf("Error response from BIGIP with status code %v", httpResp.StatusCode)
 }
 
 func (postMgr *PostManager) httpReq(request *http.Request) (*http.Response, map[string]interface{}) {


### PR DESCRIPTION
**Description**: Currently AS3 minor versions such as (3.22.1, 3.19.1 etc. ) were not working with CIS 2.x releases.

**Changes Proposed in PR**: Added support for schema version support for AS3.


## General Checklist
- [x] Added functionality in release notes
