### PR TITLE
Fix for rewrite target url for virtual server, ingress and route

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -17,6 +17,7 @@ Added Functionality
 Bug Fixes
 `````````
 * :issues: `1824` Support for ingresses.networking.k8s.io/v1.
+* Fixed rewrite-url annotation doesnt support to rewrite all child paths to specific target domain
 
 Limitations
 ```````````

--- a/pkg/crmanager/routing.go
+++ b/pkg/crmanager/routing.go
@@ -300,7 +300,7 @@ func getRewriteActions(path, rwPath string, actionNameIndex int) ([]*action, err
 				Path:    path,
 				Replace: true,
 				Request: true,
-				Value:   rwPath,
+				Value:   fmt.Sprintf("tcl:[string map {%s %s} [HTTP::uri]]", path, rwPath),
 			})
 		} else {
 			actions = append(actions, &action{

--- a/pkg/resource/resourceConfig.go
+++ b/pkg/resource/resourceConfig.go
@@ -1296,7 +1296,7 @@ func ProcessURLRewrite(target, value string, rsType int) *Rule {
 				Path:    targetURL.Path,
 				Replace: true,
 				Request: true,
-				Value:   valueURL.Path,
+				Value:   fmt.Sprintf("tcl:[string map {%s %s} [HTTP::uri]]", targetURL.Path, valueURL.Path),
 			})
 		} else {
 			actions = append(actions, &Action{

--- a/pkg/resource/resourceConfig_test.go
+++ b/pkg/resource/resourceConfig_test.go
@@ -1100,7 +1100,7 @@ var _ = Describe("Resource Config Tests", func() {
 				Path:    "/oldpath/path",
 				Replace: true,
 				Request: true,
-				Value:   "/newpath/path",
+				Value:   "tcl:[string map {/oldpath/path /newpath/path} [HTTP::uri]]",
 			}}))
 
 			// mutli-service ingress rewrite host and path
@@ -1139,7 +1139,7 @@ var _ = Describe("Resource Config Tests", func() {
 					Path:    "/path",
 					Replace: true,
 					Request: true,
-					Value:   "/newpath",
+					Value:   "tcl:[string map {/path /newpath} [HTTP::uri]]",
 				},
 			}))
 
@@ -1190,7 +1190,7 @@ var _ = Describe("Resource Config Tests", func() {
 				Path:    "/path",
 				Replace: true,
 				Request: true,
-				Value:   "/newpath",
+				Value:   "tcl:[string map {/path /newpath} [HTTP::uri]]",
 			}}))
 
 			// route rewrite host and path
@@ -1229,7 +1229,7 @@ var _ = Describe("Resource Config Tests", func() {
 					Path:    "/path",
 					Replace: true,
 					Request: true,
-					Value:   "/newpath",
+					Value:   "tcl:[string map {/path /newpath} [HTTP::uri]]",
 				},
 			}))
 		})


### PR DESCRIPTION
**Description**:  Fixed rewrite-url annotation does not support to rewrite all child paths.

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
