### PR TITLE
LTM resource name changes for multihost support

### DIFF
--- a/pkg/crmanager/resourceConfig.go
+++ b/pkg/crmanager/resourceConfig.go
@@ -321,6 +321,16 @@ func formatMonitorName(namespace, svc string, monitorType string, port int32) st
 	return AS3NameFormatter(monitorName)
 }
 
+// format the policy name for VirtualServer
+func formatPolicyName(hostname, hostGroup, name string) string {
+	host := hostname
+	if hostGroup != "" {
+		host = hostGroup
+	}
+	policyName := fmt.Sprintf("%s_%s_%s", name, host, "policy")
+	return AS3NameFormatter(policyName)
+}
+
 // Prepares resource config based on VirtualServer resource config
 func (crMgr *CRManager) prepareRSConfigFromVirtualServer(
 	rsCfg *ResourceConfig,
@@ -420,8 +430,7 @@ func (crMgr *CRManager) prepareRSConfigFromVirtualServer(
 		rsCfg.SetPolicy(*policy)
 		return nil
 	}
-
-	policyName := rsCfg.Virtual.Name + "_" + vs.Spec.Host + "_policy"
+	policyName := formatPolicyName(vs.Spec.Host, vs.Spec.HostGroup, rsCfg.Virtual.Name)
 	plcy = createPolicy(*rules, policyName, vs.ObjectMeta.Namespace)
 	if plcy != nil {
 		rsCfg.SetPolicy(*plcy)

--- a/pkg/crmanager/resourceConfig_test.go
+++ b/pkg/crmanager/resourceConfig_test.go
@@ -101,9 +101,11 @@ var _ = Describe("Resource Config Tests", func() {
 			Expect(name).To(Equal("svc1_default_http_80"), "Invalid Monitor Name")
 		})
 		It("Rule Name", func() {
-			name := formatVirtualServerRuleName("test.com", "", "sample_pool")
+			name := formatVirtualServerRuleName("test.com", "", "", "sample_pool")
 			Expect(name).To(Equal("vs_test_com_sample_pool"))
-			name = formatVirtualServerRuleName("test.com", "/foo", "sample_pool")
+			name = formatVirtualServerRuleName("test.com", "exams.com", "", "sample_pool")
+			Expect(name).To(Equal("vs_exams_com_sample_pool"))
+			name = formatVirtualServerRuleName("test.com", "", "/foo", "sample_pool")
 			Expect(name).To(Equal("vs_test_com_foo_sample_pool"))
 
 		})


### PR DESCRIPTION
**Description**:  
LTM resource names are framed based on hostname in certain places. Now this need to be based on context, in case of single host, hostname can be used, but in case of Multi-host hostGroup can be used.

**Changes Proposed in PR**:
- Helper functions identify the context and frame LTM resource name accordingly. 
