### PR TITLE
Fixed http redirect not working when used virtual-server.f5.com/rewrite-target-url annotation with routes

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -19,6 +19,8 @@ Bug Fixes
 * :issues: `1824` Support for ingresses.networking.k8s.io/v1.
 * Fixed rewrite-url annotation doesnt support to rewrite all child paths to specific target domain
 
+* Fixed http redirect not working when used virtual-server.f5.com/rewrite-target-url annotation with routes
+
 Limitations
 ```````````
 * Due to networking.k8s.io/v1 api support in ingress customer has to use "virtual-server.f5.com/clientssl" annotation in ingress if they are using bigip profiles in tls spec of ingress resource.

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -559,7 +559,7 @@ func (appMgr *Manager) handleRouteRules(
 				rc.Virtual.AddIRule(abPathIRuleName)
 			} else {
 				rc.AddRuleToPolicy(policyName, rule)
-				SetAnnotationRulesForRoute(policyName, urlRewriteRule, appRootRules, rc)
+				SetAnnotationRulesForRoute(policyName, urlRewriteRule, appRootRules, rc, false)
 			}
 		} else {
 			// Handle redirect policy for edge. Reencrypt and passthrough do not
@@ -572,7 +572,7 @@ func (appMgr *Manager) handleRouteRules(
 						rc.Virtual.AddIRule(abPathIRuleName)
 					} else {
 						rc.AddRuleToPolicy(policyName, rule)
-						SetAnnotationRulesForRoute(policyName, urlRewriteRule, appRootRules, rc)
+						SetAnnotationRulesForRoute(policyName, urlRewriteRule, appRootRules, rc, false)
 					}
 				case routeapi.InsecureEdgeTerminationPolicyRedirect:
 					redirectIRuleName := JoinBigipPath(DEFAULT_PARTITION,
@@ -589,7 +589,7 @@ func (appMgr *Manager) handleRouteRules(
 					svcFwdRulesMap.AddEntry(route.ObjectMeta.Namespace, route.Spec.To.Name,
 						route.Spec.Host, path)
 					rc.AddRuleToPolicy(policyName, rule)
-					SetAnnotationRulesForRoute(policyName, urlRewriteRule, appRootRules, rc)
+					SetAnnotationRulesForRoute(policyName, urlRewriteRule, appRootRules, rc, true)
 				}
 			}
 		}
@@ -612,7 +612,7 @@ func (appMgr *Manager) handleRouteRules(
 					appMgr.addInternalDataGroup(EdgeServerSslDgName, DEFAULT_PARTITION)
 					rc.Virtual.AddIRule(passThroughIRuleName)
 					rc.AddRuleToPolicy(policyName, rule)
-					SetAnnotationRulesForRoute(policyName, urlRewriteRule, appRootRules, rc)
+					SetAnnotationRulesForRoute(policyName, urlRewriteRule, appRootRules, rc, false)
 				}
 			case routeapi.TLSTerminationPassthrough:
 				appMgr.addIRule(
@@ -627,7 +627,7 @@ func (appMgr *Manager) handleRouteRules(
 				rc.Virtual.AddIRule(passThroughIRuleName)
 				if !abDeployment {
 					rc.AddRuleToPolicy(policyName, rule)
-					SetAnnotationRulesForRoute(policyName, urlRewriteRule, appRootRules, rc)
+					SetAnnotationRulesForRoute(policyName, urlRewriteRule, appRootRules, rc, false)
 				}
 			}
 		}

--- a/pkg/resource/resourceConfig.go
+++ b/pkg/resource/resourceConfig.go
@@ -1566,12 +1566,13 @@ func SetAnnotationRulesForRoute(
 	urlRewriteRule *Rule,
 	appRootRules []*Rule,
 	rc *ResourceConfig,
+	skipUrlRewriteRule bool,
 ) {
 	if len(appRootRules) == 2 {
 		rc.AddRuleToPolicy(policyName, appRootRules[0])
 		rc.AddRuleToPolicy(policyName, appRootRules[1])
 	}
-	if urlRewriteRule != nil {
+	if urlRewriteRule != nil && skipUrlRewriteRule != true {
 		rc.AddRuleToPolicy(policyName, urlRewriteRule)
 	}
 }


### PR DESCRIPTION
Fixed http redirect not working when used virtual-server.f5.com/rewrite-target-url annotation with routes

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes