### PR TITLE
Allow FDB updates in CRD mode in openshift cluster mode

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -789,6 +789,12 @@ func initController(
 		HttpAddress:    *httpAddress,
 		EnableIPV6:     *enableIPV6,
 	}
+
+	// When CIS is configured in OCP cluster mode disable ARP in globalSection
+	if *openshiftSDNName != "" {
+		agentParams.DisableARP = true
+	}
+
 	agent := controller.NewAgent(agentParams)
 
 	ctlr := controller.NewController(

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -86,7 +86,9 @@ func NewAgent(params AgentParams) *Agent {
 		VXLANPartition: vxlanPartition,
 		DisableLTM:     true,
 		GTM:            true,
+		DisableARP:     params.DisableARP,
 	}
+
 	bs := bigIPSection{
 		BigIPUsername:   params.PostParams.BIGIPUsername,
 		BigIPPassword:   params.PostParams.BIGIPPassword,

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -492,6 +492,7 @@ type (
 		UserAgent      string
 		HttpAddress    string
 		EnableIPV6     bool
+		DisableARP     bool
 	}
 
 	PostManager struct {
@@ -530,6 +531,7 @@ type (
 		VXLANPartition string `json:"vxlan-partition,omitempty"`
 		DisableLTM     bool   `json:"disable-ltm,omitempty"`
 		GTM            bool   `json:"gtm,omitempty"`
+		DisableARP     bool   `json:"disable-arp,omitempty"`
 	}
 
 	bigIPSection struct {


### PR DESCRIPTION
Signed-off-by: Sravya Pondugula <sravyap135@gmail.com>

**Description**:  Allow FDB updates in CRD mode in openshift cluster mode
- CRD mode initialises python driver from initController

**Changes Proposed in PR**:
- Added disableARP parameter to global section. This will be used to make a decision in f5-ctlr-agent 