### PR TITLE
Fix inconsistent behaviour with CIS while adding nodes

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -25,6 +25,7 @@ Bug Fixes
 * Fixed rewrite-url annotation doesnt support to rewrite all child paths to specific target domain
 
 * Fixed http redirect not working when used virtual-server.f5.com/rewrite-target-url annotation with routes
+* Fixed inconsistent behaviour with CIS (Transport Server) while adding/deleting a node to cluster.
 
 Limitations
 ```````````


### PR DESCRIPTION
**Description**: When a node is added/deleted to the cluster, CIS will not add the node as pool members unless any pod CIS monitors is deployed in that new node. Added TS processing for node poller.

**Changes Proposed in PR**:

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema