### PR TITLE
Parallel vsQueue handling to avoid long waiting as starting cis.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ GOBIN    = $(GOPATH)/bin/$(GOOS)-$(GOARCH)
 
 NEXT_VERSION := $(shell ./build-tools/version-tool version)
 export BUILD_VERSION := $(if $(BUILD_VERSION),$(BUILD_VERSION),$(NEXT_VERSION))
-export BUILD_INFO := $(shell ./build-tools/version-tool build-info)
+NEXT_INFO := $(shell ./build-tools/version-tool build-info)
+export BUILD_INFO := $(if $(BUILD_INFO),$(BUILD_INFO),$(NEXT_INFO))
 
 GO_BUILD_FLAGS=-v -ldflags "-extldflags \"-static\" -X main.version=$(BUILD_VERSION) -X main.buildInfo=$(BUILD_INFO)"
 


### PR DESCRIPTION
**Description**: 

Long wait at starting(issue: #2263 )

There are 2 reasons causing the long wait at starting time:

1) when CIS starts, informers receives all objects from api server, including resources created long before, which make the vsQueue too long to be handled timely.
2) All the objects in the vsQueue are handled, assembled and deployed, but the deployments are executed in serial way. ConfigDeployer will not accept new msgReq until these AS3 deployments are done.  

**Changes Proposed in PR**:

Instead of using only one `virtualServerWorker` to handle objects from `vsQueue`, we use parallel way to do the job.
That means there are multiple go-routine processes working to consume from `vsQueue`. Benefit for this way is that, it can avoid objects' long waiting time in `vsQueue`.
the 'multiple' number mentioned here can be auto scaled, depends on the length of `vsQueue`.

However, this PR does no help to 2) mentioned above. We need another idea to solve the slow processings at `ConfigDeployer` side.

**Fixes**: resolves #2263 

## General Checklist
- [ ] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation
- [ ] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema