### PR TITLE
ConfigMap backward compatibility fix

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -7,6 +7,7 @@ Enhancements
 ````````````
 * :issues:`2030` Fix for changes on Ingress Resource Service Port not reflected on BIGIP
 * :issues:`2205` Fix for deleting multiple EDNS resources
+* :issues:`2255` Fix for ConfigMap backward compatibility
 * SR - Fix iapp continuous updates with no backend pods
 
 

--- a/pkg/agent/as3/as3ConfigMap.go
+++ b/pkg/agent/as3/as3ConfigMap.go
@@ -178,6 +178,18 @@ func (am *AS3Manager) processCfgMap(rscCfgMap *AgentCfgMap) (
 					}
 				}
 
+				if port == 0 {
+					ipMap := make(map[string]bool)
+					members = append(members, eps...)
+					for _, v := range eps {
+						if _, ok := ipMap[v.Address]; !ok {
+							ipMap[v.Address] = true
+							ips = append(ips, v.Address)
+						}
+					}
+					port = eps[0].Port
+				}
+
 				// Replace pool member IP addresses
 				poolMem["serverAddresses"] = ips
 				// Replace port number


### PR DESCRIPTION
Signed-off-by: Vivek Lohiya <vklohiya@live.com>

**Description**:  Backwards incompatible in multiple port service

**Changes Proposed in PR**: If the service port does not match with the configMap port we are adding the first port of the service in the endpoint, this will make sure that old configMaps keeps working like earlier. 

**Fixes**: resolves #2255 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed