### PR TITLE
Fix alternate extSpec local ConfigMap issue

### DIFF
--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -130,6 +130,9 @@ func NewConfigMap(id, rv, namespace string,
 			ResourceVersion: rv,
 			Namespace:       namespace,
 			Annotations:     make(map[string]string),
+			CreationTimestamp: metav1.Time{
+				Time: time.Now(),
+			},
 		},
 		Data: keys,
 	}


### PR DESCRIPTION
Signed-off-by: Subba Reddy Veeramreddy <subbareddyv.uoh@gmail.com>

**Description**:  _When an extended spec local configmap was deleted, the controller was not checking for other local configmaps_

**Changes Proposed in PR**: look for other local configmaps and process latest available if the local configmp is deleted

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema