### PR TITLE
Fix for TENANT based AS3 declarations of ConfigMaps

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -7,6 +7,7 @@ Added Functionality
 ```````````````````
 * CIS supports reporting Status of VirtualServer CRD
 * CIS supports reporting Status of TransportServer CRD
+* CIS supports tenant based AS3 declarations with --filter-tenants parameter
 
 Bug Fixes
 `````````

--- a/pkg/agent/as3/l2l3agent.go
+++ b/pkg/agent/as3/l2l3agent.go
@@ -39,7 +39,7 @@ func (am *AS3Manager) SendARPEntries() {
 
 	// Filter the configs to only those that have active services
 	for _, cfg := range am.Resources.RsCfgs {
-		if cfg.MetaData.Active == true {
+		if cfg.MetaData.Active == true && am.PostManager.Tenants[cfg.Virtual.Partition] == true {
 			for _, pool := range cfg.Pools {
 				allPoolMembers = append(allPoolMembers, pool.Members...)
 			}


### PR DESCRIPTION
Signed-off-by: Vivek Lohiya <vklohiya@live.com>

**Description**:   Earlier CIS used to send Unified AS3 declaration with multiple ConfigMaps. A defect in a VS/Tenant will stop applying the good VS/Tenant configuration. This feature will be available only with CIS parameter --filter-tenants=true.

**Changes Proposed in PR**: With these changes CIS will be sending the Unified AS3 declaration to each tenant's api endpoint.

**Fixes**: resolves sr/1-7481508471/

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
