### PR TITLE
Update secrets RBAC and upgrade 2.5 notes properly

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -39,12 +39,14 @@ Known Issues
 ````````````
 * For improved performance, configure CIS deployment with ``--periodic-sync-interval`` more than 300 seconds. OpenShift Routes with termination Passthrough get processed post this interval.
 
-Note
-````
-* CIS 2.5 supports Kubenetes networking.k8s.io/v1 Ingress and IngressClass. With Kubernetes > 1.18, update CIS ClusterRole (refer for `example <https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/config_examples/crd/Install/clusterrole.yml>`_) and create IngressClass (refer for `example <https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/config_examples/ingress/networkingV1/example-default-ingress-class.yaml>`_) before version upgrade.
+Before upgrade to 2.5
+`````````````````````
+* CIS 2.5 supports Kubenetes networking.k8s.io/v1 Ingress and IngressClass. With Kubernetes > 1.18, 
+    - Reconfigure CIS `ClusterRole <https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/config_examples/crd/Install/clusterrole.yml>`_ - we removed `resourceName` to monitor all secrets. 
+    - Create `IngressClass <https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/config_examples/ingress/networkingV1/example-default-ingress-class.yaml>`_ before version upgrade.
 * To upgrade CIS using operator in OpenShift, 
-  - Install `IngressClass <https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/config_examples/ingress/networkingV1/example-default-ingress-class.yaml>_` manually if CIS is monitoring ingress resource. 
-  - Install `CRDs <https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/config_examples/crd/Install/customresourcedefinitions.yml>_` manually if using CIS CustomResources (VirtualServer/TransportServer/IngressLink).
+    - Install `IngressClass <https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/config_examples/ingress/networkingV1/example-default-ingress-class.yaml>`_ manually. 
+    - Install `CRDs <https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/config_examples/crd/Install/customresourcedefinitions.yml>`_ manually if using CIS CustomResources (VirtualServer/TransportServer/IngressLink).
 
 
 F5 IPAM Controller v0.1.4

--- a/docs/config_examples/crd/IngressLink/cis-config/cis_rbac.yaml
+++ b/docs/config_examples/crd/IngressLink/cis-config/cis_rbac.yaml
@@ -11,7 +11,6 @@ rules:
     verbs: ["get", "list", "watch", "update", "create", "patch"]
   - apiGroups: ["", "extensions"]
     resources: ["secrets"]
-    resourceNames: ["bigip-login"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["cis.f5.com"]
     resources: ["ingresslinks"]

--- a/docs/config_examples/crd/Install/clusterrole.yml
+++ b/docs/config_examples/crd/Install/clusterrole.yml
@@ -22,7 +22,6 @@ rules:
       verbs: ["get", "list", "watch", "update", "create", "patch"]
   - apiGroups: ["", "extensions"]
     resources: ["secrets"]
-    resourceNames: ["<secret-containing-bigip-login>"]
     verbs: ["get", "list", "watch"]
 ---
 


### PR DESCRIPTION
**Description**:  Updated ClusterRole - Removed `resourceName` in rule for secrets resources.

**Changes Proposed in PR**: From 2.5, CIS monitors Secret resources. So update the ClusterRole. 

## General Checklist
- [] Updated the documentation