### PR TITLE
Added fix for processing oldest route when same host and path in routes

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -7,6 +7,7 @@ Added Functionality
 ```````````````````
 Enhancements
 ````````````
+* Added fix for processing oldest route when same host and path in routes
 
 2.7.1
 -------------

--- a/pkg/appmanager/agentResponseHandler.go
+++ b/pkg/appmanager/agentResponseHandler.go
@@ -71,7 +71,7 @@ func (appMgr *Manager) updateRouteAdmitStatus() {
 	var processedRoutes []*routeapi.Route
 	getOptions := metaV1.GetOptions{}
 
-	for namespace, routeNames := range appMgr.RoutesProcessed {
+	for namespace, routeNames := range getProcessedResources(appMgr.processedResources, Routes) {
 		for _, routeName := range routeNames {
 			Admitted := false
 			route, err := appMgr.routeClientV1.Routes(namespace).Get(context.TODO(), routeName, getOptions)

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -4613,7 +4613,20 @@ var _ = Describe("AppManager Tests", func() {
 				Expect(ok).To(BeTrue(), "Config map should be accessible.")
 				Expect(rs.MetaData.Active).To(BeTrue())
 			})
-
+			It("Test processedResources function", func() {
+				processedResources := make(map[string]bool)
+				processedResources["routes_default/route-1"] = true
+				processedResources["routes_default/route-2"] = false
+				processedResources["routes_test/test-route-1"] = true
+				processedResources["routes_test/test-route-2"] = true
+				resources := getProcessedResources(processedResources, Routes)
+				defaultNamespace, ok := resources["default"]
+				Expect(ok).To(BeTrue())
+				testNamespace, ok := resources["test"]
+				Expect(ok).To(BeTrue())
+				Expect(len(defaultNamespace)).To(Equal(1))
+				Expect(len(testNamespace)).To(Equal(2))
+			})
 			//FixMe: Fix this unit test as we updated checkValidRoute function - included certificate and key validation.
 
 			// It("handles routes and services in multiple namespaces", func() {

--- a/pkg/appmanager/routing.go
+++ b/pkg/appmanager/routing.go
@@ -923,7 +923,15 @@ func (slice RouteList) Len() int {
 }
 
 func (slice RouteList) Less(i, j int) bool {
+	if slice[i].Spec.Host == slice[j].Spec.Host {
+		if (len(slice[i].Spec.Path) == 0 || len(slice[j].Spec.Path) == 0) && (slice[i].Spec.Path == "/" || slice[j].Spec.Path == "/") {
+			return slice[i].CreationTimestamp.Before(&slice[j].CreationTimestamp)
+		}
+	}
 	return (slice[i].Spec.Host < slice[j].Spec.Host) ||
+		(slice[i].Spec.Host == slice[j].Spec.Host &&
+			slice[i].Spec.Path == slice[j].Spec.Path &&
+			slice[i].CreationTimestamp.Before(&slice[j].CreationTimestamp)) ||
 		(slice[i].Spec.Host == slice[j].Spec.Host &&
 			slice[i].Spec.Path < slice[j].Spec.Path)
 }


### PR DESCRIPTION
Signed-off-by: Vivek Lohiya <vklohiya@live.com>

**Description**: Added fix for processing oldest route when same host and path in routes

**Changes Proposed in PR**: Updated the sorting logic of routes and removed unnecessary variables

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
