### PR TITLE
Fix for Allow type LoadBalancer with different TargetPort and Port values

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -19,7 +19,9 @@ Bug Fixes
 * :issues:`1873` Enable /metrics endpoint with crd mode.
 * :issues:`1659` Report "status" of TransportServer CRD
 * :issues:`2006` Add support for Wildcard domain name with TLSProfile and VirtualServer
-* :issues:`2102,2016` Fixed crash while validating secrets
+* :issues:`2102,2016` Fix for crash while validating secrets
+* :issues:`2014` Allow type LoadBalancer with different TargetPort and Port values
+
 
 2.6.1
 -------------

--- a/pkg/crmanager/resourceConfig.go
+++ b/pkg/crmanager/resourceConfig.go
@@ -1189,13 +1189,13 @@ func (crMgr *CRManager) prepareRSConfigFromLBService(
 	poolName := formatVirtualServerPoolName(
 		svc.Namespace,
 		svc.Name,
-		svcPort.Port,
+		svcPort.TargetPort.IntVal,
 		"")
 	pool := Pool{
 		Name:            poolName,
 		Partition:       rsCfg.Virtual.Partition,
 		ServiceName:     svc.Name,
-		ServicePort:     svcPort.Port,
+		ServicePort:     svcPort.TargetPort.IntVal,
 		NodeMemberLabel: "",
 	}
 
@@ -1212,9 +1212,9 @@ func (crMgr *CRManager) prepareRSConfigFromLBService(
 			log.Errorf("[CORE] %s", msg)
 		}
 		pool.MonitorNames = append(pool.MonitorNames, JoinBigipPath(DEFAULT_PARTITION,
-			formatMonitorName(svc.Namespace, svc.Name, monitorType, svcPort.Port)))
+			formatMonitorName(svc.Namespace, svc.Name, monitorType, svcPort.TargetPort.IntVal)))
 		monitor = Monitor{
-			Name:      formatMonitorName(svc.Namespace, svc.Name, monitorType, svcPort.Port),
+			Name:      formatMonitorName(svc.Namespace, svc.Name, monitorType, svcPort.TargetPort.IntVal),
 			Partition: rsCfg.Virtual.Partition,
 			Type:      monitorType,
 			Interval:  mon.Interval,


### PR DESCRIPTION

Signed-off-by: Vivek Lohiya <vklohiya@live.com>

**Description**:  Fix for Allow type LoadBalancer with different TargetPort and Port values

**Changes Proposed in PR**: Replaced the service port value with target port for pool and health monitor in service type load balancer

**Fixes**: resolves #2014 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
