### PR TITLE
Fix to pick global config when local configMap is deleted

### DIFF
--- a/pkg/controller/nativeResourceWorker.go
+++ b/pkg/controller/nativeResourceWorker.go
@@ -758,7 +758,12 @@ func (ctlr *Controller) getLatestLocalConfigMap(ns string) *v1.ConfigMap {
 		return nil
 	}
 
-	objList := inf.cmInformer.GetIndexer().List()
+	objList, err := inf.cmInformer.GetIndexer().ByIndex("namespace", ns)
+
+	if err != nil {
+		log.Errorf("Unable to fetch local config map from namespace: %v ", ns)
+		return nil
+	}
 
 	if len(objList) == 0 {
 		return nil


### PR DESCRIPTION
**Description**:  CIS is not reverting the global policies when local configMap is deleted

**Changes Proposed in PR**: When a local config map is deleted we are looking for the configMap in the respective namespace and then CIS will fallback to Global configMap

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema