### PR TITLE
Fix crash while validating secrets

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -19,6 +19,7 @@ Bug Fixes
 * :issues:`1873` Enable /metrics endpoint with crd mode.
 * :issues:`1659` Report "status" of TransportServer CRD
 * :issues:`2006` Add support for Wildcard domain name with TLSProfile and VirtualServer
+* :issues:`2102,2016` Fixed crash while validating secrets
 
 2.6.1
 -------------
@@ -432,11 +433,11 @@ Added Functionality
 
 Bug Fixes
 `````````
-* :issues:`1420` Enhanced performance for lower BIG-IP CPU Utilization with optimized CCCL calls.
-* :issues:`1362` CIS supports HTTP Header with iv-groups
-* :issues:`1388,1311` CIS properly manages AS3 ConfigMaps when configured with namespace-labels.
-* :issues:`1337` CIS supports multiple AS3 ConfigMaps
-* :issues:`1171` CIS will not create `_AS3` partition anymore
+* :issues: 1420 Enhanced performance for lower BIG-IP CPU Utilization with optimized CCCL calls.
+* :issues: 1362 CIS supports HTTP Header with iv-groups
+* :issues: 1388,1311 CIS properly manages AS3 ConfigMaps when configured with namespace-labels.
+* :issues: 1337 CIS supports multiple AS3 ConfigMaps
+* :issues: 1171 CIS will not create `_AS3` partition anymore
 
 Vulnerability Fixes
 ```````````````````

--- a/pkg/agent/as3/as3Manager.go
+++ b/pkg/agent/as3/as3Manager.go
@@ -46,7 +46,7 @@ const (
 	as3template          = "template"
 	//as3SchemaLatestURL   = "https://raw.githubusercontent.com/F5Networks/f5-appsvcs-extension/master/schema/latest/as3-schema.json"
 	as3defaultRouteDomain = "defaultRouteDomain"
-	as3SchemaFileName = "as3-schema-3.30.0-5-cis.json"
+	as3SchemaFileName     = "as3-schema-3.30.0-5-cis.json"
 )
 
 var baseAS3Config = `{


### PR DESCRIPTION
**Description**:  Fix crash while validating secrets

**Changes Proposed in PR**:
- handle `use-secrets` config option  while checking for valid secrets in ingresses and configmaps 
- handle nil ingress and ConfigMap informer case 

**Fixes**: resolves #2102, resolves #2016

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
