### PR TITLE
Fix pushing premature config to BIGIP durinng init process

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -7,6 +7,7 @@ Next Release
 Bug Fixes
 `````````
 * Added the complete path for datagroups in http redirect irule
+* :issues:`1911` Fix CIS pushes premature config to BIG-IP during init process
 
 2.6.0
 -------------


### PR DESCRIPTION
Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>

**Description**:  _CIS pushing pre mature config during the init process, which leads to deletion of resources in BIG-IP due to declarative nature of underlying agent_

**Changes Proposed in PR**: Handled Queue Length properly during the init process.

**Fixes**: resolves #_https://github.com/F5Networks/k8s-bigip-ctlr/issues/1911_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema