### PR TITLE
Allow customized BUILD_INFO, same behavior with NEXT_VERSION

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,8 @@ GOBIN    = $(GOPATH)/bin/$(GOOS)-$(GOARCH)
 
 NEXT_VERSION := $(shell ./build-tools/version-tool version)
 export BUILD_VERSION := $(if $(BUILD_VERSION),$(BUILD_VERSION),$(NEXT_VERSION))
-export BUILD_INFO := $(shell ./build-tools/version-tool build-info)
+NEXT_INFO := $(shell ./build-tools/version-tool build-info)
+export BUILD_INFO := $(if $(BUILD_INFO),$(BUILD_INFO),$(NEXT_INFO))
 
 GO_BUILD_FLAGS=-v -ldflags "-extldflags \"-static\" -X main.version=$(BUILD_VERSION) -X main.buildInfo=$(BUILD_INFO)"
 


### PR DESCRIPTION
**Description**:  

Bit change for enabling local image building.

**Changes Proposed in PR**:

We should allow BUILD_INFO var to be customized, just like NEXT_VERSION.

**Fixes**: 
None

## General Checklist
- [ ] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation
- [ ] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema