### PR TITLE
Remove unused GTM PoolMembers created by CIS in old versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/f5devcentral/f5-ctlr-agent.git@c3a5ee7655d6b624fd438ebef18af7ee8938fe32#egg=f5-ctlr-agent
+-e git+https://github.com/f5devcentral/f5-ctlr-agent.git@2028359d248bf116ff46cea0c10525a67aa5e18e#egg=f5-ctlr-agent
 -e git+https://github.com/f5devcentral/f5-cccl.git@09fc9e609b54a0d5eccb593a57834395db0edf4c#egg=f5-cccl


### PR DESCRIPTION
**Description**:  Currently, CIS just attaches only secured GTM pool members ignoring to remove the oldGTMPoolmembers created by CIS if existing. This fix ensures that CIS properly removes the old GTM pool members from the BIGIP.

**Changes Proposed in PR**:

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema