### PR TITLE
Fix issue of deleting partition when bad as3 schema.

### DIFF
--- a/pkg/agent/as3/as3ConfigMap.go
+++ b/pkg/agent/as3/as3ConfigMap.go
@@ -48,14 +48,15 @@ func (am *AS3Manager) prepareResourceAS3ConfigMaps() (
 			cfgmap := &AS3ConfigMap{
 				Name:      rscCfgMap.Name,
 				Namespace: rscCfgMap.Namespace,
+				Validated: true,
 			}
 
-			if am.as3Validation == true {
+			if am.as3Validation {
 				if ok := am.validateAS3Template(rscCfgMap.Data); !ok {
 					log.Errorf("[AS3][Configmap] Error validating AS3 template")
 					log.Errorf("[AS3][Configmap] Error in processing the resource ConfigMap: %v in Namespace: %v",
 						rscCfgMap.Name, rscCfgMap.Namespace)
-					continue
+					cfgmap.Validated = false
 				}
 			}
 
@@ -63,6 +64,7 @@ func (am *AS3Manager) prepareResourceAS3ConfigMaps() (
 			if tenantMap == nil {
 				continue
 			}
+
 			cfgmap.config = tenantMap
 			cfgmap.endPoints = endPoints
 			as3Cfgmaps = append(as3Cfgmaps, cfgmap)


### PR DESCRIPTION
**Description**:  

CIS should not delete existing config when configmap in bad format 


**Changes Proposed in PR**:

The issue happens because:
The coming configmap json(containing partitions to create) is fully parsed because of bad schema format.
Thus, by comparing existing configmap in CIS, the fails-to-parsed partition is considered as `deleteTenants`.

The fix can be: recording the parsing result, more concisely tell later logic to distinguish it's invalid or real-missing.

**Fixes**: resolves SR  1-8181523521 / connell-1 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes - TBD in release notes 
- [x] Smoke testing completed