### PR TITLE
Update vendor with IPv6 support for ipam f5-ip-provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/F5Networks/k8s-bigip-ctlr
 go 1.16
 
 require (
-	github.com/F5Networks/f5-ipam-controller v0.1.6-0.20211130120610-2c17f16226f4
+	github.com/F5Networks/f5-ipam-controller v0.1.6-0.20211213121023-410e5df250de
 	github.com/f5devcentral/go-bigip/f5teem v0.0.0-20210918163638-28fdd0579913
 	github.com/f5devcentral/mockhttpclient v0.0.0-20210630101009-cc12e8b81051
 	github.com/google/uuid v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -37,6 +37,8 @@ github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03
 github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym/WlBOVXweHU+Q+/VP0lqqI8lqeDx9IjBqo=
 github.com/F5Networks/f5-ipam-controller v0.1.6-0.20211130120610-2c17f16226f4 h1:/v96hLuCmvomisAQLcIcAacdmdlWJyjh61FHFBWEm2I=
 github.com/F5Networks/f5-ipam-controller v0.1.6-0.20211130120610-2c17f16226f4/go.mod h1:XBOjYUVRKG8q8atIpNmil/XF6RAGVekqfbeNQludcV4=
+github.com/F5Networks/f5-ipam-controller v0.1.6-0.20211213121023-410e5df250de h1:uj7KI3iGhh7AP7ettwskXp7L2XGOvvX5imuCwvGXxr8=
+github.com/F5Networks/f5-ipam-controller v0.1.6-0.20211213121023-410e5df250de/go.mod h1:XBOjYUVRKG8q8atIpNmil/XF6RAGVekqfbeNQludcV4=
 github.com/NYTimes/gziphandler v0.0.0-20170623195520-56545f4a5d46/go.mod h1:3wb06e3pkSAbeQ52E9H9iFoQsEEwGN64994WTCIhntQ=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/vendor/github.com/F5Networks/f5-ipam-controller/pkg/ipammachinery/ipam.go
+++ b/vendor/github.com/F5Networks/f5-ipam-controller/pkg/ipammachinery/ipam.go
@@ -41,8 +41,8 @@ const (
 	CRDGroup         string = "fic.f5.com"
 	CRDVersion       string = "v1"
 	FullCRDName      string = CRDPlural + "." + CRDGroup
-	HostnamePattern  string = "^(([a-zA-Z0-9]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$"
-	IPADdressPattern string = "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])$"
+	HostnamePattern  string = "^(([a-zA-Z0-9\\*]|[a-zA-Z0-9][a-zA-Z0-9\\-]*[a-zA-Z0-9])\\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\\-]*[A-Za-z0-9])$"
+	IPAddressPattern string = "^(([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])|(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,7}:|([0-9a-fA-F]{1,4}:){1,6}:[0-9a-fA-F]{1,4}|([0-9a-fA-F]{1,4}:){1,5}(:[0-9a-fA-F]{1,4}){1,2}|([0-9a-fA-F]{1,4}:){1,4}(:[0-9a-fA-F]{1,4}){1,3}|([0-9a-fA-F]{1,4}:){1,3}(:[0-9a-fA-F]{1,4}){1,4}|([0-9a-fA-F]{1,4}:){1,2}(:[0-9a-fA-F]{1,4}){1,5}|[0-9a-fA-F]{1,4}:((:[0-9a-fA-F]{1,4}){1,6})|:((:[0-9a-fA-F]{1,4}){1,7}|:)|fe80:(:[0-9a-fA-F]{0,4}){0,4}%[0-9a-zA-Z]{1,}|::(ffff(:0{1,4}){0,1}:){0,1}((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])|([0-9a-fA-F]{1,4}:){1,4}:((25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9])\\.){3,3}(25[0-5]|(2[0-4]|1{0,1}[0-9]){0,1}[0-9]))$"
 )
 
 // NewIPAM creates a new IPAMClient Instance.
@@ -174,7 +174,7 @@ func ipamCRSchemaValidation() *apiextensionv1.CustomResourceValidation {
 							Schema: &apiextensionv1.JSONSchemaProps{Type: "object", Properties: map[string]apiextensionv1.JSONSchemaProps{
 								"host":      {Type: "string", Format: "string", Pattern: HostnamePattern},
 								"key":       {Type: "string", Format: "string"},
-								"ip":        {Type: "string", Format: "string", Pattern: IPADdressPattern},
+								"ip":        {Type: "string", Format: "string", Pattern: IPAddressPattern},
 								"ipamLabel": {Type: "string", Format: "string"}},
 							},
 						},

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,4 +1,4 @@
-# github.com/F5Networks/f5-ipam-controller v0.1.6-0.20211130120610-2c17f16226f4
+# github.com/F5Networks/f5-ipam-controller v0.1.6-0.20211213121023-410e5df250de
 ## explicit
 github.com/F5Networks/f5-ipam-controller/pkg/ipamapis/apis/fic/v1
 github.com/F5Networks/f5-ipam-controller/pkg/ipamapis/client/clientset/versioned


### PR DESCRIPTION
**Description**:  Update vendor with IPv6 support for ipam f5-ip-provider

**Changes Proposed in PR**:
- updated go.mod and synced vendor

**Fixes**: internal CONTCNTR-2994 

https://github.com/F5Networks/f5-ipam-controller/pull/83