### PR TITLE
Added support for "virtual-server.f5.com/clientssl" annotation in ingress resource

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -6,13 +6,18 @@ Next Release
 
 Added Functionality
 ```````````````````
-* Added support for networking.k8s.io/v1 ingress
+* Added support for networking.k8s.io/v1 ingress.
+* Added support for "virtual-server.f5.com/clientssl" annotation in ingress resource.
 * Service Type LB Enhancements:
-   - Added support for Multiport service
+   - Added support for Multiport service.
 
 Bug Fixes
 `````````
-* :issues: `1824` Support for ingresses.networking.k8s.io/v1
+* :issues: `1824` Support for ingresses.networking.k8s.io/v1.
+
+Limitations
+```````````
+* Due to networking.k8s.io/v1 api support in ingress customer has to use "virtual-server.f5.com/clientssl" annotation in ingress if they are using bigip profiles in tls spec of ingress resource.
 
 
 2.4.1

--- a/docs/config_examples/ingress/networkingV1/single-service-tls-ingress.yaml
+++ b/docs/config_examples/ingress/networkingV1/single-service-tls-ingress.yaml
@@ -1,25 +1,27 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: ingressTLS
-  namespace: default
+  name: tls-example-ingress
   annotations:
     # Provide an IP address for the BIG-IP Virtual Server.
     virtual-server.f5.com/ip: "1.2.3.4"
-    # Specify the BIG-IP partition containing the virtual server.
-    virtual-server.f5.com/partition: "k8s"
+    # Specifies an already-configured SSL Profile on BIG-IP that should be
+    # used for this Ingress.
+    # Follows the format "/partition/profile_name".
+    virtual-server.f5.com/clientssl: '[ { "hosts": [ "https-example.foo.com" ], "bigIpProfile": "/Common/clientssl" } ]'
     # Allow/deny TLS connections
     ingress.kubernetes.io/ssl-redirect: "true"
     # Allow/deny HTTP connections
     ingress.kubernetes.io/allow-http: "false"
 spec:
-  tls:
-    # Specifies an already-configured SSL Profile on BIG-IP that should be
-    # used for this Ingress.
-    # Follows the format "/partition/profile_name".
-    - secretName: /Common/clientssl
-  backend:
-    # The name of a single Kubernetes Service you want to expose to external
-    # traffic using TLS
-    serviceName: myService
-    servicePort: 443
+  rules:
+    - host: https-example.foo.com
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: svc
+                port:
+                  number: 80

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -121,7 +121,7 @@ func newMockAppManager(params *Params) *mockAppManager {
 
 func (m *mockAppManager) startNonLabelMode(namespaces []string) error {
 	ls, err := labels.Parse(DefaultConfigMapLabel)
-	m.appMgr.K8sVersion = "v1.18.6"
+	m.appMgr.K8sVersion = "v1.19.6"
 	if err != nil {
 		return fmt.Errorf("failed to parse Label Selector string: %v", err)
 	}
@@ -1215,9 +1215,9 @@ var _ = Describe("AppManager Tests", func() {
 					defer GinkgoRecover()
 					err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Delete(context.TODO(), "node0", metav1.DeleteOptions{})
 					Expect(err).To(BeNil())
-					err = mockMgr.appMgr.kubeClient.CoreV1().Nodes().Delete(context.TODO(),"node1", metav1.DeleteOptions{})
+					err = mockMgr.appMgr.kubeClient.CoreV1().Nodes().Delete(context.TODO(), "node1", metav1.DeleteOptions{})
 					Expect(err).To(BeNil())
-					err = mockMgr.appMgr.kubeClient.CoreV1().Nodes().Delete(context.TODO(),"node2", metav1.DeleteOptions{})
+					err = mockMgr.appMgr.kubeClient.CoreV1().Nodes().Delete(context.TODO(), "node2", metav1.DeleteOptions{})
 					Expect(err).To(BeNil())
 					_, err = mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), extraNode, metav1.CreateOptions{})
 					Expect(err).To(BeNil())
@@ -1278,7 +1278,7 @@ var _ = Describe("AppManager Tests", func() {
 						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
 				}
 				for _, node := range nodes {
-					n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(),node, metav1.CreateOptions{})
+					n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 					Expect(err).To(BeNil(), "Should not fail creating node.")
 					Expect(n).To(Equal(node))
 				}
@@ -1437,7 +1437,7 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(fakeClient).ToNot(BeNil())
 				mockMgr.appMgr.kubeClient = fakeClient
 
-				n, err := fakeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+				n, err := fakeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil())
 				Expect(len(n.Items)).To(Equal(3))
 
@@ -1531,9 +1531,9 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(rs.Pools[0].Members).To(Equal(generateExpectedAddrs(37001, 80, addrs)))
 
 				// Nodes ADDED
-				_, err = fakeClient.CoreV1().Nodes().Create(context.TODO(),extraNode, metav1.CreateOptions{})
+				_, err = fakeClient.CoreV1().Nodes().Create(context.TODO(), extraNode, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
-				n, err = fakeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+				n, err = fakeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil(), "Should not fail listing nodes.")
 				mockMgr.processNodeUpdate(n.Items, err)
 				Expect(resources.PoolCount()).To(Equal(4))
@@ -1599,13 +1599,13 @@ var _ = Describe("AppManager Tests", func() {
 					Equal(1), "Virtual servers should contain remaining ports.")
 
 				// Nodes DELETED
-				err = fakeClient.CoreV1().Nodes().Delete(context.TODO(),"node0", metav1.DeleteOptions{})
+				err = fakeClient.CoreV1().Nodes().Delete(context.TODO(), "node0", metav1.DeleteOptions{})
 				Expect(err).To(BeNil())
-				err = fakeClient.CoreV1().Nodes().Delete(context.TODO(),"node1", metav1.DeleteOptions{})
+				err = fakeClient.CoreV1().Nodes().Delete(context.TODO(), "node1", metav1.DeleteOptions{})
 				Expect(err).To(BeNil())
-				err = fakeClient.CoreV1().Nodes().Delete(context.TODO(),"node2", metav1.DeleteOptions{})
+				err = fakeClient.CoreV1().Nodes().Delete(context.TODO(), "node2", metav1.DeleteOptions{})
 				Expect(err).To(BeNil())
-				n, err = fakeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+				n, err = fakeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil(), "Should not fail listing nodes.")
 				mockMgr.processNodeUpdate(n.Items, err)
 				Expect(resources.PoolCount()).To(Equal(2))
@@ -1741,9 +1741,9 @@ var _ = Describe("AppManager Tests", func() {
 
 				node := test.NewNode("node3", "3", false,
 					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
-				_, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(),node,metav1.CreateOptions{})
+				_, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
-				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil(), "Should not fail listing nodes.")
 				mockMgr.processNodeUpdate(n.Items, err)
 
@@ -1858,7 +1858,7 @@ var _ = Describe("AppManager Tests", func() {
 				fakeClient := fake.NewSimpleClientset(&v1.NodeList{Items: nodes})
 				Expect(fakeClient).ToNot(BeNil(), "Mock client cannot be nil.")
 
-				n, err := fakeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+				n, err := fakeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil())
 				Expect(len(n.Items)).To(Equal(4))
 
@@ -1914,9 +1914,9 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(resources.PoolCount()).To(Equal(2))
 
 				// Nodes ADDED
-				_, err = fakeClient.CoreV1().Nodes().Create(context.TODO(),extraNode,metav1.CreateOptions{})
+				_, err = fakeClient.CoreV1().Nodes().Create(context.TODO(), extraNode, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
-				n, err = fakeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+				n, err = fakeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil(), "Should not fail listing nodes.")
 				mockMgr.processNodeUpdate(n.Items, err)
 				Expect(resources.PoolCount()).To(Equal(2))
@@ -1933,11 +1933,11 @@ var _ = Describe("AppManager Tests", func() {
 				validateConfig(mw, twoIappsThreeNodesConfig)
 
 				// Nodes DELETED
-				err = fakeClient.CoreV1().Nodes().Delete(context.TODO(),"node1", metav1.DeleteOptions{})
+				err = fakeClient.CoreV1().Nodes().Delete(context.TODO(), "node1", metav1.DeleteOptions{})
 				Expect(err).To(BeNil())
-				err = fakeClient.CoreV1().Nodes().Delete(context.TODO(),"node2", metav1.DeleteOptions{})
+				err = fakeClient.CoreV1().Nodes().Delete(context.TODO(), "node2", metav1.DeleteOptions{})
 				Expect(err).To(BeNil())
-				n, err = fakeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+				n, err = fakeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil(), "Should not fail listing nodes.")
 				mockMgr.processNodeUpdate(n.Items, err)
 				Expect(resources.PoolCount()).To(Equal(2))
@@ -2107,11 +2107,11 @@ var _ = Describe("AppManager Tests", func() {
 						{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}),
 				}
 				for _, node := range nodes {
-					n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(),node,metav1.CreateOptions{})
+					n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 					Expect(err).To(BeNil(), "Should not fail creating node.")
 					Expect(n).To(Equal(node))
 				}
-				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil())
 				mockMgr.processNodeUpdate(n.Items, nil)
 
@@ -2200,11 +2200,11 @@ var _ = Describe("AppManager Tests", func() {
 						{Type: "ExternalIP", Address: "127.0.0.5"}}, []v1.Taint{}),
 				}
 				for _, node := range nodes {
-					n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(),node, metav1.CreateOptions{})
+					n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 					Expect(err).To(BeNil(), "Should not fail creating node.")
 					Expect(n).To(Equal(node))
 				}
-				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil())
 				mockMgr.processNodeUpdate(n.Items, nil)
 
@@ -2349,11 +2349,11 @@ var _ = Describe("AppManager Tests", func() {
 
 				node := test.NewNode("node0", "0", false, []v1.NodeAddress{
 					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{})
-				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(),node,metav1.CreateOptions{})
+				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 				Expect(err).To(BeNil(), "Should not fail creating node.")
 				Expect(n).To(Equal(node))
 
-				nodes, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+				nodes, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil())
 				mockMgr.processNodeUpdate(nodes.Items, nil)
 
@@ -2779,9 +2779,9 @@ var _ = Describe("AppManager Tests", func() {
 				// Create Node so we get endpoints
 				node := test.NewNode("node1", "1", false,
 					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.1"}}, []v1.Taint{})
-				_, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(),node, metav1.CreateOptions{})
+				_, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
-				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil(), "Should not fail listing nodes.")
 				mockMgr.processNodeUpdate(n.Items, err)
 
@@ -4298,9 +4298,9 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(err).To(BeNil())
 				node := test.NewNode("node1", "1", false,
 					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
-				_, err = mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(),node, metav1.CreateOptions{})
+				_, err = mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
-				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil(), "Should not fail listing nodes.")
 				mockMgr.processNodeUpdate(n.Items, err)
 
@@ -4452,9 +4452,9 @@ var _ = Describe("AppManager Tests", func() {
 
 				node := test.NewNode("node1", "1", false,
 					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
-				_, err = mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(),node, metav1.CreateOptions{})
+				_, err = mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
-				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 				Expect(err).To(BeNil(), "Should not fail listing nodes.")
 				mockMgr.processNodeUpdate(n.Items, err)
 

--- a/pkg/appmanager/eventNotifier_test.go
+++ b/pkg/appmanager/eventNotifier_test.go
@@ -229,7 +229,6 @@ var _ = Describe("Event Notifier Tests", func() {
 
 			}
 
-
 		}
 		// TODO remove the tests for "ingress v1beta1" once v1beta1.Ingress is deprecated in k8s 1.22
 		It("multiple namespace ingress", func() {

--- a/pkg/appmanager/ingress_test.go
+++ b/pkg/appmanager/ingress_test.go
@@ -1007,9 +1007,9 @@ var _ = Describe("V1 Ingress Tests", func() {
 			// Create Node so we get endpoints
 			node := test.NewNode("node1", "1", false,
 				[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.1"}}, []v1.Taint{})
-			_, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(),node, metav1.CreateOptions{})
+			_, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 			Expect(err).To(BeNil())
-			n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(),metav1.ListOptions{})
+			n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
 			Expect(err).To(BeNil(), "Should not fail listing nodes.")
 			mockMgr.processNodeUpdate(n.Items, err)
 
@@ -1490,11 +1490,6 @@ var _ = Describe("V1 Ingress Tests", func() {
 					},
 				},
 			}
-			tlsArray := []netv1.IngressTLS{
-				{
-					SecretName: "/Common/clientssl",
-				},
-			}
 			specFoo := netv1.IngressSpec{
 				Rules: []netv1.IngressRule{
 					{Host: host,
@@ -1503,7 +1498,6 @@ var _ = Describe("V1 Ingress Tests", func() {
 						},
 					},
 				},
-				TLS: tlsArray,
 			}
 			specBar := netv1.IngressSpec{
 				Rules: []netv1.IngressRule{
@@ -1513,7 +1507,6 @@ var _ = Describe("V1 Ingress Tests", func() {
 						},
 					},
 				},
-				TLS: tlsArray,
 			}
 
 			// Create the first ingress and associate a service
@@ -1522,6 +1515,7 @@ var _ = Describe("V1 Ingress Tests", func() {
 					F5VsBindAddrAnnotation:  "1.2.3.4",
 					F5VsPartitionAnnotation: DEFAULT_PARTITION,
 					IngressSslRedirect:      "true",
+					F5ClientSslProfileAnnotation: "[ { \"hosts\": [ \"foo.com\" ], \"bigIpProfile\": \"/Common/clientssl\" } ]",
 				})
 			r := mockMgr.addV1Ingress(ing1a)
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
@@ -1536,6 +1530,7 @@ var _ = Describe("V1 Ingress Tests", func() {
 					F5VsBindAddrAnnotation:  "1.2.3.4",
 					F5VsPartitionAnnotation: DEFAULT_PARTITION,
 					IngressSslRedirect:      "true",
+					F5ClientSslProfileAnnotation: "[ { \"hosts\": [ \"foo.com\" ], \"bigIpProfile\": \"/Common/clientssl\" } ]",
 				})
 			r = mockMgr.addV1Ingress(ing2)
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
@@ -1563,6 +1558,7 @@ var _ = Describe("V1 Ingress Tests", func() {
 					F5VsBindAddrAnnotation:  "1.2.3.4",
 					F5VsPartitionAnnotation: "velcro",
 					IngressSslRedirect:      "true",
+					F5ClientSslProfileAnnotation: "[ { \"hosts\": [ \"bar.com\" ], \"bigIpProfile\": \"/Common/clientssl\" } ]",
 				})
 			r = mockMgr.addV1Ingress(ing1b)
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")
@@ -1605,6 +1601,7 @@ var _ = Describe("V1 Ingress Tests", func() {
 					F5VsBindAddrAnnotation:  "1.2.3.4",
 					F5VsPartitionAnnotation: DEFAULT_PARTITION,
 					IngressSslRedirect:      "false",
+					F5ClientSslProfileAnnotation: "[ { \"hosts\": [ \"foo.com\" ], \"bigIpProfile\": \"/Common/clientssl\" } ]",
 				})
 			r = mockMgr.addV1Ingress(ing1a)
 			Expect(r).To(BeTrue(), "Ingress resource should be processed.")

--- a/pkg/appmanager/validateResources.go
+++ b/pkg/appmanager/validateResources.go
@@ -23,10 +23,10 @@ import (
 
 	. "github.com/F5Networks/k8s-bigip-ctlr/pkg/resource"
 	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
-	netv1 "k8s.io/api/networking/v1"
 	routeapi "github.com/openshift/api/route/v1"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
+	netv1 "k8s.io/api/networking/v1"
 )
 
 func (appMgr *Manager) checkValidConfigMap(

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -331,6 +331,14 @@ type (
 	}
 	AnnotationHealthMonitors []AnnotationHealthMonitor
 
+	// This is the format for each item in the clientssl annotation used
+	// in the Ingress objects.
+	AnnotationProfile struct {
+		hosts        []string `json:"hosts"`
+		Bigipprofile string   `json:"bigIpProfile"`
+	}
+	AnnotationProfiles []AnnotationProfile
+
 	RuleData struct {
 		SvcName   string
 		SvcPort   int32

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -303,7 +303,7 @@ func (fns *fakeNegotiatedSerializer) SupportedMediaTypes() []runtime.SerializerI
 		PrettySerializer: nil,
 		StreamSerializer: &runtime.StreamSerializerInfo{
 			EncodesAsText: true,
-			Serializer:    runtime.NewCodec(nil,nil),
+			Serializer:    runtime.NewCodec(nil, nil),
 			Framer:        &fakeFrame{},
 		},
 	}


### PR DESCRIPTION
**Description**:  Added support for "virtual-server.f5.com/clientssl" annotation in ingress resource

**Changes Proposed in PR**:  Added support for "virtual-server.f5.com/clientssl" annotation in ingress resource

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature

