### PR TITLE
Fix firewall and log profile support for transport server

### DIFF
--- a/docs/config_examples/customResource/Policy/transportserver-with-policy.yaml
+++ b/docs/config_examples/customResource/Policy/transportserver-with-policy.yaml
@@ -1,0 +1,24 @@
+# policyName can be used to attach profiles/policies defined in Policy CRD
+apiVersion: "cis.f5.com/v1"
+kind: TransportServer
+metadata:
+  labels:
+    f5cr: "true"
+  name: tcp-ts-with-policy
+  namespace: default
+spec:
+  virtualServerAddress: "172.16.3.9"
+  virtualServerPort: 8544
+  virtualServerName: svc1-tcp-ts
+  mode: standard
+  snat: auto
+  policyName: sample-policy
+  allowVlans: [ "/Common/devtraffic" ]
+  pool:
+    service: svc-1
+    servicePort: 8181
+    monitor:
+      type: tcp
+      interval: 10
+      timeout: 10
+

--- a/docs/config_examples/customResource/Policy/virtualserver-with-policy.yaml
+++ b/docs/config_examples/customResource/Policy/virtualserver-with-policy.yaml
@@ -1,0 +1,24 @@
+# policyName can be used to attach profiles/policies defined in Policy CRD
+apiVersion: cis.f5.com/v1
+kind: VirtualServer
+metadata:
+  labels:
+    f5cr: "true"
+  name: cr-foo-with-policy
+  namespace: default
+spec:
+  host: foo.example.com
+  iRules: []
+  policyName: sample-policy
+  pools:
+    - monitor:
+        interval: 13
+        recv: a
+        send: /
+        timeout: 10
+        type: http
+      path: /foo
+      service: svc-1
+      servicePort: 80
+  snat: auto
+  virtualServerAddress: 10.1.2.3


### PR DESCRIPTION
**Description**:  
Policy CRD Firewall and log profile assignment for transport server was missed while framing AS3 declaration

**Changes Proposed in PR**:
- common AS3 supported options in VS and TS are now processed in `processCommonDecl` function

**Fixes**: internal CONTCNTR-3022

## General Checklist
- [x] Added examples for new feature