### PR TITLE
Support GTM global-availability mode and order precedence with EDNS

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -235,6 +235,7 @@ type DNSPool struct {
 	DataServerName    string    `json:"dataServerName"`
 	DNSRecordType     string    `json:"dnsRecordType"`
 	LoadBalanceMethod string    `json:"loadBalanceMethod"`
+	PriorityOrder     int       `json:"order"`
 	Monitor           Monitor   `json:"monitor"`
 	Monitors          []Monitor `json:"monitors"`
 }

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -14,6 +14,7 @@ Added Functionality
         * client ProfileL4 support for TransportServer and Policy CRs. See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/>`_
         * OneConnect profile support added for VirtualServer CRs. See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/>`_
         * TCP Client and Server profile support added for VirtualServer, TransportServer and Policy CRs. See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/>`_
+        * GTM global-availability LB method and order precedence support with EDNS CRs. See `Examples <https://github.com/sravyap135/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/ExternalDNS>`_
     * Added support for SCTP protocol in Services of type LoadBalancer
     * Added support for AS3 3.36
     * Added support for route admit status for rejected routes
@@ -25,6 +26,11 @@ Bug Fixes
 * :issues:`2151` Fix for adding unique pool members only to AS3 declaration with AS3 configmap
 * :issues:`2326` Support for Configmap resource with NodePortLocal mode
 * :issues:`2294` Fix for service supporting with named ports
+
+Upgrade notes
+``````````````
+requires update to RBAC and CR schema definition before upgrade
+* To use order precedence mode in EDNS CR, upgrade the EDNS CRD. See `CR schema <https://raw.githubusercontent.com/F5Networks/k8s-bigip-ctlr/master/docs/config_examples/customResourceDefinitions/customresourcedefinitions.yml>`_
 
 2.8.1
 -------------

--- a/docs/config_examples/customResource/ExternalDNS/README.md
+++ b/docs/config_examples/customResource/ExternalDNS/README.md
@@ -49,3 +49,11 @@ Note: **monitors** take priority over **monitor** if both are provided in edns s
 ## externaldns-tcp-monitor.yaml
 
 By deploying this yaml file in your cluster, CIS will create a edns containing GSLB pool health monitored on BIG-IP.
+
+## externaldns-pool-priority-order.yaml
+
+When the load balancing method is set to Global Availability, BIG-IP GTM distributes DNS name resolution requests to the first available virtual server in a pool. BIG-IP GTM starts at the top of a manually configured list of virtual servers and sends requests to the first available virtual server in the list. Only when the virtual server becomes unavailable does BIG-IP GTM send requests to the next virtual server in the list. Over time, the first virtual server in the list receives the most requests and the last virtual server in the list receives the least requests.
+
+To set this option on BIG-IP using CIS, in the EDNS resource spec, 
+* Set the load balancing method to `global-availability`.
+* Configure the priority order of pool members using `spec.pools[].order`. All the distributed wideIP pools need to have correct pool order.

--- a/docs/config_examples/customResource/ExternalDNS/externaldns-pool-priority-order.yaml
+++ b/docs/config_examples/customResource/ExternalDNS/externaldns-pool-priority-order.yaml
@@ -1,0 +1,19 @@
+apiVersion: "cis.f5.com/v1"
+kind: ExternalDNS
+metadata:
+  name: exdns
+  labels:
+    f5cr: "true"
+spec:
+  domainName: example.com
+  dnsRecordType: A
+  loadBalanceMethod: global-availability
+  pools:
+  - dnsRecordType: A
+    loadBalanceMethod: round-robin
+    order: 1
+    dataServerName: /Common/GSLBServer
+    monitor:
+      type: tcp
+      interval: 10
+      timeout: 10

--- a/docs/config_examples/customResourceDefinitions/customresourcedefinitions.yml
+++ b/docs/config_examples/customResourceDefinitions/customresourcedefinitions.yml
@@ -462,6 +462,8 @@ spec:
                         pattern: 'A'
                       loadBalanceMethod:
                         type: string
+                      order:
+                        type: integer
                       monitor:
                         type: object
                         properties:

--- a/docs/upgradeProcess.md
+++ b/docs/upgradeProcess.md
@@ -207,12 +207,14 @@ Refer Release Notes for [CIS v2.8.0](https://github.com/F5Networks/k8s-bigip-ctl
 
 ### **Upgrading from 2.8.1 to 2.9.0:**
 
-Refer Release Notes for [CIS v2.8.0](https://github.com/F5Networks/k8s-bigip-ctlr/blob/master/docs/RELEASE-NOTES.rst#280)
+Refer Release Notes for [CIS v2.9.0](https://github.com/F5Networks/k8s-bigip-ctlr/blob/master/docs/RELEASE-NOTES.rst#290)
 
 **_Functionality Change:_**
 
 * TCP Client and Server support for VirtualServer, TransportServer and Policy CRs
+* Support for GTM pools priority order with global-availability load balancing method
 
 **_Configuration Change:_**
 
 * Setting TCP Profile in Policy CRD changed to support TCP Client and Server profiles. (See [documentation](https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/Policy))
+* Setting pool priority order in EDNS CRD requires a CRD schema update. (See [documentation](https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/ExternalDNS))

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -18,9 +18,10 @@ package controller
 
 import (
 	"container/list"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"net/http"
 	"sync"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	routeclient "github.com/openshift/client-go/route/clientset/versioned/typed/route/v1"
 
@@ -288,11 +289,12 @@ type (
 	}
 
 	GSLBPool struct {
-		Name       string    `json:"name"`
-		RecordType string    `json:"recordType"`
-		LBMethod   string    `json:"LoadBalancingMode"`
-		Members    []string  `json:"members"`
-		Monitors   []Monitor `json:"monitors,omitempty"`
+		Name          string    `json:"name"`
+		RecordType    string    `json:"recordType"`
+		LBMethod      string    `json:"LoadBalancingMode"`
+		PriorityOrder int       `json:"order"`
+		Members       []string  `json:"members"`
+		Monitors      []Monitor `json:"monitors,omitempty"`
 	}
 
 	ResourceConfigRequest struct {

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -2209,9 +2209,10 @@ func (ctlr *Controller) processExternalDNS(edns *cisapiv1.ExternalDNS, isDelete 
 		UniquePoolName := edns.Spec.DomainName + "_" + strings.ReplaceAll(edns.GetCreationTimestamp().Format(time.RFC3339Nano), ":", "-")
 		log.Debugf("Processing WideIP Pool: %v", UniquePoolName)
 		pool := GSLBPool{
-			Name:       UniquePoolName,
-			RecordType: pl.DNSRecordType,
-			LBMethod:   pl.LoadBalanceMethod,
+			Name:          UniquePoolName,
+			RecordType:    pl.DNSRecordType,
+			LBMethod:      pl.LoadBalanceMethod,
+			PriorityOrder: pl.PriorityOrder,
 		}
 
 		if pl.DNSRecordType == "" {

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/f5devcentral/f5-ctlr-agent.git@fced6f20bb0e360bcf3c4fdda6075c468e00973d#egg=f5-ctlr-agent
+-e git+https://github.com/f5devcentral/f5-ctlr-agent.git@2d27867ee90d7fc1bfde9d07e24799410c772b03#egg=f5-ctlr-agent
 -e git+https://github.com/f5devcentral/f5-cccl.git@09fc9e609b54a0d5eccb593a57834395db0edf4c#egg=f5-cccl


### PR DESCRIPTION
Signed-off-by: Sravya Pondugula <sravyap135@gmail.com>

**Description**: 
- Support GTM global-availability mode and order precedence with EDNS.
- With global-availability LB mode,  BIG-IP GTM distributes DNS name resolution requests to the first available virtual server in a pool. BIG-IP GTM starts at the top of a manually configured list of virtual servers and sends requests to the first available virtual server in the list. Only when the virtual server becomes unavailable does BIG-IP GTM send requests to the next virtual server in the list. Over time, the first virtual server in the list receives the most requests and the last virtual server in the list receives the least requests.

**Changes Proposed in PR**:
- https://github.com/f5devcentral/f5-ctlr-agent/pull/64
- Support new order parameter in EDNS spec.pools[]


## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation

## CRD Checklist
- [x] Updated required CR schema