### PR TITLE
Allow pushing resources in CCCL nodeport mode and openshift cluster mode

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -74,6 +74,7 @@ type globalSection struct {
 	VerifyInterval int    `json:"verify-interval,omitempty"`
 	VXLANPartition string `json:"vxlan-partition,omitempty"`
 	DisableLTM     bool   `json:"disable-ltm,omitempty"`
+	DisableARP     bool   `json:"disable-arp,omitempty"`
 }
 
 type bigIPSection struct {
@@ -974,11 +975,18 @@ func main() {
 	if *agent == cisAgent.AS3Agent {
 		disableLTM = true
 	}
+	// When CIS configured in OCP cluster mode disable ARP in globalSection
+	disableARP := false
+	if *openshiftSDNName != "" {
+		disableARP = true
+	}
+
 	gs := globalSection{
 		LogLevel:       *logLevel,
 		VerifyInterval: *verifyInterval,
 		VXLANPartition: vxlanPartition,
 		DisableLTM:     disableLTM,
+		DisableARP:     disableARP,
 	}
 	if *ccclLogLevel != "" {
 		gs.LogLevel = *ccclLogLevel

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/f5devcentral/f5-ctlr-agent.git@dd9664fa153c0b966acda4fcc407a137258b2e87#egg=f5-ctlr-agent
+-e git+https://github.com/f5devcentral/f5-ctlr-agent.git@b8aead4b19d840a24250aac7f2b1616299663fdb#egg=f5-ctlr-agent
 -e git+https://github.com/f5devcentral/f5-cccl.git@3139dee4f1bef91104da830ba518b078f0b30895#egg=f5-cccl


### PR DESCRIPTION
**Description**:  Allow pushing resources in CCCL nodeport mode and openshift cluster mode

**Changes Proposed in PR**:
- introduced new disable-arp entry in global section for agent to distinguish whether or not to push ARP/FDB's

**Fixes**: internal issues 836, 837
