### PR TITLE
Revert "virtualServerAddress must be present for hostGroup"

### DIFF
--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -141,9 +141,9 @@ func (agent *Agent) PostConfig(rsConfig ResourceConfigRequest) {
 		return
 	}
 	cfg := agentConfig{
-		data:      string(decl),
-		as3APIURL: agent.getAS3APIURL(nil),
-		id:        rsConfig.reqId,
+		data:            string(decl),
+		as3APIURL:       agent.getAS3APIURL(nil),
+		id:              rsConfig.reqId,
 	}
 
 	agent.Write(cfg)
@@ -492,7 +492,7 @@ func createServiceDecl(cfg *ResourceConfig, sharedApp as3Application) {
 				ps[len(ps)-1])
 		}
 	}
-	if cfg.Virtual.TLSTermination != TLSPassthrough {
+	if cfg.Virtual.TLSTermination != TLSPassthrough{
 		svc.Layer4 = cfg.Virtual.IpProtocol
 		svc.Source = "0.0.0.0/0"
 		svc.TranslateServerAddress = true
@@ -510,7 +510,7 @@ func createServiceDecl(cfg *ResourceConfig, sharedApp as3Application) {
 			svc.PersistenceMethods = &[]string{}
 		}
 	}
-	// Attaching Profiles from Policy CRD
+   	// Attaching Profiles from Policy CRD
 	for _, profile := range cfg.Virtual.Profiles {
 		partition, name := getPartitionAndName(profile.Name)
 		switch profile.Context {

--- a/pkg/controller/responseHandler.go
+++ b/pkg/controller/responseHandler.go
@@ -26,7 +26,7 @@ func (ctlr *Controller) enqueueReq(config ResourceConfigRequest) int {
 		ctlr.requestQueue.PushBack(rm)
 		ctlr.requestQueue.Unlock()
 	}
-	return rm.id
+    return rm.id
 }
 
 func (ctlr *Controller) responseHandler(respChan chan int) {
@@ -34,7 +34,7 @@ func (ctlr *Controller) responseHandler(respChan chan int) {
 
 	for id := range respChan {
 		var rm requestMeta
-		for ctlr.requestQueue.Len() > 0 && ctlr.requestQueue.Front().Value.(requestMeta).id <= id {
+		for ctlr.requestQueue.Len() > 0 && ctlr.requestQueue.Front().Value.(requestMeta).id <= id{
 			ctlr.requestQueue.Lock()
 			rm = ctlr.requestQueue.Remove(ctlr.requestQueue.Front()).(requestMeta)
 			ctlr.requestQueue.Unlock()
@@ -52,7 +52,7 @@ func (ctlr *Controller) responseHandler(respChan chan int) {
 				}
 				obj, exist, err := crInf.vsInformer.GetIndexer().GetByKey(vsKey)
 				if err != nil {
-					log.Debugf("Could not fetch VirtualServer: %v: %v", vsKey, err)
+					log.Debugf("Could not fetch VirtualServer: %v: %v",vsKey, err)
 					continue
 				}
 				if !exist {
@@ -73,7 +73,7 @@ func (ctlr *Controller) responseHandler(respChan chan int) {
 				}
 				obj, exist, err := crInf.tsInformer.GetIndexer().GetByKey(vsKey)
 				if err != nil {
-					log.Debugf("Could not fetch TransportServer: %v: %v", vsKey, err)
+					log.Debugf("Could not fetch TransportServer: %v: %v",vsKey, err)
 					continue
 				}
 				if !exist {

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -445,6 +445,7 @@ type (
 	requestMeta struct {
 		meta []metaData
 		id   int
+
 	}
 
 	Node struct {
@@ -520,9 +521,9 @@ type (
 	}
 
 	agentConfig struct {
-		data      string
-		as3APIURL string
-		id        int
+		data            string
+		as3APIURL       string
+		id              int
 	}
 
 	globalSection struct {

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -1066,19 +1066,6 @@ func (ctlr *Controller) getAssociatedVirtualServers(
 			}
 		}
 
-		//skip the virtuals if VirtualServerAddress not mentioned with hostGroup
-		//skip the virtuals if different virtualServerAddresses are found
-		if vrt.Spec.HostGroup != "" {
-			if vrt.Spec.VirtualServerAddress == "" {
-				log.Infof("No IP was specified for the virtual server %s", currentVS.Name)
-				continue
-			}
-			if vrt.Spec.VirtualServerAddress != currentVS.Spec.VirtualServerAddress {
-				log.Errorf("Same hostGroup %v is configured with different virtualServerAddress: %v - %v ", vrt.Spec.HostGroup, currentVS.Spec.VirtualServerAddress, currentVS.Name)
-				return nil
-			}
-		}
-
 		// skip the virtuals with different custom HTTP/HTTPS ports
 		if vrt.Spec.VirtualServerHTTPPort != currentVS.Spec.VirtualServerHTTPPort ||
 			vrt.Spec.VirtualServerHTTPSPort != currentVS.Spec.VirtualServerHTTPSPort {

--- a/pkg/controller/worker_test.go
+++ b/pkg/controller/worker_test.go
@@ -609,7 +609,9 @@ var _ = Describe("Worker Tests", func() {
 					[]*cisapiv1.VirtualServer{vrt2, vrt3, vrt4},
 					false)
 
-				Expect(len(virts)).To(Equal(1), "Wrong number of Virtual Servers")
+				Expect(len(virts)).To(Equal(2), "Wrong number of Virtual Servers")
+				Expect(virts[0].Spec.Host).To(Equal("test2.com"), "Wrong Virtual Server Host")
+				Expect(virts[1].Spec.Host).To(Equal("test3.com"), "Wrong Virtual Server Host")
 			})
 
 			It("HostGroup with wrong custom port", func() {


### PR DESCRIPTION
Reverts F5Networks/k8s-bigip-ctlr#2288

ipam and hostgroup combinations needs to be validated. Reverting changes for now.