### PR TITLE
Fix recreating arp entries on restart

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -23,7 +23,7 @@ Enhancements
 * :issues:`2222` Fix deleting VirtualServer using hostGroup
 * :issues:`2233` TS and VS CRD don't detect the pool members for grafana service
 * :issues:`2234` Fix for CIS crash with subsequent creation and deletion of wrong ConfigMap
-
+* :issues:`2077` CIS deletes all existing ARP on restart and recreates it, which affects traffic
 
 2.7.1
 -------------

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/f5devcentral/f5-ctlr-agent.git@a9c42c190558dac40459509611f6c2e35d789ae7#egg=f5-ctlr-agent
--e git+https://github.com/f5devcentral/f5-cccl.git@2a611157e4949d6e367a3a26fee20da301545b7c#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-ctlr-agent.git@dd9664fa153c0b966acda4fcc407a137258b2e87#egg=f5-ctlr-agent
+-e git+https://github.com/f5devcentral/f5-cccl.git@3139dee4f1bef91104da830ba518b078f0b30895#egg=f5-cccl


### PR DESCRIPTION
Signed-off-by: Sravya Pondugula <sravyap135@gmail.com>

**Description**:  Fix recreating arp entries

**Changes Proposed in PR**: 
- updating f5-ctlr-agent, f5-cccl commit ID's
- addresses both as3 and CCCL mode ARP entries recreation issue

**Fixes**: resolves #2077

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes

Related PRs: 
https://github.com/f5devcentral/f5-ctlr-agent/pull/58
https://github.com/f5devcentral/f5-cccl/pull/272
