### PR TITLE
Fix for ECDSA-signed cert in Openshift routes

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -14,6 +14,7 @@ Bug Fixes
 `````````
 * SR - Fix continuous overwrites with iapp in cccl mode
 * Fix Stale Datagroup issue
+* :issues: `1723` Fix for ECDSA-signed certificates in Openshift routes
 
 Limitations
 ```````````

--- a/pkg/agent/as3/as3Common.go
+++ b/pkg/agent/as3/as3Common.go
@@ -579,6 +579,7 @@ func (am *AS3Manager) createUpdateTLSServer(prof CustomProfile, svcName string, 
 			tlsServer.Certificates = append(
 				tlsServer.Certificates,
 				as3TLSServerCertificates{
+					MatchToSNI:  prof.MatchToSNI,
 					Certificate: certName,
 				},
 			)

--- a/pkg/agent/as3/as3Types.go
+++ b/pkg/agent/as3/as3Types.go
@@ -203,6 +203,7 @@ type (
 
 	// as3TLSServerCertificates maps to TLS_Server_certificates in AS3 Resources
 	as3TLSServerCertificates struct {
+		MatchToSNI  string `json:"matchToSNI,omitempty"`
 		Certificate string `json:"certificate,omitempty"`
 	}
 

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -260,6 +260,7 @@ type (
 		Cert         string `json:"cert"`
 		Key          string `json:"key"`
 		ServerName   string `json:"serverName,omitempty"`
+		MatchToSNI   string `json:"matchToSNI,omitempty"`
 		SNIDefault   bool   `json:"sniDefault,omitempty"`
 		PeerCertMode string `json:"peerCertMode,omitempty"`
 		CAFile       string `json:"caFile,omitempty"`


### PR DESCRIPTION
**Description**:  If ECDSA-signed certificate/key used in an OS-Route, the BIG-IP selects wrong certificate and present it to the client.
The BIG-IP selects the certificate which is marked as sni-default=true in specific client-ssl profile option
**Changes Proposed in PR**:
Add servername to clientssl profile for ECDSA cert

**Fixes**:  Resolves #1723 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
