### PR TITLE
Fix for ExternalDNS adds both VSs to a Wide IP pool

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,11 +1,13 @@
 Release Notes for Container Ingress Services for Kubernetes & OpenShift
 =======================================================================
-2.7.1
+
+Next Release
 -------------
 Enhancements
 ````````````
 * Optimized processing of ConfigMaps with FilterTenants enabled
 * Added support for multihost VS policy rules for same path and service backend combination
+* :issues:`1918` ExternalDNS adds both VSs to a Wide IP pool
 
 
 2.7.0

--- a/pkg/crmanager/types.go
+++ b/pkg/crmanager/types.go
@@ -116,6 +116,7 @@ type (
 		namespace    string
 		hosts        []string
 		Protocol     string
+		httpTraffic  string
 	}
 
 	// Virtual Server Key - unique server is Name + Port
@@ -149,8 +150,6 @@ type (
 		Source                 string                `json:"source,omitempty"`
 		AllowVLANs             []string              `json:"allowVlans,omitempty"`
 		PersistenceMethods     []string              `json:"-"`
-		HTTPTraffic            string                `json:"-"`
-		isSecure               bool                  `json:"-"`
 	}
 	// Virtuals is slice of virtuals
 	Virtuals []Virtual


### PR DESCRIPTION
Signed-off-by: Vivek Lohiya <vklohiya@live.com>

**Description**:  Fix for ExternalDNS adds both VSs to a Wide IP pool. Also added the fix for processing the dns resources if virtual server is deleted.

**Changes Proposed in PR**: Fix for ExternalDNS adds both VSs to a Wide IP pool. Also added the fix for processing the dns resources if virtual server is deleted.

**Fixes**: resolves #1918 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed