### PR TITLE
rename customresource.md in README.md to improve visibility by user.

### DIFF
--- a/docs/_static/config_examples/crd/README.md
+++ b/docs/_static/config_examples/crd/README.md
@@ -171,7 +171,7 @@ Known Issues:
    * Schema Validation
      - OpenAPI Schema Validation
      
-        https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/_static/config_examples/crd/basic/vs-customresourcedefinition.yml
+        https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/_static/config_examples/crd/Install/customresourcedefinitions.yml
 
 
 **VirtualServer Components**
@@ -224,7 +224,7 @@ Known Issues:
    * Schema Validation
      - OpenAPI Schema Validation
      
-        https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/_static/config_examples/crd/tls/tls-customresourcedefinition.yml
+        https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/_static/config_examples/crd/Install/customresourcedefinitions.yml
 
 
 **TLSProfile Components**
@@ -240,7 +240,7 @@ Known Issues:
    * Schema Validation
      - OpenAPI Schema Validation
      
-        https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/_static/config_examples/crd/basic/vs-customresourcedefinition.yml
+        https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/_static/config_examples/crd/Install/customresourcedefinitions.yml
 
 
 **TransportServer Components**
@@ -288,7 +288,7 @@ Known Issues:
    * Schema Validation
      - OpenAPI Schema Validation
      
-        https://github.com/F5Networks/k8s-bigip-ctlr/blob/master/docs/_static/config_examples/crd/ExternalDNS/%20externaldns-customresourcedefinition.yml
+        https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/_static/config_examples/crd/Install/customresourcedefinitions.yml
 
 
 **ExternalDNS Components**


### PR DESCRIPTION
Updated schemadefinition link to always provide the same

**Description**:  _Add Issue/Feature description_
Improve visibility of our doc and provide consistent/accurate information

**Changes Proposed in PR**:
rename customresource.md in README so that it will be readable by user as soon as they get into this folder
Correct link to reference a single location for our custom resource definition: https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/_static/config_examples/crd/Install/customresourcedefinitions.yml


## General Checklist
- [x] Updated the documentation
