### PR TITLE
Fix VirtualAddress issue with HostGroup

### DIFF
--- a/pkg/crmanager/worker_test.go
+++ b/pkg/crmanager/worker_test.go
@@ -598,6 +598,21 @@ var _ = Describe("Worker Tests", func() {
 				Expect(virts[1].Spec.Host).To(Equal("test3.com"), "Wrong Virtual Server Host")
 			})
 
+			It("Host Group with IP Address Only specified once", func() {
+				vrt2.Spec.HostGroup = "test"
+				vrt3.Spec.HostGroup = "test"
+				vrt3.Spec.Host = "test3.com"
+				vrt3.Spec.VirtualServerAddress = ""
+
+				virts := mockCRM.getAssociatedVirtualServers(vrt2,
+					[]*cisapiv1.VirtualServer{vrt2, vrt3, vrt4},
+					false)
+
+				Expect(len(virts)).To(Equal(2), "Wrong number of Virtual Servers")
+				Expect(virts[0].Spec.Host).To(Equal("test2.com"), "Wrong Virtual Server Host")
+				Expect(virts[1].Spec.Host).To(Equal("test3.com"), "Wrong Virtual Server Host")
+			})
+
 			It("HostGroup with wrong custom port", func() {
 				vrt2.Spec.HostGroup = "test"
 				vrt2.Spec.VirtualServerHTTPPort = 8080


### PR DESCRIPTION
Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>

**Description**:  _VirtualServers are not being processed if hostGroup is used and VirtualServerAddress is specified only in one VS_

**Changes Proposed in PR**: VirtualServers will be processed even if VirtualServerAddress is specified in one VS.

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema