### PR TITLE
Fix:ExternalDNS CRD adds both VSs (HTTP and HTTPS) to a WideIP pool, …

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -7,6 +7,7 @@ Next Release
 Bug Fixes
 `````````
 * Added tcp type monitor support for EDNS.
+* :issues:`1918` ExternalDNS adds both VSs to a Wide IP pool.
 
 2.6.1
 -------------

--- a/pkg/crmanager/types.go
+++ b/pkg/crmanager/types.go
@@ -142,6 +142,8 @@ type (
 		Source                 string                `json:"source,omitempty"`
 		AllowVLANs             []string              `json:"allowVlans,omitempty"`
 		PersistenceMethods     []string              `json:"-"`
+		HTTPTraffic            string                `json:"-"`
+		isSecure               bool                  `json:"-"`
 	}
 	// Virtuals is slice of virtuals
 	Virtuals []Virtual


### PR DESCRIPTION
**Description**:  Fix:ExternalDNS CRD adds both VSs (HTTP and HTTPS) to a WideIP pool, if in the VirtualServer CRD was added the parameter httptraffic: redirect

**Changes Proposed in PR**:

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema

Signed-off-by: Amit Kumar Gupta amitg2812@gmail.com