### PR TITLE
added missing httpTraffic description

### DIFF
--- a/docs/_static/config_examples/crd/CustomResource.md
+++ b/docs/_static/config_examples/crd/CustomResource.md
@@ -255,6 +255,7 @@ Known Issues:
 | mode | String | Required | NA |  "standard" or "performance". A Standard mode transport server processes connections using the full proxy architecture. A Performance mode transport server uses FastL4 packet-by-packet TCP behavior. |
 | snat | String | Optional | auto |  |
 | allowVlans | List of Vlans | Optional | Allow traffic from all VLANS | list of Vlan objects to allow traffic from |
+| httpTraffic | String | Optional | NA | Describes whether http traffic should be allowed, redirected or dropped (allow, redirect, none) |
 
 **Pool Components**
 

--- a/docs/_static/config_examples/crd/CustomResource.md
+++ b/docs/_static/config_examples/crd/CustomResource.md
@@ -186,7 +186,8 @@ Known Issues:
 | rewriteAppRoot | String | Optional | NA |  Rewrites the path in the HTTP Header (and Redirects) from \"/" (root path) to specifed path |
 | waf | String | Optional | NA | Reference to WAF policy on BIG-IP |
 | snat | String | Optional | auto | Reference to SNAT pool on BIG-IP or Other allowed value is: "none" |
-| allowVlans | List of Vlans | Optional | NA | list of Vlan objects to allow traffic from |  
+| allowVlans | List of Vlans | Optional | NA | list of Vlan objects to allow traffic from |
+| httpTraffic | String | Optional | NA | Describes whether http traffic should be allowed, redirected or dropped (allow, redirect, none) |
 
 **Pool Components**
 


### PR DESCRIPTION
**Description**:  Added missing httpTraffic definition for Virtual and Transport Server CRD 

**Changes Proposed in PR**:

**Fixes**: #_Github issue id_

## General Checklist
- [ ] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation

## CRD Checklist
- [ ] Updated required CR schema