### PR TITLE
Fix ExternalDNS adds both VSs to a Wide IP pool with using "httpTraffic: allow" with VS CR

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -9,6 +9,7 @@ Enhancements
 ````````````
 * Added fix for processing oldest route when same host and path in routes
 * Added fix for cis crash with routes
+* :issues:`2212` Fix ExternalDNS adds both VSs to a Wide IP pool with using "httpTraffic: allow" with VS CR
 
 2.7.1
 -------------

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -1972,7 +1972,7 @@ func (ctlr *Controller) processExternalDNS(edns *cisapiv1.ExternalDNS, isDelete 
 			}
 			if found {
 				//No need to add insecure VS into wideIP pool if VS configured with httpTraffic as redirect
-				if vs.MetaData.Protocol == "http" && vs.MetaData.httpTraffic == TLSRedirectInsecure {
+				if vs.MetaData.Protocol == "http" && (vs.MetaData.httpTraffic == TLSRedirectInsecure || vs.MetaData.httpTraffic == TLSAllowInsecure) {
 					continue
 				}
 				log.Debugf("Adding WideIP Pool Member: %v", fmt.Sprintf("%v:/%v/Shared/%v",


### PR DESCRIPTION
Signed-off-by: Vivek Lohiya <vklohiya@live.com>

**Description**:  Fix ExternalDNS adds both VSs to a Wide IP pool with using "httpTraffic: allow" with VS CR

**Changes Proposed in PR**: Fix ExternalDNS adds both VSs to a Wide IP pool with using "httpTraffic: allow" with VS CR

**Fixes**: resolves #2212 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed