### PR TITLE
Rename ExternalDNS resource name

### DIFF
--- a/config/client/clientset/versioned/typed/cis/v1/externaldns.go
+++ b/config/client/clientset/versioned/typed/cis/v1/externaldns.go
@@ -68,7 +68,7 @@ func (c *externalDNSs) Get(ctx context.Context, name string, options metav1.GetO
 	result = &v1.ExternalDNS{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("externaldnss").
+		Resource("externaldns").
 		Name(name).
 		VersionedParams(&options, scheme.ParameterCodec).
 		Do(ctx).
@@ -85,7 +85,7 @@ func (c *externalDNSs) List(ctx context.Context, opts metav1.ListOptions) (resul
 	result = &v1.ExternalDNSList{}
 	err = c.client.Get().
 		Namespace(c.ns).
-		Resource("externaldnss").
+		Resource("externaldns").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Do(ctx).
@@ -102,7 +102,7 @@ func (c *externalDNSs) Watch(ctx context.Context, opts metav1.ListOptions) (watc
 	opts.Watch = true
 	return c.client.Get().
 		Namespace(c.ns).
-		Resource("externaldnss").
+		Resource("externaldns").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Watch(ctx)
@@ -113,7 +113,7 @@ func (c *externalDNSs) Create(ctx context.Context, externalDNS *v1.ExternalDNS, 
 	result = &v1.ExternalDNS{}
 	err = c.client.Post().
 		Namespace(c.ns).
-		Resource("externaldnss").
+		Resource("externaldns").
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(externalDNS).
 		Do(ctx).
@@ -126,7 +126,7 @@ func (c *externalDNSs) Update(ctx context.Context, externalDNS *v1.ExternalDNS, 
 	result = &v1.ExternalDNS{}
 	err = c.client.Put().
 		Namespace(c.ns).
-		Resource("externaldnss").
+		Resource("externaldns").
 		Name(externalDNS.Name).
 		VersionedParams(&opts, scheme.ParameterCodec).
 		Body(externalDNS).
@@ -139,7 +139,7 @@ func (c *externalDNSs) Update(ctx context.Context, externalDNS *v1.ExternalDNS, 
 func (c *externalDNSs) Delete(ctx context.Context, name string, opts metav1.DeleteOptions) error {
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("externaldnss").
+		Resource("externaldns").
 		Name(name).
 		Body(&opts).
 		Do(ctx).
@@ -154,7 +154,7 @@ func (c *externalDNSs) DeleteCollection(ctx context.Context, opts metav1.DeleteO
 	}
 	return c.client.Delete().
 		Namespace(c.ns).
-		Resource("externaldnss").
+		Resource("externaldns").
 		VersionedParams(&listOpts, scheme.ParameterCodec).
 		Timeout(timeout).
 		Body(&opts).
@@ -167,7 +167,7 @@ func (c *externalDNSs) Patch(ctx context.Context, name string, pt types.PatchTyp
 	result = &v1.ExternalDNS{}
 	err = c.client.Patch(pt).
 		Namespace(c.ns).
-		Resource("externaldnss").
+		Resource("externaldns").
 		Name(name).
 		SubResource(subresources...).
 		VersionedParams(&opts, scheme.ParameterCodec).

--- a/config/client/clientset/versioned/typed/cis/v1/fake/fake_externaldns.go
+++ b/config/client/clientset/versioned/typed/cis/v1/fake/fake_externaldns.go
@@ -36,7 +36,7 @@ type FakeExternalDNSs struct {
 	ns   string
 }
 
-var externaldnssResource = schema.GroupVersionResource{Group: "cis.f5.com", Version: "v1", Resource: "externaldnss"}
+var externaldnssResource = schema.GroupVersionResource{Group: "cis.f5.com", Version: "v1", Resource: "externaldns"}
 
 var externaldnssKind = schema.GroupVersionKind{Group: "cis.f5.com", Version: "v1", Kind: "ExternalDNS"}
 

--- a/config/client/informers/externalversions/generic.go
+++ b/config/client/informers/externalversions/generic.go
@@ -53,7 +53,7 @@ func (f *genericInformer) Lister() cache.GenericLister {
 func (f *sharedInformerFactory) ForResource(resource schema.GroupVersionResource) (GenericInformer, error) {
 	switch resource {
 	// Group=cis.f5.com, Version=v1
-	case v1.SchemeGroupVersion.WithResource("externaldnss"):
+	case v1.SchemeGroupVersion.WithResource("externaldns"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Cis().V1().ExternalDNSs().Informer()}, nil
 	case v1.SchemeGroupVersion.WithResource("ingresslinks"):
 		return &genericInformer{resource: resource.GroupResource(), informer: f.Cis().V1().IngressLinks().Informer()}, nil

--- a/docs/config_examples/crd/ExternalDNS/externaldns-customresourcedefinition.yml
+++ b/docs/config_examples/crd/ExternalDNS/externaldns-customresourcedefinition.yml
@@ -6,7 +6,7 @@ spec:
   group: cis.f5.com
   names:
     kind: ExternalDNS
-    plural: externaldnss
+    plural: externaldns
     shortNames:
       - edns
     singular: externaldns
@@ -65,3 +65,14 @@ spec:
                       - dataServerName
               required:
                 - domainName
+      additionalPrinterColumns:
+        - name: domainName
+          type: string
+          description: Domain name of virtual server resource
+          jsonPath: .spec.domainName
+        - name: Age
+          type: date
+          jsonPath: .metadata.creationTimestamp
+        - name: CREATED ON
+          type: string
+          jsonPath: .metadata.creationTimestamp

--- a/docs/config_examples/crd/Install/clusterrole.yml
+++ b/docs/config_examples/crd/Install/clusterrole.yml
@@ -12,7 +12,7 @@ rules:
     resources: ["configmaps", "events", "ingresses/status", "services/status"]
     verbs: ["get", "list", "watch", "update", "create", "patch"]
   - apiGroups: ["cis.f5.com"]
-    resources: ["virtualservers","virtualservers/status", "tlsprofiles", "transportservers", "ingresslinks", "ingresslinks/status", "externaldnss"]
+    resources: ["virtualservers","virtualservers/status", "tlsprofiles", "transportservers", "ingresslinks", "ingresslinks/status", "externaldns"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["fic.f5.com"]
       resources: ["ipams", "ipams/status"]

--- a/docs/config_examples/crd/Install/customresourcedefinitions.yml
+++ b/docs/config_examples/crd/Install/customresourcedefinitions.yml
@@ -335,7 +335,7 @@ spec:
   group: cis.f5.com
   names:
     kind: ExternalDNS
-    plural: externaldnss
+    plural: externaldns
     shortNames:
       - edns
     singular: externaldns
@@ -401,6 +401,9 @@ spec:
           jsonPath: .spec.domainName
         - name: Age
           type: date
+          jsonPath: .metadata.creationTimestamp
+        - name: CREATED ON
+          type: string
           jsonPath: .metadata.creationTimestamp
 ---
 apiVersion: apiextensions.k8s.io/v1

--- a/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-clusterrole.yaml
+++ b/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-clusterrole.yaml
@@ -63,7 +63,7 @@ rules:
       - virtualservers
       - tlsprofiles
       - transportservers
-      - externaldnss
+      - externaldns
       - ingresslinks
       - virtualservers/status
       - ingresslinks/status


### PR DESCRIPTION
**Description**:  Rename ExternalDNS resource name from "externaldnss" to "externaldns"

**Changes Proposed in PR**:

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema