### PR TITLE
Added support for passthrough traffic termination for routes 

### DIFF
--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -785,6 +785,19 @@ func createServiceDecl(cfg *ResourceConfig, sharedApp as3Application, tenant str
 		svc.Class = "Service_TCP"
 	}
 
+	// updating the virtual server to https if a passthrough datagroup is found
+	name := getRSCfgResName(cfg.Virtual.Name, PassthroughHostsDgName)
+	mapKey := NameRef{
+		Name:      name,
+		Partition: cfg.Virtual.Partition,
+	}
+	if _, ok := cfg.IntDgMap[mapKey]; ok {
+		svc.ServerTLS = &as3ResourcePointer{
+			BigIP: "/Common/clientssl",
+		}
+		updateVirtualToHTTPS(svc)
+	}
+
 	// Attaching Profiles from Policy CRD
 	for _, profile := range cfg.Virtual.Profiles {
 		_, name := getPartitionAndName(profile.Name)
@@ -866,33 +879,6 @@ func createServiceAddressDecl(cfg *ResourceConfig, virtualAddress string, shared
 func createRuleCondition(rl *Rule, rulesData *as3Rule, port int) {
 	for _, c := range rl.Conditions {
 		condition := &as3Condition{}
-		if c.SSLExtensionClient {
-			condition.Name = "host"
-			condition.Type = "sslExtension"
-			condition.Event = "ssl-client-hello"
-
-			// For ports other then 80 and 443, attaching port number to host.
-			// Ex. example.com:8080
-			if port != 80 && port != 443 {
-				var values []string
-				for i := range c.Values {
-					val := c.Values[i] + ":" + strconv.Itoa(port)
-					values = append(values, val)
-				}
-				condition.ServerName = &as3PolicyCompareString{
-					Values: values,
-				}
-			} else {
-				condition.ServerName = &as3PolicyCompareString{
-					Values: c.Values,
-				}
-			}
-			if c.Equals {
-				condition.ServerName.Operand = "equals"
-			}
-			rulesData.Conditions = append(rulesData.Conditions, condition)
-			continue
-		}
 
 		if c.Host {
 			condition.Name = "host"

--- a/pkg/controller/backend_test.go
+++ b/pkg/controller/backend_test.go
@@ -137,9 +137,8 @@ var _ = Describe("Backend Tests", func() {
 						&Rule{
 							Conditions: []*condition{
 								{
-									SSLExtensionClient: true,
-									Values:             []string{"test.com"},
-									Equals:             true,
+									Values: []string{"test.com"},
+									Equals: true,
 								},
 							},
 							Actions: []*action{

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -84,10 +84,6 @@ const (
 	TLSAllowInsecure    = "allow"
 	TLSNoInsecure       = "none"
 
-	// HTTP Events for LTM Policy
-	HTTPRequest    = "HTTPRequest"
-	TLSClientHello = "TLSClientHello"
-
 	LBServiceIPAMLabelAnnotation = "cis.f5.com/ipamLabel"
 	HealthMonitorAnnotation      = "cis.f5.com/health"
 )

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -288,6 +288,7 @@ func formatPolicyName(hostname, hostGroup, name string) string {
 func (ctlr *Controller) prepareRSConfigFromVirtualServer(
 	rsCfg *ResourceConfig,
 	vs *cisapiv1.VirtualServer,
+	passthroughVS bool,
 ) error {
 
 	var httpPort int32
@@ -371,14 +372,17 @@ func (ctlr *Controller) prepareRSConfigFromVirtualServer(
 		return nil
 	}
 
-	rules = ctlr.prepareVirtualServerRules(vs)
-	if rules == nil {
-		return fmt.Errorf("failed to create LTM Rules")
+	// skip the policy creation for passthrough termination
+	if !passthroughVS {
+		rules = ctlr.prepareVirtualServerRules(vs)
+		if rules == nil {
+			return fmt.Errorf("failed to create LTM Rules")
+		}
+
+		policyName := formatPolicyName(vs.Spec.Host, vs.Spec.HostGroup, rsCfg.Virtual.Name)
+
+		rsCfg.AddRuleToPolicy(policyName, vs.Namespace, rules)
 	}
-
-	policyName := formatPolicyName(vs.Spec.Host, vs.Spec.HostGroup, rsCfg.Virtual.Name)
-
-	rsCfg.AddRuleToPolicy(policyName, vs.Namespace, rules)
 
 	// Attach user specified iRules
 	if len(vs.Spec.IRules) > 0 {
@@ -408,147 +412,145 @@ func (ctlr *Controller) handleTLS(
 ) bool {
 
 	if rsCfg.Virtual.VirtualAddress.Port == tlsContext.httpsPort {
+		if tlsContext.termination != TLSPassthrough {
+			clientSSL := tlsContext.bigIPSSLProfiles.clientSSL
+			serverSSL := tlsContext.bigIPSSLProfiles.serverSSL
+			// Process Profile
+			switch tlsContext.referenceType {
+			case BIGIP:
+				log.Debugf("Processing  BIGIP referenced profiles for '%s' '%s'/'%s'",
+					tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
+				// Process referenced BIG-IP clientSSL
+				if clientSSL != "" {
+					clientProfRef := ConvertStringToProfileRef(
+						clientSSL, CustomProfileClient, tlsContext.namespace)
+					rsCfg.Virtual.AddOrUpdateProfile(clientProfRef)
+				}
+				// Process referenced BIG-IP serverSSL
+				if serverSSL != "" {
+					serverProfRef := ConvertStringToProfileRef(
+						serverSSL, CustomProfileServer, tlsContext.namespace)
+					rsCfg.Virtual.AddOrUpdateProfile(serverProfRef)
+				}
+				log.Debugf("Updated BIGIP referenced profiles for '%s' '%s'/'%s'",
+					tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
+			case Secret:
+				// Prepare SSL Transient Context
+				// Check if TLS Secret already exists
+				// Process ClientSSL stored as kubernetes secret
+				if clientSSL != "" {
+					if secret, ok := ctlr.SSLContext[clientSSL]; ok {
+						log.Debugf("clientSSL secret %s for '%s'/'%s' is already available with CIS in "+
+							"SSLContext as clientSSL", secret.ObjectMeta.Name, tlsContext.namespace, tlsContext.name)
+						err, _ := ctlr.createSecretClientSSLProfile(rsCfg, secret, CustomProfileClient)
+						if err != nil {
+							log.Debugf("error %v encountered while creating clientssl profile  for '%s' '%s'/'%s' using secret '%s'",
+								err, tlsContext.resourceType, tlsContext.namespace, tlsContext.name, secret.ObjectMeta.Name)
+							return false
+						}
+					} else {
+						// Check if profile is contained in a Secret
+						// Update the SSL Context if secret found, This is used to avoid api calls
+						log.Debugf("saving clientSSL secret for '%s' '%s'/'%s' into SSLContext", tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
+						secret, err := ctlr.kubeClient.CoreV1().Secrets(tlsContext.namespace).
+							Get(context.TODO(), clientSSL, metav1.GetOptions{})
+						if err != nil {
+							log.Errorf("secret %s not found for '%s' '%s'/'%s'",
+								clientSSL, tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
+							return false
+						}
+						ctlr.SSLContext[clientSSL] = secret
+						err, _ = ctlr.createSecretClientSSLProfile(rsCfg, secret, CustomProfileClient)
+						if err != nil {
+							log.Errorf("error %v encountered while creating clientssl profile for '%s' '%s'/'%s'",
+								err, tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
+							return false
+						}
+					}
+				}
+				// Process ServerSSL stored as kubernetes secret
+				if serverSSL != "" {
+					if secret, ok := ctlr.SSLContext[serverSSL]; ok {
+						log.Debugf("serverSSL secret %s for '%s'/'%s' is already available with CIS in "+
+							"SSLContext as serverSSL", secret.ObjectMeta.Name, tlsContext.namespace, tlsContext.name)
+						err, _ := ctlr.createSecretServerSSLProfile(rsCfg, secret, CustomProfileServer)
+						if err != nil {
+							log.Debugf("error %v encountered while creating serverssl profile for '%s' '%s'/'%s' using secret '%s'",
+								err, tlsContext.resourceType, tlsContext.namespace, tlsContext.name, secret.ObjectMeta.Name)
+							return false
+						}
+					} else {
+						// Check if profile is contained in a Secret
+						// Update the SSL Context if secret found, This is used to avoid api calls
+						log.Debugf("saving serverSSL secret for '%s' '%s'/'%s' into SSLContext", tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
+						secret, err := ctlr.kubeClient.CoreV1().Secrets(tlsContext.namespace).
+							Get(context.TODO(), serverSSL, metav1.GetOptions{})
+						if err != nil {
+							log.Errorf("secret %s not found for '%s' '%s'/'%s'",
+								serverSSL, tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
+							return false
+						}
+						ctlr.SSLContext[serverSSL] = secret
+						err, _ = ctlr.createSecretServerSSLProfile(rsCfg, secret, CustomProfileServer)
+						if err != nil {
+							log.Errorf("error %v encountered while creating serverssl profile for '%s' '%s'/'%s'",
+								err, tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
+							return false
+						}
+					}
+				}
 
-		if tlsContext.termination == TLSPassthrough {
-			rsCfg.Virtual.PersistenceMethods = []string{"tls-session-id"}
-			return true
-		}
-		clientSSL := tlsContext.bigIPSSLProfiles.clientSSL
-		serverSSL := tlsContext.bigIPSSLProfiles.serverSSL
-		// Process Profile
-		switch tlsContext.referenceType {
-		case BIGIP:
-			log.Debugf("Processing  BIGIP referenced profiles for '%s' '%s'/'%s'",
-				tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
-			// Process referenced BIG-IP clientSSL
-			if clientSSL != "" {
-				clientProfRef := ConvertStringToProfileRef(
-					clientSSL, CustomProfileClient, tlsContext.namespace)
-				rsCfg.Virtual.AddOrUpdateProfile(clientProfRef)
-			}
-			// Process referenced BIG-IP serverSSL
-			if serverSSL != "" {
-				serverProfRef := ConvertStringToProfileRef(
-					serverSSL, CustomProfileServer, tlsContext.namespace)
-				rsCfg.Virtual.AddOrUpdateProfile(serverProfRef)
-			}
-			log.Debugf("Updated BIGIP referenced profiles for '%s' '%s'/'%s'",
-				tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
-		case Secret:
-			// Prepare SSL Transient Context
-			// Check if TLS Secret already exists
-			// Process ClientSSL stored as kubernetes secret
-			if clientSSL != "" {
-				if secret, ok := ctlr.SSLContext[clientSSL]; ok {
-					log.Debugf("clientSSL secret %s for '%s'/'%s' is already available with CIS in "+
-						"SSLContext as clientSSL", secret.ObjectMeta.Name, tlsContext.namespace, tlsContext.name)
-					err, _ := ctlr.createSecretClientSSLProfile(rsCfg, secret, CustomProfileClient)
+			case Certificate:
+				// Prepare SSL Transient Context
+				if tlsContext.bigIPSSLProfiles.key != "" && tlsContext.bigIPSSLProfiles.certificate != "" {
+					err, _ := ctlr.createClientSSLProfile(rsCfg, tlsContext.bigIPSSLProfiles.key, tlsContext.bigIPSSLProfiles.certificate, fmt.Sprintf("%s-clientssl", tlsContext.name), tlsContext.namespace, CustomProfileClient)
 					if err != nil {
-						log.Debugf("error %v encountered while creating clientssl profile  for '%s' '%s'/'%s' using secret '%s'",
-							err, tlsContext.resourceType, tlsContext.namespace, tlsContext.name, secret.ObjectMeta.Name)
-						return false
-					}
-				} else {
-					// Check if profile is contained in a Secret
-					// Update the SSL Context if secret found, This is used to avoid api calls
-					log.Debugf("saving clientSSL secret for '%s' '%s'/'%s' into SSLContext", tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
-					secret, err := ctlr.kubeClient.CoreV1().Secrets(tlsContext.namespace).
-						Get(context.TODO(), clientSSL, metav1.GetOptions{})
-					if err != nil {
-						log.Errorf("secret %s not found for '%s' '%s'/'%s'",
-							clientSSL, tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
-						return false
-					}
-					ctlr.SSLContext[clientSSL] = secret
-					err, _ = ctlr.createSecretClientSSLProfile(rsCfg, secret, CustomProfileClient)
-					if err != nil {
-						log.Errorf("error %v encountered while creating clientssl profile for '%s' '%s'/'%s'",
+						log.Debugf("error %v encountered while creating clientssl profile  for '%s' '%s'/'%s'",
 							err, tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
 						return false
 					}
 				}
-			}
-			// Process ServerSSL stored as kubernetes secret
-			if serverSSL != "" {
-				if secret, ok := ctlr.SSLContext[serverSSL]; ok {
-					log.Debugf("serverSSL secret %s for '%s'/'%s' is already available with CIS in "+
-						"SSLContext as serverSSL", secret.ObjectMeta.Name, tlsContext.namespace, tlsContext.name)
-					err, _ := ctlr.createSecretServerSSLProfile(rsCfg, secret, CustomProfileServer)
-					if err != nil {
-						log.Debugf("error %v encountered while creating serverssl profile for '%s' '%s'/'%s' using secret '%s'",
-							err, tlsContext.resourceType, tlsContext.namespace, tlsContext.name, secret.ObjectMeta.Name)
-						return false
+				// Create Server SSL profile for bigip
+				if tlsContext.bigIPSSLProfiles.destinationCACertificate != "" {
+					var err error
+					if tlsContext.bigIPSSLProfiles.caCertificate != "" {
+						err, _ = ctlr.createServerSSLProfile(rsCfg, tlsContext.bigIPSSLProfiles.destinationCACertificate, tlsContext.bigIPSSLProfiles.caCertificate, tlsContext.name, tlsContext.namespace, CustomProfileServer)
+					} else {
+						err, _ = ctlr.createServerSSLProfile(rsCfg, tlsContext.bigIPSSLProfiles.destinationCACertificate, "", fmt.Sprintf("%s-serverssl", tlsContext.name), tlsContext.namespace, CustomProfileServer)
 					}
-				} else {
-					// Check if profile is contained in a Secret
-					// Update the SSL Context if secret found, This is used to avoid api calls
-					log.Debugf("saving serverSSL secret for '%s' '%s'/'%s' into SSLContext", tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
-					secret, err := ctlr.kubeClient.CoreV1().Secrets(tlsContext.namespace).
-						Get(context.TODO(), serverSSL, metav1.GetOptions{})
 					if err != nil {
-						log.Errorf("secret %s not found for '%s' '%s'/'%s'",
-							serverSSL, tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
-						return false
-					}
-					ctlr.SSLContext[serverSSL] = secret
-					err, _ = ctlr.createSecretServerSSLProfile(rsCfg, secret, CustomProfileServer)
-					if err != nil {
-						log.Errorf("error %v encountered while creating serverssl profile for '%s' '%s'/'%s'",
+						log.Debugf("error %v encountered while creating serverssl profile  for '%s' '%s'/'%s'",
 							err, tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
 						return false
 					}
 				}
+			default:
+				log.Errorf("Invalid reference type provided for  '%s' '%s'/'%s'",
+					tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
+				return false
 			}
-
-		case Certificate:
-			// Prepare SSL Transient Context
-			if tlsContext.bigIPSSLProfiles.key != "" && tlsContext.bigIPSSLProfiles.certificate != "" {
-				err, _ := ctlr.createClientSSLProfile(rsCfg, tlsContext.bigIPSSLProfiles.key, tlsContext.bigIPSSLProfiles.certificate, fmt.Sprintf("%s-clientssl", tlsContext.name), tlsContext.namespace, CustomProfileClient)
-				if err != nil {
-					log.Debugf("error %v encountered while creating clientssl profile  for '%s' '%s'/'%s'",
-						err, tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
-					return false
-				}
-			}
-			// Create Server SSL profile for bigip
-			if tlsContext.bigIPSSLProfiles.destinationCACertificate != "" {
-				var err error
-				if tlsContext.bigIPSSLProfiles.caCertificate != "" {
-					err, _ = ctlr.createServerSSLProfile(rsCfg, tlsContext.bigIPSSLProfiles.destinationCACertificate, tlsContext.bigIPSSLProfiles.caCertificate, tlsContext.name, tlsContext.namespace, CustomProfileServer)
-				} else {
-					err, _ = ctlr.createServerSSLProfile(rsCfg, tlsContext.bigIPSSLProfiles.destinationCACertificate, "", fmt.Sprintf("%s-serverssl", tlsContext.name), tlsContext.namespace, CustomProfileServer)
-				}
-				if err != nil {
-					log.Debugf("error %v encountered while creating serverssl profile  for '%s' '%s'/'%s'",
-						err, tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
-					return false
-				}
-			}
-		default:
-			log.Errorf("Invalid reference type provided for  '%s' '%s'/'%s'",
-				tlsContext.resourceType, tlsContext.namespace, tlsContext.name)
-			return false
-		}
-		// TLS Cert/Key
-		for _, poolPathRef := range tlsContext.poolPathRefs {
-			switch tlsContext.termination {
-			case TLSEdge:
-				serverSsl := "false"
-				sslPath := tlsContext.hostname + poolPathRef.path
-				sslPath = strings.TrimSuffix(sslPath, "/")
-				updateDataGroup(rsCfg.IntDgMap, getRSCfgResName(rsCfg.Virtual.Name, EdgeServerSslDgName),
-					rsCfg.Virtual.Partition, tlsContext.namespace, sslPath, serverSsl)
-
-			case TLSReencrypt:
-				sslPath := tlsContext.hostname + poolPathRef.path
-				sslPath = strings.TrimSuffix(sslPath, "/")
-				serverSsl := AS3NameFormatter("crd_" + tlsContext.ipAddress + "_tls_client")
-				if "" != serverSSL {
-					updateDataGroup(rsCfg.IntDgMap, getRSCfgResName(rsCfg.Virtual.Name, ReencryptServerSslDgName),
+			// TLS Cert/Key
+			for _, poolPathRef := range tlsContext.poolPathRefs {
+				switch tlsContext.termination {
+				case TLSEdge:
+					serverSsl := "false"
+					sslPath := tlsContext.hostname + poolPathRef.path
+					sslPath = strings.TrimSuffix(sslPath, "/")
+					updateDataGroup(rsCfg.IntDgMap, getRSCfgResName(rsCfg.Virtual.Name, EdgeServerSslDgName),
 						rsCfg.Virtual.Partition, tlsContext.namespace, sslPath, serverSsl)
+
+				case TLSReencrypt:
+					sslPath := tlsContext.hostname + poolPathRef.path
+					sslPath = strings.TrimSuffix(sslPath, "/")
+					serverSsl := AS3NameFormatter("crd_" + tlsContext.ipAddress + "_tls_client")
+					if "" != serverSSL {
+						updateDataGroup(rsCfg.IntDgMap, getRSCfgResName(rsCfg.Virtual.Name, ReencryptServerSslDgName),
+							rsCfg.Virtual.Partition, tlsContext.namespace, sslPath, serverSsl)
+					}
 				}
 			}
 		}
+
 		//Create datagroups
 		switch tlsContext.termination {
 		case TLSReencrypt:
@@ -564,6 +566,7 @@ func (ctlr *Controller) handleTLS(
 				ReencryptHostsDgName,
 				tlsContext.hostname,
 				tlsContext.namespace,
+				rsCfg.Virtual.Partition,
 			)
 		case TLSEdge:
 			updateDataGroupOfDgName(
@@ -573,15 +576,23 @@ func (ctlr *Controller) handleTLS(
 				EdgeHostsDgName,
 				tlsContext.hostname,
 				tlsContext.namespace,
+				rsCfg.Virtual.Partition,
 			)
+		case TLSPassthrough:
+			updateDataGroupOfDgName(
+				rsCfg.IntDgMap,
+				tlsContext.poolPathRefs,
+				rsCfg.Virtual.Name,
+				PassthroughHostsDgName,
+				tlsContext.hostname,
+				tlsContext.namespace,
+				rsCfg.Virtual.Partition)
 		}
-
 		ctlr.handleDataGroupIRules(
 			rsCfg,
 			tlsContext.hostname,
 			tlsContext.termination,
 		)
-
 		return true
 	}
 	// httpTraffic defines the behaviour of http Virtual Server on BIG-IP
@@ -614,6 +625,7 @@ func (ctlr *Controller) handleTLS(
 				HttpsRedirectDgName,
 				tlsContext.hostname,
 				tlsContext.namespace,
+				rsCfg.Virtual.Partition,
 			)
 		case TLSAllowInsecure:
 			// State 3, do not apply any policy
@@ -1132,6 +1144,9 @@ const ReencryptHostsDgName = "ssl_reencrypt_servername_dg"
 // Internal data group for edge termination.
 const EdgeHostsDgName = "ssl_edge_servername_dg"
 
+// Internal data group for passthrough termination.
+const PassthroughHostsDgName = "ssl_passthrough_servername_dg"
+
 // Internal data group for reencrypt termination that maps the host name to the
 // server ssl profile.
 const ReencryptServerSslDgName = "ssl_reencrypt_serverssl_dg"
@@ -1224,15 +1239,15 @@ func (ctlr *Controller) handleDataGroupIRules(
 	if "" != tlsTerminationType {
 		tlsIRuleName := JoinBigipPath(rsCfg.Virtual.Partition,
 			getRSCfgResName(rsCfg.Virtual.Name, TLSIRuleName))
+		rsCfg.addIRule(
+			getRSCfgResName(rsCfg.Virtual.Name, TLSIRuleName), rsCfg.Virtual.Partition, ctlr.getTLSIRule(rsCfg.Virtual.Name, rsCfg.Virtual.Partition))
 		switch tlsTerminationType {
 		case TLSEdge:
-			rsCfg.addIRule(
-				getRSCfgResName(rsCfg.Virtual.Name, TLSIRuleName), rsCfg.Virtual.Partition, ctlr.getTLSIRule(rsCfg.Virtual.Name, rsCfg.Virtual.Partition))
 			rsCfg.addInternalDataGroup(getRSCfgResName(rsCfg.Virtual.Name, EdgeHostsDgName), rsCfg.Virtual.Partition)
 			rsCfg.addInternalDataGroup(getRSCfgResName(rsCfg.Virtual.Name, EdgeServerSslDgName), rsCfg.Virtual.Partition)
+		case TLSPassthrough:
+			rsCfg.addInternalDataGroup(getRSCfgResName(rsCfg.Virtual.Name, PassthroughHostsDgName), rsCfg.Virtual.Partition)
 		case TLSReencrypt:
-			rsCfg.addIRule(
-				getRSCfgResName(rsCfg.Virtual.Name, TLSIRuleName), rsCfg.Virtual.Partition, ctlr.getTLSIRule(rsCfg.Virtual.Name, rsCfg.Virtual.Partition))
 			rsCfg.addInternalDataGroup(getRSCfgResName(rsCfg.Virtual.Name, ReencryptHostsDgName), rsCfg.Virtual.Partition)
 			rsCfg.addInternalDataGroup(getRSCfgResName(rsCfg.Virtual.Name, ReencryptServerSslDgName), rsCfg.Virtual.Partition)
 		}

--- a/pkg/controller/resourceConfig_test.go
+++ b/pkg/controller/resourceConfig_test.go
@@ -252,7 +252,7 @@ var _ = Describe("Resource Config Tests", func() {
 					IRules:         []string{"SampleIRule"},
 				},
 			)
-			err := mockCtlr.prepareRSConfigFromVirtualServer(rsCfg, vs)
+			err := mockCtlr.prepareRSConfigFromVirtualServer(rsCfg, vs, false)
 			Expect(err).To(BeNil(), "Failed to Prepare Resource Config from VirtualServer")
 		})
 


### PR DESCRIPTION
Signed-off-by: Vivek Lohiya <vklohiya@live.com>

**Description**:  Added support for passthrough traffic termination for routes 

**Changes Proposed in PR**: All the passthrough traffic will be handled via iRule only for both virtual server and route resources. Removed the policy rules implementation for virtual server's passthrough traffic.


## General Checklist
- [ ] Smoke testing completed
