### PR TITLE
Update IPAM resource name format to support partitions with Captial letters

### DIFF
--- a/pkg/crmanager/worker_test.go
+++ b/pkg/crmanager/worker_test.go
@@ -147,6 +147,7 @@ var _ = Describe("Worker Tests", func() {
 	})
 
 	Describe("IPAM", func() {
+		DEFAULT_PARTITION = "Test"
 		BeforeEach(func() {
 			mockCRM.Agent = &Agent{
 				PostManager: &PostManager{


### PR DESCRIPTION

Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>

**Description**:  _Kubernetes does not accept capital letters as part of resource names and CIS uses BIGIP partition names as part IPAM resource name. When BIGIP partition has a capital letter in its name, there is a conflict. _

**Changes Proposed in PR**: To solve this issue CIS replaces Capital letters with corresponding small letter along with an extra "-"

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema