### PR TITLE
Send test coverage reports to coveralls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,10 @@
-[![Build Status](https://dev.azure.com/f5networks/CIS/_apis/build/status/F5Networks.k8s-bigip-ctlr?branchName=refs%2Fpull%2F1886%2Fmerge)](https://dev.azure.com/f5networks/CIS/_build/latest?definitionId=6&branchName=refs%2Fpull%2F1886%2Fmerge)
+
+<!--- uncomment after go fmt is fixed
+[![Build Status](https://dev.azure.com/f5networks/CIS/_apis/build/status/F5Networks.k8s-bigip-ctlr?branchName=master) ](https://dev.azure.com/f5networks/CIS/_build/latest?definitionId=6&branchName=master)
+-->
+[![Coverage Status](https://coveralls.io/repos/github/F5Networks/k8s-bigip-ctlr/badge.svg) ](https://coveralls.io/github/F5Networks/k8s-bigip-ctlr)
+
+
 
 F5 Container Ingress Services for Kubernetes & OpenShift
 ========================================================

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -85,7 +85,7 @@ stages:
           Dockerfile: build-tools/Dockerfile.ubi
           buildContext: .
           tags: $(Build.SourceVersion)
-          arguments: "--build-arg BUILD_INFO=azure-$(Build.BuildId)-$(Build.SourceVersion) --build-arg BUILD_VERSION=$(BUILD_VERSION) --build-arg RUN_TESTS=$(RUN_TESTS)"
+          arguments: "--build-arg BUILD_INFO=azure-$(Build.BuildId)-$(Build.SourceVersion) --build-arg BUILD_VERSION=$(BUILD_VERSION) --build-arg RUN_TESTS=$(RUN_TESTS) --build-arg COVERALLS_TOKEN=$(COVERALLS_TOKEN)"
       - task: Docker@2
         displayName: Push image to Quay
         inputs:

--- a/build-tools/rel-build.sh
+++ b/build-tools/rel-build.sh
@@ -24,8 +24,7 @@ if [ $RUN_TESTS -eq 1 ]; then
     ginkgo_test_with_coverage
     # push coverage data to coveralls if F5 repo or if configured for fork.
     if [ "$COVERALLS_TOKEN" ]; then
-      goveralls \
-        -coverprofile=./coverage/coverage.out \
-        -service=azure
+      echo "Pushing coverage data to coveralls"
+      goveralls -coverprofile=./coverage.out -service=azure
     fi
 fi


### PR DESCRIPTION
**Description**: Coveralls integration with azure

**Changes Proposed in PR**:
- updated readme badge for azure pipeline build status 
- added new readme badge for coveralls testcase coverage percent 
- update coveralls push step 

**Fixes**: internal CONTCNTR-2474 

_Known issues_ - Broken commit message in coveralls - https://github.com/lemurheavy/coveralls-public/issues/1394 

_Successful run_ - https://dev.azure.com/f5networks/CIS/_build/results?buildId=1113&view=logs&j=10cdb312-541c-5bcd-418b-9a3c1da5544f&t=c95c4113-b8c7-5df6-40b2-5f19d93499df&l=1333  

https://coveralls.io/builds/43570646 