### PR TITLE
Replace reflect.DeepEqual to improve Performance

### DIFF
--- a/pkg/appmanager/profiles.go
+++ b/pkg/appmanager/profiles.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	netv1 "k8s.io/api/networking/v1"
-	"reflect"
 	"strings"
 
 	. "github.com/F5Networks/k8s-bigip-ctlr/pkg/resource"
@@ -139,7 +138,7 @@ func (appMgr *Manager) setClientSslProfile(
 				ResourceName: rsCfg.GetName(),
 			}
 			if prof, ok := appMgr.customProfiles.Profs[skey]; ok {
-				if !reflect.DeepEqual(prof, cp) {
+				if prof != cp {
 					stats.cpUpdated += 1
 				}
 			}
@@ -311,7 +310,7 @@ func (appMgr *Manager) handleDestCACert(
 		)
 		caKey := SecretKey{Name: caProfRef.Name}
 		caExistingProf, ok := appMgr.customProfiles.Profs[caKey]
-		if !ok || !reflect.DeepEqual(caProf, caExistingProf) {
+		if !ok || caProf != caExistingProf {
 			appMgr.customProfiles.Profs[caKey] = caProf
 			stats.cpUpdated += 1
 		}
@@ -336,7 +335,7 @@ func (appMgr *Manager) handleDestCACert(
 		ResourceName: rsCfg.GetName(),
 	}
 	svrExistingProf, ok := appMgr.customProfiles.Profs[skey]
-	if !ok || !reflect.DeepEqual(svrProf, svrExistingProf) {
+	if !ok || svrProf != svrExistingProf {
 		appMgr.customProfiles.Profs[skey] = svrProf
 		stats.cpUpdated += 1
 	}
@@ -418,7 +417,7 @@ func (appMgr *Manager) createSecretSslProfile(
 	appMgr.customProfiles.Lock()
 	defer appMgr.customProfiles.Unlock()
 	if prof, ok := appMgr.customProfiles.Profs[skey]; ok {
-		if !reflect.DeepEqual(prof, cp) {
+		if prof != cp {
 			appMgr.customProfiles.Profs[skey] = cp
 			return nil, true
 		} else {

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -20,10 +20,9 @@ import (
 	"bytes"
 	"fmt"
 	"net/url"
+	"reflect"
 	"strconv"
 
-	//"net/url"
-	"reflect"
 	"sort"
 
 	//"strconv"

--- a/pkg/crmanager/profile.go
+++ b/pkg/crmanager/profile.go
@@ -2,8 +2,6 @@ package crmanager
 
 import (
 	"fmt"
-	"reflect"
-
 	v1 "k8s.io/api/core/v1"
 )
 
@@ -66,7 +64,7 @@ func (crMgr *CRManager) createSecretClientSSLProfile(
 		ResourceName: rsCfg.GetName(),
 	}
 	if prof, ok := rsCfg.customProfiles.Profs[skey]; ok {
-		if !reflect.DeepEqual(prof, cp) {
+		if prof != cp {
 			rsCfg.customProfiles.Profs[skey] = cp
 			rsCfg.Virtual.AddOrUpdateProfile(profRef)
 			return nil, true
@@ -132,7 +130,7 @@ func (crMgr *CRManager) createSecretServerSSLProfile(
 		ResourceName: rsCfg.GetName(),
 	}
 	if prof, ok := rsCfg.customProfiles.Profs[skey]; ok {
-		if !reflect.DeepEqual(prof, cp) {
+		if prof != cp {
 			rsCfg.customProfiles.Profs[skey] = cp
 			rsCfg.Virtual.AddOrUpdateProfile(profRef)
 			return nil, true

--- a/pkg/crmanager/resourceConfig.go
+++ b/pkg/crmanager/resourceConfig.go
@@ -21,7 +21,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
-	"reflect"
 	"sort"
 	"strconv"
 	"strings"
@@ -795,7 +794,7 @@ func (rc *ResourceConfig) SetPolicy(policy Policy) {
 	}
 	found := false
 	for _, polName := range rc.Virtual.Policies {
-		if reflect.DeepEqual(toFind, polName) {
+		if toFind == polName {
 			found = true
 			break
 		}

--- a/pkg/resource/resourceConfig.go
+++ b/pkg/resource/resourceConfig.go
@@ -1711,7 +1711,7 @@ func (rc *ResourceConfig) SetPolicy(policy Policy) {
 	}
 	found := false
 	for _, polName := range rc.Virtual.Policies {
-		if reflect.DeepEqual(toFind, polName) {
+		if toFind == polName {
 			found = true
 			break
 		}
@@ -1734,7 +1734,7 @@ func (rc *ResourceConfig) RemovePolicy(policy Policy) {
 		Partition: policy.Partition,
 	}
 	for i, polName := range rc.Virtual.Policies {
-		if reflect.DeepEqual(toFind, polName) {
+		if toFind == polName {
 			// Remove from array
 			copy(rc.Virtual.Policies[i:], rc.Virtual.Policies[i+1:])
 			rc.Virtual.Policies[len(rc.Virtual.Policies)-1] = NameRef{}
@@ -1785,7 +1785,7 @@ func (rc *ResourceConfig) SetMonitor(pool *Pool, monitor Monitor) bool {
 	}
 	for i, mon := range rc.Monitors {
 		if mon.Name == monitor.Name && mon.Partition == monitor.Partition {
-			if !reflect.DeepEqual(rc.Monitors[i], monitor) {
+			if rc.Monitors[i] != monitor {
 				rc.Monitors[i] = monitor
 				updated = true
 			}
@@ -2099,7 +2099,7 @@ func (rc *ResourceConfig) MergeRules(mergedRulesMap map[string]map[string]Merged
 								mergerName := rules[j].Actions[l].Name
 								rules[i].Actions[k].Name = ""
 								rules[j].Actions[l].Name = ""
-								if reflect.DeepEqual(rules[i].Actions[k], rules[j].Actions[l]) {
+								if rules[i].Actions[k] == rules[j].Actions[l] {
 									found = true
 								}
 								rules[i].Actions[k].Name = mergeeName
@@ -2129,7 +2129,7 @@ func (rc *ResourceConfig) MergeRules(mergedRulesMap map[string]map[string]Merged
 								mergerName := rules[i].Actions[l].Name
 								rules[j].Actions[k].Name = ""
 								rules[i].Actions[l].Name = ""
-								if reflect.DeepEqual(rules[j].Actions[k], rules[i].Actions[l]) {
+								if rules[j].Actions[k] == rules[i].Actions[l] {
 									found = true
 								}
 								rules[j].Actions[k].Name = mergeeName


### PR DESCRIPTION
**Description**:  reflect package impacts performance. reflect.DeepEqual consumed ~12% = 1 GB of memory while running performance on scale setup with 1000 ingresses. 

**Changes Proposed in PR**:

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema