### PR TITLE
Fix for CIS crash when a wrong ConfigMap is created and deleted subsequently

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -21,7 +21,9 @@ Enhancements
 * Added fix for cis crash with routes
 * :issues:`2212` Fix ExternalDNS adds both VSs to a Wide IP pool with using "httpTraffic: allow" with VS CR
 * :issues:`2222` Fix deleting VirtualServer using hostGroup
-* :issues:`2233` TS and VS CRD don't detect the pool members
+* :issues:`2233` TS and VS CRD don't detect the pool members for grafana service
+* :issues:`2234` Fix for CIS crash with subsequent creation and deletion of wrong ConfigMap
+
 
 2.7.1
 -------------

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1415,9 +1415,12 @@ func (appMgr *Manager) syncConfigMaps(
 	if appMgr.AgentCIS.IsImplInAgent(ResourceTypeCfgMap) {
 		key := sKey.Namespace + "/" + sKey.ResourceName
 		if sKey.Operation == OprTypeDelete && sKey.ResourceKind == Configmaps {
-			appMgr.agentCfgMap[key].Operation = OprTypeDelete
-			stats.vsDeleted += 1
+			if _, ok := appMgr.agentCfgMap[key]; ok {
+				appMgr.agentCfgMap[key].Operation = OprTypeDelete
+				stats.vsDeleted += 1
+			}
 			return nil
+
 		}
 		if nil != svc {
 			tntLabel, tntOk := svc.ObjectMeta.Labels["cis.f5.com/as3-tenant"]


### PR DESCRIPTION


Signed-off-by: Vivek Lohiya <vklohiya@live.com>

**Description**:  Fix for CIS crash when a wrong ConfigMap is created and deleted subsequently


**Fixes**: resolves #2234 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes