### PR TITLE
Fix continuous overwrites with iApp in cccl mode

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,6 +1,14 @@
 Release Notes for Container Ingress Services for Kubernetes & OpenShift
 =======================================================================
 
+Next Release
+-------------
+Added Functionality
+```````````````````
+
+Bug Fixes
+`````````
+* SR - Fix continuous overwrites with iapp in cccl mode
 2.3.0
 -------------
 Added Functionality

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1935,6 +1935,14 @@ func (appMgr *Manager) syncPoolMembers(rsName string, rsCfg *ResourceConfig) {
 				}
 			}
 		}
+		//for iApp resource update IAppPoolMemberTable with members found for pool.
+		if rsCfg.MetaData.ResourceType == "iapp" {
+			for _, p := range rsCfg.Pools {
+				if rsCfg.IApp.Name == p.Name {
+					rsCfg.IApp.IAppPoolMemberTable.Members = p.Members
+				}
+			}
+		}
 	}
 }
 
@@ -1955,8 +1963,8 @@ func (appMgr *Manager) updatePoolMembersForNodePort(
 			}
 		}
 		//check if endpoints are found
-		if rsCfg.Pools[index].Members == nil{
-			log.Errorf("[Core]Endpoints could not be fetched for service '#{svcKey.ServiceName}' with port '#{svcKey.ServicePort}'")
+		if rsCfg.Pools[index].Members == nil {
+			log.Errorf("[CORE]Endpoints could not be fetched for service %v with port %v", svcKey.ServiceName, svcKey.ServicePort)
 		}
 		return true, "", ""
 	} else {
@@ -1991,8 +1999,8 @@ func (appMgr *Manager) updatePoolMembersForCluster(
 		}
 	}
 	//check if endpoints are found
-	if rsCfg.Pools[index].Members == nil{
-		log.Errorf("[Core]Endpoints could not be fetched for service '#{svcKey}' with port '#{sKey.ServicePort}'")
+	if rsCfg.Pools[index].Members == nil {
+		log.Errorf("[CORE]Endpoints could not be fetched for service %v with port %v", sKey.ServiceName, sKey.ServicePort)
 	}
 	return true, "", ""
 }


### PR DESCRIPTION
**Description**: Continuous overwrite of backend observed when using Configmap with iApp in cccl mode.
**Changes Proposed in PR**:
- Update pool members properly in iAppPoolmembers Table, so that resource config doesn't take this as an update and process every 30s  
**Fixes**: #1690

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes