### PR TITLE
Fix Stale entries of IPAM Spec when CIS restarts

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -10,6 +10,7 @@ Added Functionality
 Bug Fixes
 `````````
 * :issues: `1737` Inconsistent ordering of policy rules when adding an Ingress path
+* Fix Deleting Stale Specs from IPAM CR when CIS restarts
 
 Limitations
 ```````````

--- a/docs/_static/config_examples/crd/Install/clusterrole.yml
+++ b/docs/_static/config_examples/crd/Install/clusterrole.yml
@@ -16,7 +16,7 @@ rules:
     verbs: ["get", "list", "watch", "update"]
   - apiGroups: ["fic.f5.com"]
       resources: ["f5ipams", "f5ipams/status"]
-      verbs: ["get", "list", "watch", "update", "create", "patch"]
+      verbs: ["get", "list", "watch", "update", "create", "patch", "delete"]
   - apiGroups: ["apiextensions.k8s.io"]
       resources: ["customresourcedefinitions"]
       verbs: ["get", "list", "watch", "update", "create", "patch"]


### PR DESCRIPTION
Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>

**Description**:  _CIS is unable to track the changes happened that would effect IPAM Spec_

**Changes Proposed in PR**: _Delete and Create the IPAM resource, so that the old entires gets freed and IP requests made according the latest configs_

**Fixes**: #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema