### PR TITLE
Add CIS BIGIP credential to GTM if GTM credential is not present

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -10,7 +10,8 @@ Next Release
 Added Functionality
 ```````````````````
 * Improved Ingress, EDNS Performance 
-  * New VirtualServer creation triggers processing of only associated EDNS resources. 
+* New VirtualServer creation triggers processing of only associated EDNS resources.
+* CIS uses default BIGIP credentials if GTM credentials are not given. 
 
 Bug Fixes
 `````````

--- a/pkg/crmanager/backend.go
+++ b/pkg/crmanager/backend.go
@@ -94,8 +94,14 @@ func NewAgent(params AgentParams) *Agent {
 	}
 
 	var gtm gtmBigIPSection
-	if len(params.GTMParams.GTMBigIpUsername) == 0 || len(params.GTMParams.GTMBigIpPassword) == 0 || len(params.GTMParams.GTMBigIpUrl) == 0 {
-		gs.GTM = false
+	if len(params.GTMParams.GTMBigIpUrl) == 0 || len(params.GTMParams.GTMBigIpUsername) == 0 || len(params.GTMParams.GTMBigIpPassword) == 0 {
+		// gs.GTM = false
+		gtm = gtmBigIPSection{
+			GtmBigIPUsername: params.PostParams.BIGIPUsername,
+			GtmBigIPPassword: params.PostParams.BIGIPPassword,
+			GtmBigIPURL:      params.PostParams.BIGIPURL,
+		}
+		log.Warning("Creating GTM with default bigip credentials as GTM BIGIP Url or GTM BIGIP Username or GTM BIGIP Password is missing on CIS args.")
 	} else {
 		gtm = gtmBigIPSection{
 			GtmBigIPUsername: params.GTMParams.GTMBigIpUsername,


### PR DESCRIPTION
**Description**: Add CIS BIGIP credential to GTM if GTM credential is not present

**Changes Proposed in PR**:

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema