### PR TITLE
CIS unable to post the declaration when configured to watch namespaces

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -17,6 +17,7 @@ Bug Fixes
 * SR - Fix continuous overwrites with iapp in cccl mode
 * Fix Stale Datagroup issue
 * :issues: `1723` Fix for ECDSA-signed certificates in Openshift routes
+* Fix to post virtual and transport server declarations when CIS is configured to watch namespaces
 
 Limitations
 ```````````

--- a/pkg/crmanager/crManager.go
+++ b/pkg/crmanager/crManager.go
@@ -90,16 +90,16 @@ func NewCRManager(params Params) *CRManager {
 		crInformers: make(map[string]*CRInformer),
 		rscQueue: workqueue.NewNamedRateLimitingQueue(
 			workqueue.DefaultControllerRateLimiter(), "custom-resource-controller"),
-		resources:       NewResources(),
-		Agent:           params.Agent,
-		ControllerMode:  params.ControllerMode,
-		UseNodeInternal: params.UseNodeInternal,
-		initState:       true,
-		SSLContext:      make(map[string]*v1.Secret),
-		customProfiles:  NewCustomProfiles(),
-		dgPath:          strings.Join([]string{DEFAULT_PARTITION, "Shared"}, "/"),
-		shareNodes:      params.ShareNodes,
-		eventNotifier:   apm.NewEventNotifier(nil),
+		resources:          NewResources(),
+		Agent:              params.Agent,
+		ControllerMode:     params.ControllerMode,
+		UseNodeInternal:    params.UseNodeInternal,
+		initState:          true,
+		SSLContext:         make(map[string]*v1.Secret),
+		customProfiles:     NewCustomProfiles(),
+		dgPath:             strings.Join([]string{DEFAULT_PARTITION, "Shared"}, "/"),
+		shareNodes:         params.ShareNodes,
+		eventNotifier:      apm.NewEventNotifier(nil),
 		defaultRouteDomain: params.DefaultRouteDomain,
 	}
 
@@ -245,9 +245,10 @@ func (crMgr *CRManager) setupClients(config *rest.Config) error {
 }
 
 func (crMgr *CRManager) setupInformers() error {
-	for n, _ := range crMgr.namespaces {
+	for n := range crMgr.namespaces {
 		if err := crMgr.addNamespacedInformer(n); err != nil {
 			log.Errorf("Unable to setup informer for namespace: %v, Error:%v", n, err)
+			return err
 		}
 	}
 	return nil


### PR DESCRIPTION
**Description**:  
CIS is unable to process any updates when used --namespace in CIS deployment. CIS post the config after the controller is restarted.

**Changes Proposed in PR**: 
CR Informer was configured to listen to all namespaces. When CIS is started for specific namespaces, informer was not found. Added code to handle same.  

**Fixes**: 
Internal 679 ; CONTCNTR-2567

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes