### PR TITLE
iapps is not copied over

### DIFF
--- a/pkg/agent/cccl/outputConfig.go
+++ b/pkg/agent/cccl/outputConfig.go
@@ -312,6 +312,9 @@ func copyResourceData(resources PartitionMap) PartitionMap {
 		resourceLog[partition].IRules = make([]IRule, len(cfg.IRules))
 		copy(resourceLog[partition].IRules, cfg.IRules)
 
+		resourceLog[partition].IApps = make([]IApp, len(cfg.IApps))
+		copy(resourceLog[partition].IApps, cfg.IApps)
+
 		resourceLog[partition].InternalDataGroups = make([]InternalDataGroup, len(cfg.InternalDataGroups))
 		copy(resourceLog[partition].InternalDataGroups, cfg.InternalDataGroups)
 	}


### PR DESCRIPTION

**Description**:  

It seems inside copyResourceData(), it forgot to
copy over iapps as well. To reproduce, if you set log-level to DEBUG,
and you create a configmap for iapp, you will see logs like
"[CCCL] LTM Resources: XXX", which does not include iapp
part.

**Fixes**: resolves #2191 

## General Checklist
- [x] Smoke testing completed
