### PR TITLE
Revert "Fix VS with same virtual address but different hosts"

### DIFF
--- a/pkg/crmanager/worker.go
+++ b/pkg/crmanager/worker.go
@@ -975,19 +975,15 @@ func (crMgr *CRManager) getAssociatedVirtualServers(
 		}
 
 		if currentVS.Spec.HostGroup == "" {
+			// in the absence of HostGroup, skip the virtuals with other host name
 			if vrt.Spec.Host != currentVS.Spec.Host {
-				if vrt.Spec.VirtualServerAddress == currentVS.Spec.VirtualServerAddress {
-					log.Errorf("Same VirtualServerAddress %v is configured with different hosts : %v %v without hostGroup", vrt.Spec.VirtualServerAddress, currentVS.Spec.Host, vrt.Spec.Host)
-					return nil
-				}
-				// in the absence of HostGroup, skip the virtuals with other host name
 				continue
 			}
 
 			// Same host with different VirtualServerAddress is invalid
 			if vrt.Spec.VirtualServerAddress != currentVS.Spec.VirtualServerAddress {
 				if vrt.Spec.Host != "" {
-					log.Errorf("Same host %v is configured with different VirtualServerAddress : %v", vrt.Spec.Host, vrt.Spec.VirtualServerName)
+					log.Errorf("Same host %v is configured with different VirtualServerAddress : %v ", vrt.Spec.Host, vrt.Spec.VirtualServerName)
 					return nil
 				}
 				// In case of empty host name, skip the virtual with other VirtualServerAddress

--- a/pkg/crmanager/worker_test.go
+++ b/pkg/crmanager/worker_test.go
@@ -541,7 +541,6 @@ var _ = Describe("Worker Tests", func() {
 
 			It("Absence of HostName of Unassociated VS", func() {
 				vrt3.Spec.Host = ""
-				vrt3.Spec.VirtualServerAddress = "1.2.3.6"
 				//vrt3.Spec.Pools[0].Path = "/path3"
 				virts := mockCRM.getAssociatedVirtualServers(vrt2,
 					[]*cisapiv1.VirtualServer{vrt2, vrt3},
@@ -554,7 +553,7 @@ var _ = Describe("Worker Tests", func() {
 				vrt3.Spec.Host = ""
 				//vrt3.Spec.Pools[0].Path = "/path3"
 				vrt4.Spec.Host = ""
-				vrt2.Spec.VirtualServerAddress = "1.2.3.4"
+
 				virts := mockCRM.getAssociatedVirtualServers(vrt3,
 					[]*cisapiv1.VirtualServer{vrt2, vrt3, vrt4},
 					false)
@@ -565,7 +564,6 @@ var _ = Describe("Worker Tests", func() {
 
 			It("UnAssociated VS 2", func() {
 				vrt3.Spec.Host = ""
-				vrt3.Spec.VirtualServerAddress = "1.2.3.4"
 				//vrt3.Spec.Pools[0].Path = "/path3"
 				vrt4.Spec.Host = ""
 				vrt4.Spec.VirtualServerAddress = "1.2.3.6"
@@ -580,15 +578,6 @@ var _ = Describe("Worker Tests", func() {
 			It("Virtuals with same Host, but different Virtual Address", func() {
 				vrt4.Spec.Host = "test2.com"
 				vrt4.Spec.VirtualServerAddress = "1.2.3.6"
-
-				virts := mockCRM.getAssociatedVirtualServers(vrt2,
-					[]*cisapiv1.VirtualServer{vrt2, vrt4},
-					false)
-				Expect(virts).To(BeNil(), "Wrong Number of Virtual Servers")
-			})
-
-			It("Virtuals with same Virtual Address, but different Host", func() {
-				vrt4.Spec.Host = "test4.com"
 
 				virts := mockCRM.getAssociatedVirtualServers(vrt2,
 					[]*cisapiv1.VirtualServer{vrt2, vrt4},


### PR DESCRIPTION
Reverts F5Networks/k8s-bigip-ctlr#2186

Reverting this PR to avoid hybrid - IPAM and static IP address combination -  deployment conflicts