### PR TITLE
Fixing the issue with credential-directory parameter

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -552,7 +552,7 @@ func getCredentials() error {
 					return fmt.Errorf(fmt.Sprintf("BIG-IP %s not specified", fieldType))
 				}
 			} else {
-				*field = string(fileBytes)
+				*field = strings.TrimSpace(string(fileBytes))
 			}
 			return nil
 		}

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -4,6 +4,9 @@ Release Notes for Container Ingress Services for Kubernetes & OpenShift
 Next Release
 -------------
 
+Bug Fixes
+`````````
+* :issues:`1921` Plain text login and password in process status on node that is running controller.
 
 Vulnerability Fixes
 ```````````````````


### PR DESCRIPTION
**Description**:  If there is newline character at end of file due to which CIS fails to map the username, password and url. We need to remove the newline character while parsing file.

**Changes Proposed in PR**: Removing the newline characters from file while mapping the credentials. Customer can use --credentials-directory parameter instead of these three parameters (--bigip-username, --bigip-password, --bigip-url ). For that they need to create three files named username, password and url inside a directory and then create a Kubernetes secrets using this directory. Please see the CIS deploy file for [example](https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/config_examples/example-bigip-credentials-directory.yaml)

**Fixes**: #1921

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes