### PR TITLE
Using strings.ReplaceAll to improve performance

### DIFF
--- a/pkg/crmanager/resourceConfig.go
+++ b/pkg/crmanager/resourceConfig.go
@@ -309,8 +309,7 @@ func formatVirtualServerPoolName(namespace, svc string, port int32, nodeMemberLa
 	servicePort := fmt.Sprint(port)
 	poolName := fmt.Sprintf("%s_%s_%s", namespace, svc, servicePort)
 	if nodeMemberLabel != "" {
-		replacer := strings.NewReplacer("=", "_")
-		nodeMemberLabel = replacer.Replace(nodeMemberLabel)
+		nodeMemberLabel = strings.ReplaceAll(nodeMemberLabel, "=", "_")
 		poolName = fmt.Sprintf("%s_%s", poolName, nodeMemberLabel)
 	}
 	return AS3NameFormatter(poolName)
@@ -1052,8 +1051,16 @@ func (idg *InternalDataGroup) RemoveRecord(name string) bool {
 // AS3NameFormatter formarts resources names according to AS3 convention
 // TODO: Should we use this? Or this will be done in agent?
 func AS3NameFormatter(name string) string {
-	replacer := strings.NewReplacer(".", "_", ":", "_", "/", "_", "%", ".", "-", "_", "=", "_")
-	name = replacer.Replace(name)
+	modifySpecialChars := map[string]string{
+		".": "_",
+		":": "_",
+		"/": "_",
+		"%": ".",
+		"-": "_",
+		"=": "_"}
+	for key, value := range modifySpecialChars {
+		name = strings.ReplaceAll(name, key, value)
+	}
 	return name
 }
 

--- a/pkg/resource/resourceConfig.go
+++ b/pkg/resource/resourceConfig.go
@@ -224,8 +224,14 @@ func FormatIngressVSName(ip string, port int32) string {
 	// Strip any bracket characters; replace special characters ". : /"
 	// with "-" and "%" with ".", for naming purposes
 	ip = strings.Trim(ip, "[]")
-	var replacer = strings.NewReplacer(".", "-", ":", "-", "/", "-", "%", ".")
-	ip = replacer.Replace(ip)
+	modifySpecialChars := map[string]string{
+		".": "-",
+		":": "-",
+		"/": "-",
+		"%": "."}
+	for key, value := range modifySpecialChars {
+		ip = strings.ReplaceAll(ip, key, value)
+	}
 	return fmt.Sprintf("ingress_%s_%d", ip, port)
 }
 


### PR DESCRIPTION
**Description**:  For CIS use case of formatting IP address, strings.ReplaceAll solves efficiently reducing processing time by a factor of 2. => 50% lesser time

**Changes Proposed in PR**:

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema