### PR TITLE
Fixed issue related to allowing of insecure traffic

### DIFF
--- a/pkg/controller/constants.go
+++ b/pkg/controller/constants.go
@@ -19,4 +19,7 @@ const (
 	Shared = "Shared"
 
 	F5RouterName = "F5 BIG-IP"
+
+	HTTP  = "http"
+	HTTPS = "https"
 )


### PR DESCRIPTION
**Description**:  Fixed issue of CIS allowing insecure traffic for all the routes when one route is having insecureEdgeTerminationPolicy policy as allow.

**Changes Proposed in PR**: Skip adding forwarding policy rule to HTTP virtual server if the route doesn't allow insecure traffic.

**Fixes**: resolves #_Github issue id_

## General Checklist
- [ ] Smoke testing completed