### PR TITLE
Service address support in VS and TS CRD

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -18,20 +18,30 @@ type VirtualServer struct {
 
 // VirtualServerSpec is the spec of the VirtualServer resource.
 type VirtualServerSpec struct {
-	Host                   string   `json:"host"`
-	VirtualServerAddress   string   `json:"virtualServerAddress"`
-	Cidr                   string   `json:"cidr"`
-	VirtualServerName      string   `json:"virtualServerName"`
-	VirtualServerHTTPPort  int32    `json:"virtualServerHTTPPort"`
-	VirtualServerHTTPSPort int32    `json:"virtualServerHTTPSPort"`
-	Pools                  []Pool   `json:"pools"`
-	TLSProfileName         string   `json:"tlsProfileName"`
-	HTTPTraffic            string   `json:"httpTraffic,omitempty"`
-	SNAT                   string   `json:"snat,omitempty"`
-	WAF                    string   `json:"waf,omitempty"`
-	RewriteAppRoot         string   `json:"rewriteAppRoot,omitempty"`
-	AllowVLANs             []string `json:"allowVlans,omitempty"`
-	IRules                 []string `json:"iRules,omitempty"`
+	Host                   string           `json:"host"`
+	VirtualServerAddress   string           `json:"virtualServerAddress"`
+	Cidr                   string           `json:"cidr"`
+	VirtualServerName      string           `json:"virtualServerName"`
+	VirtualServerHTTPPort  int32            `json:"virtualServerHTTPPort"`
+	VirtualServerHTTPSPort int32            `json:"virtualServerHTTPSPort"`
+	Pools                  []Pool           `json:"pools"`
+	TLSProfileName         string           `json:"tlsProfileName"`
+	HTTPTraffic            string           `json:"httpTraffic,omitempty"`
+	SNAT                   string           `json:"snat,omitempty"`
+	WAF                    string           `json:"waf,omitempty"`
+	RewriteAppRoot         string           `json:"rewriteAppRoot,omitempty"`
+	AllowVLANs             []string         `json:"allowVlans,omitempty"`
+	IRules                 []string         `json:"iRules,omitempty"`
+	ServiceIPAddress       []ServiceAddress `json:"serviceAddress"`
+}
+
+// ServiceAddress Service IP address definition (BIG-IP virtual-address).
+type ServiceAddress struct {
+	ArpEnabled         bool   `json:"arpEnabled,omitempty"`
+	ICMPEcho           string `json:"icmpEcho,omitempty"`
+	RouteAdvertisement string `json:"routeAdvertisement,omitempty"`
+	TrafficGroup       string `json:"trafficGroup,omitempty,omitempty"`
+	SpanningEnabled    bool   `json:"spanningEnabled,omitempty"`
 }
 
 // Pool defines a pool object in BIG-IP.
@@ -140,14 +150,15 @@ type TransportServer struct {
 
 // TransportServerSpec is the spec of the VirtualServer resource.
 type TransportServerSpec struct {
-	VirtualServerAddress string   `json:"virtualServerAddress"`
-	VirtualServerPort    int32    `json:"virtualServerPort"`
-	VirtualServerName    string   `json:"virtualServerName"`
-	Mode                 string   `json:"mode"`
-	SNAT                 string   `json:"snat"`
-	Pool                 Pool     `json:"pool"`
-	AllowVLANs           []string `json:"allowVlans,omitempty"`
-	Type                 string   `json:"type,omitempty"`
+	VirtualServerAddress string           `json:"virtualServerAddress"`
+	VirtualServerPort    int32            `json:"virtualServerPort"`
+	VirtualServerName    string           `json:"virtualServerName"`
+	Mode                 string           `json:"mode"`
+	SNAT                 string           `json:"snat"`
+	Pool                 Pool             `json:"pool"`
+	AllowVLANs           []string         `json:"allowVlans,omitempty"`
+	Type                 string           `json:"type,omitempty"`
+	ServiceIPAddress     []ServiceAddress `json:"serviceAddress"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -5,6 +5,7 @@ Next Release
 -------------
 Added Functionality
 ```````````````````
+* CIS supports service address reference in virtual server CRD.
 * Integrated the ingress link mode with CRD mode
 * :issues:`1573` Added support for type UDP Transport Server CRD
 

--- a/docs/_static/config_examples/crd/CustomResource.md
+++ b/docs/_static/config_examples/crd/CustomResource.md
@@ -180,7 +180,7 @@ Known Issues:
 | ------ | ------ | ------ | ------ | ------ |
 | host | String | Optional | NA |  Virtual Host |
 | pools | List of pool | Required | NA | List of BIG-IP Pool members |
-| virtualServerAddress | String | Required | NA | IP Address of BIG-IP Virtual Server |
+| virtualServerAddress | String | Required | NA | IP Address of BIG-IP Virtual Server. IP address can also be replaced by a reference to a Service_Address. |
 | virtualServerName | String | Optional | NA | Custom name of BIG-IP Virtual Server |
 | TLSProfile | String | Optional | NA | Describes the TLS configuration for BIG-IP Virtual Server |
 | rewriteAppRoot | String | Optional | NA |  Rewrites the path in the HTTP Header (and Redirects) from \"/" (root path) to specifed path |
@@ -198,6 +198,16 @@ Known Issues:
 | servicePort | String | Required | NA | Port to access Service |
 | monitor | String | Optional | NA | Health Monitor to check the health of Pool Members |
 | rewrite | String | Optional | NA | Rewrites the path in the HTTP Header while submitting the request to Server in the pool |
+
+**Service_Address Components**
+
+| PARAMETER | TYPE | REQUIRED | DEFAULT | DESCRIPTION |
+| ------ | ------ | ------ | ------ | ------ |
+| arpEnabled | Boolean | Optional | true |  If true (default), the system services ARP requests on this address |
+| icmpEcho | String | Optional | “enable” | If true (default), the system answers ICMP echo requests on this address. Values: “enable”, “disable”, “selective” |
+| routeAdvertisement | String | Optional | “disable” | If true, the route is advertised. Values: “enable”, “disable”, “selective”, “always”, “any”, “all” |
+| spanningEnabled | Boolean | Optional | false | Enable all BIG-IP systems in device group to listen for and process traffic on the same virtual address |
+| trafficGroup | String | Optional | "default" | Specifies the traffic group which the Service_Address belongs. |
 
 **Health Monitor**
 
@@ -237,7 +247,7 @@ Known Issues:
 | PARAMETER | TYPE | REQUIRED | DEFAULT | DESCRIPTION |
 | ------ | ------ | ------ | ------ | ------ |
 | pool | pool | Required | NA | BIG-IP Pool member |
-| virtualServerAddress | String | Required | NA | IP Address of BIG-IP Virtual Server |
+| virtualServerAddress | String | Required | NA | IP Address of BIG-IP Virtual Server. IP address can also be replaced by a reference to a Service_Address. |
 | virtualServerPort | String | Required | NA | Port Address of BIG-IP Virtual Server |
 | virtualServerName | String | Optional | NA | Custom name of BIG-IP Virtual Server |
 | type | String | Optional | tcp | "tcp" or "udp" L4 transport server type |
@@ -252,6 +262,16 @@ Known Issues:
 | service | String | Required | NA | Service deployed in kubernetes cluster |
 | servicePort | String | Required | NA | Port to access Service |
 | monitor | String | Optional | NA | Health Monitor to check the health of Pool Members |
+
+**Service_Address Components**
+
+| PARAMETER | TYPE | REQUIRED | DEFAULT | DESCRIPTION |
+| ------ | ------ | ------ | ------ | ------ |
+| arpEnabled | Boolean | Optional | true |  If true (default), the system services ARP requests on this address |
+| icmpEcho | String | Optional | “enable” | If true (default), the system answers ICMP echo requests on this address. Values: “enable”, “disable”, “selective” |
+| routeAdvertisement | String | Optional | “disable” | If true, the route is advertised. Values: “enable”, “disable”, “selective”, “always”, “any”, “all” |
+| spanningEnabled | Boolean | Optional | false | Enable all BIG-IP systems in device group to listen for and process traffic on the same virtual address |
+| trafficGroup | String | Optional | "default" | Specifies the traffic group which the Service_Address belongs. |
 
 **Health Monitor**
 

--- a/docs/_static/config_examples/crd/Install/customresourcedefinitions.yml
+++ b/docs/_static/config_examples/crd/Install/customresourcedefinitions.yml
@@ -49,6 +49,25 @@ spec:
                   type: array
                   items:
                     type: string
+                serviceAddress:
+                  type: array
+                  maxItems: 1
+                  items:
+                    type: object
+                    properties:
+                      arpEnabled:
+                        type: boolean
+                      icmpEcho:
+                        type: string
+                        enum: [enable, disable, selective]
+                      routeAdvertisement:
+                        type: string
+                        enum: [enable, disable, selective, always, any, all]
+                      spanningEnabled:
+                        type: boolean
+                      trafficGroup:
+                        type: string
+                        pattern: '^\/([A-z0-9-_+]+\/)*([A-z0-9]+\/?)*$'
                 pools:
                   type: array
                   items:
@@ -222,6 +241,25 @@ spec:
                     type: string
                     pattern: '^\/([A-z0-9-_+]+\/)*([A-z0-9-_]+\/?)*$'
                   type: array
+                serviceAddress:
+                  type: array
+                  maxItems: 1
+                  items:
+                    type: object
+                    properties:
+                      arpEnabled:
+                        type: boolean
+                      icmpEcho:
+                        type: string
+                        enum: [enable, disable, selective]
+                      routeAdvertisement:
+                        type: string
+                        enum: [enable, disable, selective, always, any, all]
+                      spanningEnabled:
+                        type: boolean
+                      trafficGroup:
+                        type: string
+                        pattern: '^\/([A-z0-9-_+]+\/)*([A-z0-9]+\/?)*$'
                 pool:
                   type: object
                   properties:

--- a/docs/_static/config_examples/crd/TransportServer/ts-with-service-address.yaml
+++ b/docs/_static/config_examples/crd/TransportServer/ts-with-service-address.yaml
@@ -1,0 +1,26 @@
+apiVersion: "cis.f5.com/v1"
+kind: TransportServer
+metadata:
+  labels:
+    f5cr: "true"
+  name: my-transport-server
+  namespace: default
+spec:
+  virtualServerAddress: "172.16.3.9"
+  virtualServerPort: 8544
+  virtualServerName: my-ts
+  mode: standard
+  snat: auto
+  allowVlans: ["/Common/devtraffic"]
+  serviceAddress:
+  - icmpEcho: "enable"
+    arpEnabled: true
+    routeAdvertisement: "all"
+    spanningEnabled: true
+  pool:
+    service: svc-1
+    servicePort: 8181
+    monitor:
+      type: tcp
+      interval: 10
+      timeout: 10

--- a/docs/_static/config_examples/crd/basic/virtual-with-aservice-address/README.md
+++ b/docs/_static/config_examples/crd/basic/virtual-with-aservice-address/README.md
@@ -1,0 +1,15 @@
+# Virtual Service Address
+
+This section demonstrates the option to configure virtual address with service address. This is optional to use.
+Virtual server address can also be replaced by a reference to a Service_Address.
+CRD allows the user to create a service address for virtual servers on BIG-IP.
+
+
+Option which can be used to configure is :
+    serviceAddress
+
+## example-service-address-with-virtual.yaml
+
+By deploying this yaml file in your cluster, CIS will create a Virtual Server with service address on BIG-IP as 
+"crd_service_address_<virtual address>"
+Ex. "crd_service_address_172_16_3_9"

--- a/docs/_static/config_examples/crd/basic/virtual-with-aservice-address/example-service-address-with-virtual.yaml
+++ b/docs/_static/config_examples/crd/basic/virtual-with-aservice-address/example-service-address-with-virtual.yaml
@@ -1,0 +1,21 @@
+apiVersion: "cis.f5.com/v1"
+kind: VirtualServer
+metadata:
+  name: cafe-virtual-server
+  labels:
+    f5cr: "true"
+spec:
+  # This is an insecure virtual, Please use TLSProfile to secure the virtual
+  # check out tls examples to understand more.
+  host: cafe.example.com
+  virtualServerAddress: "172.16.3.9"
+  virtualServerName: "cafe-virtual-server"
+  pools:
+  - path: /coffee
+    service: svc-2
+    servicePort: 80
+  serviceAddress:
+  - icmpEcho: "enable"
+    arpEnabled: true
+    routeAdvertisement: "all"
+    spanningEnabled: true

--- a/pkg/crmanager/backend.go
+++ b/pkg/crmanager/backend.go
@@ -505,13 +505,41 @@ func createServiceDecl(cfg *ResourceConfig, sharedApp as3Application) {
 	virtualAddress, port := extractVirtualAddressAndPort(cfg.Virtual.Destination)
 	// verify that ip address and port exists.
 	if virtualAddress != "" && port != 0 {
-		va := append(svc.VirtualAddresses, virtualAddress)
-		svc.VirtualAddresses = va
-		svc.VirtualPort = port
+		if len(cfg.ServiceAddress) == 0 {
+			va := append(svc.VirtualAddresses, virtualAddress)
+			svc.VirtualAddresses = va
+			svc.VirtualPort = port
+		} else {
+			//Attach Service Address
+			serviceAddressName := createServiceAddressDecl(cfg, virtualAddress, sharedApp)
+			sa := &as3ResourcePointer{
+				Use: serviceAddressName,
+			}
+			svc.VirtualAddresses = append(svc.VirtualAddresses, sa)
+			svc.VirtualPort = port
+		}
 	}
 	//process irules for crd
 	processIrulesForCRD(cfg, svc)
 	sharedApp[cfg.Virtual.Name] = svc
+}
+
+// Create AS3 Service Address for Virtual Server Address
+func createServiceAddressDecl(cfg *ResourceConfig, virtualAddress string, sharedApp as3Application) string {
+	var name string
+	for _, sa := range cfg.ServiceAddress {
+		serviceAddress := &as3ServiceAddress{}
+		serviceAddress.Class = "Service_Address"
+		serviceAddress.ArpEnabled = sa.ArpEnabled
+		serviceAddress.ICMPEcho = sa.ICMPEcho
+		serviceAddress.RouteAdvertisement = sa.RouteAdvertisement
+		serviceAddress.SpanningEnabled = sa.SpanningEnabled
+		serviceAddress.TrafficGroup = sa.TrafficGroup
+		serviceAddress.VirtualAddress = virtualAddress
+		name = "crd_service_address_" + strings.Replace(virtualAddress, ".", "_", -1)
+		sharedApp[name] = serviceAddress
+	}
+	return name
 }
 
 // Create AS3 Rule Condition for CRD
@@ -934,9 +962,19 @@ func createTransportServiceDecl(cfg *ResourceConfig, sharedApp as3Application) {
 	virtualAddress, port := extractVirtualAddressAndPort(cfg.Virtual.Destination)
 	// verify that ip address and port exists.
 	if virtualAddress != "" && port != 0 {
-		va := append(svc.VirtualAddresses, virtualAddress)
-		svc.VirtualAddresses = va
-		svc.VirtualPort = port
+		if len(cfg.ServiceAddress) == 0 {
+			va := append(svc.VirtualAddresses, virtualAddress)
+			svc.VirtualAddresses = va
+			svc.VirtualPort = port
+		} else {
+			//Attach Service Address
+			serviceAddressName := createServiceAddressDecl(cfg, virtualAddress, sharedApp)
+			sa := &as3ResourcePointer{
+				Use: serviceAddressName,
+			}
+			svc.VirtualAddresses = append(svc.VirtualAddresses, sa)
+			svc.VirtualPort = port
+		}
 	}
 	svc.Pool = cfg.Virtual.PoolName
 	if cfg.Virtual.AllowVLANs != nil {

--- a/pkg/crmanager/resourceConfig.go
+++ b/pkg/crmanager/resourceConfig.go
@@ -388,6 +388,12 @@ func (crMgr *CRManager) prepareRSConfigFromVirtualServer(
 		rsCfg.Virtual.SNAT = vs.Spec.SNAT
 	}
 
+	if len(rsCfg.ServiceAddress) == 0 {
+		for _, sa := range vs.Spec.ServiceIPAddress {
+			rsCfg.ServiceAddress = append(rsCfg.ServiceAddress, ServiceAddress(sa))
+		}
+	}
+
 	// set the WAF policy
 	if vs.Spec.WAF != "" {
 		rsCfg.Virtual.WAF = vs.Spec.WAF

--- a/pkg/crmanager/types.go
+++ b/pkg/crmanager/types.go
@@ -145,6 +145,15 @@ type (
 	// Virtuals is slice of virtuals
 	Virtuals []Virtual
 
+	// ServiceAddress Service IP address definition (BIG-IP virtual-address).
+	ServiceAddress struct {
+		ArpEnabled         bool   `json:"arpEnabled,omitempty"`
+		ICMPEcho           string `json:"icmpEcho,omitempty"`
+		RouteAdvertisement string `json:"routeAdvertisement,omitempty"`
+		TrafficGroup       string `json:"trafficGroup,omitempty"`
+		SpanningEnabled    bool   `json:"spanningEnabled,omitempty"`
+	}
+
 	// SourceAddrTranslation is Virtual Server Source Address Translation
 	SourceAddrTranslation struct {
 		Type string `json:"type"`
@@ -165,11 +174,12 @@ type (
 
 	// ResourceConfig is a Config for a single VirtualServer.
 	ResourceConfig struct {
-		MetaData metaData  `json:"-"`
-		Virtual  Virtual   `json:"virtual,omitempty"`
-		Pools    Pools     `json:"pools,omitempty"`
-		Policies Policies  `json:"policies,omitempty"`
-		Monitors []Monitor `json:"monitors,omitempty"`
+		MetaData       metaData         `json:"-"`
+		Virtual        Virtual          `json:"virtual,omitempty"`
+		Pools          Pools            `json:"pools,omitempty"`
+		Policies       Policies         `json:"policies,omitempty"`
+		Monitors       []Monitor        `json:"monitors,omitempty"`
+		ServiceAddress []ServiceAddress `json:"serviceAddress,omitempty"`
 	}
 	// ResourceConfigs is group of ResourceConfig
 	ResourceConfigs []*ResourceConfig
@@ -517,7 +527,7 @@ type (
 		TranslateServerAddress bool                 `json:"translateServerAddress,omitempty"`
 		TranslateServerPort    bool                 `json:"translateServerPort,omitempty"`
 		Class                  string               `json:"class,omitempty"`
-		VirtualAddresses       []string             `json:"virtualAddresses,omitempty"`
+		VirtualAddresses       []as3MultiTypeParam  `json:"virtualAddresses,omitempty"`
 		VirtualPort            int                  `json:"virtualPort,omitempty"`
 		SNAT                   as3MultiTypeParam    `json:"snat,omitempty"`
 		PolicyEndpoint         as3MultiTypeParam    `json:"policyEndpoint,omitempty"`
@@ -530,6 +540,17 @@ type (
 		ProfileL4              string               `json:"profileL4,omitempty"`
 		AllowVLANs             []as3ResourcePointer `json:"allowVlans,omitempty"`
 		PersistenceMethods     []string             `json:"persistenceMethods,omitempty"`
+	}
+
+	// as3ServiceAddress maps to VirtualAddress in AS3 Resources
+	as3ServiceAddress struct {
+		Class              string `json:"class,omitempty"`
+		VirtualAddress     string `json:"virtualAddress,omitempty"`
+		ArpEnabled         bool   `json:"arpEnabled"`
+		ICMPEcho           string `json:"icmpEcho,omitempty"`
+		RouteAdvertisement string `json:"routeAdvertisement,omitempty"`
+		TrafficGroup       string `json:"trafficGroup,omitempty,omitempty"`
+		SpanningEnabled    bool   `json:"spanningEnabled"`
 	}
 
 	// as3Monitor maps to the following in AS3 Resources

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -30,18 +30,28 @@ type (
 		IRules             []IRule             `json:"iRules,omitempty"`
 		InternalDataGroups []InternalDataGroup `json:"internalDataGroups,omitempty"`
 		IApps              []IApp              `json:"iapps,omitempty"`
+		ServiceIPAddress   []ServiceAddress    `json:"serviceAddress,omitempty"`
 	}
 
 	// Config for a single resource (ConfigMap, Ingress, or Route)
 	ResourceConfig struct {
-		MetaData MetaData `json:"-"`
-		Virtual  Virtual  `json:"virtual,omitempty"`
-		IApp     IApp     `json:"iapp,omitempty"`
-		Pools    Pools    `json:"pools,omitempty"`
-		Monitors Monitors `json:"monitors,omitempty"`
-		Policies Policies `json:"policies,omitempty"`
+		MetaData       MetaData         `json:"-"`
+		Virtual        Virtual          `json:"virtual,omitempty"`
+		IApp           IApp             `json:"iapp,omitempty"`
+		Pools          Pools            `json:"pools,omitempty"`
+		Monitors       Monitors         `json:"monitors,omitempty"`
+		Policies       Policies         `json:"policies,omitempty"`
+		ServiceAddress []ServiceAddress `json:"serviceAddress,omitempty"`
 	}
 	ResourceConfigs []*ResourceConfig
+
+	ServiceAddress struct {
+		ArpEnabled         bool   `json:"arpEnabled,omitempty"`
+		ICMPEcho           string `json:"icmpEcho,omitempty"`
+		RouteAdvertisement string `json:"routeAdvertisement,omitempty"`
+		TrafficGroup       string `json:"trafficGroup,omitempty,omitempty"`
+		SpanningEnabled    bool   `json:"spanningEnabled,omitempty"`
+	}
 
 	MetaData struct {
 		Active       bool


### PR DESCRIPTION
**Description**:  Virtual server IP address can also be replaced by a reference to a Service_Address.

**Changes Proposed in PR**: Service_Address reference support in Virtual Server CRD and Transport Server CRD

**Fixes**: https://github.com/F5Networks/k8s-bigip-ctlr/issues/1592

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema