### PR TITLE
Fix for  Allow type LoadBalancer with different TargetPort and Port value in nodeport mode

### DIFF
--- a/pkg/crmanager/worker.go
+++ b/pkg/crmanager/worker.go
@@ -1319,7 +1319,7 @@ func (crMgr *CRManager) updatePoolMembersForNodePort(
 			svc.Spec.Type == v1.ServiceTypeLoadBalancer {
 			// TODO: Instead of looping over Spec Ports, get the port from the pool itself
 			for _, portSpec := range svc.Spec.Ports {
-				if portSpec.Port == pool.ServicePort {
+				if portSpec.TargetPort.IntVal == pool.ServicePort {
 					rsCfg.MetaData.Active = true
 					rsCfg.Pools[index].Members =
 						crMgr.getEndpointsForNodePort(portSpec.NodePort, pool.NodeMemberLabel)


### PR DESCRIPTION
Fix for  Allow type LoadBalancer with different TargetPort and Port value in nodeport mode

Signed-off-by: Vivek Lohiya <vklohiya@live.com>



## General Checklist
- [x] Updated Added functionality/ bug fix in release notes