### PR TITLE
Added missing clusterrole permission for routes in OpenShift

### DIFF
--- a/docs/config_examples/rbac/clusterrole.yaml
+++ b/docs/config_examples/rbac/clusterrole.yaml
@@ -5,11 +5,11 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: bigip-ctlr-clusterrole
 rules:
-  - apiGroups: ["", "extensions", "networking.k8s.io"]
-    resources: ["nodes", "services", "endpoints", "namespaces", "ingresses", "pods", "ingressclasses", "policies"]
+  - apiGroups: ["", "extensions", "networking.k8s.io", "route.openshift.io"]
+    resources: ["nodes", "services", "endpoints", "namespaces", "ingresses", "pods", "ingressclasses", "policies", "routes"]
     verbs: ["get", "list", "watch"]
-  - apiGroups: ["", "extensions", "networking.k8s.io"]
-    resources: ["configmaps", "events", "ingresses/status", "services/status"]
+  - apiGroups: ["", "extensions", "networking.k8s.io", "route.openshift.io"]
+    resources: ["configmaps", "events", "ingresses/status", "services/status", "routes/status"]
     verbs: ["get", "list", "watch", "update", "create", "patch"]
   - apiGroups: ["cis.f5.com"]
     resources: ["virtualservers","virtualservers/status", "tlsprofiles", "transportservers", "transportservers/status", "ingresslinks", "ingresslinks/status", "externaldnses", "policies"]


### PR DESCRIPTION
**Description**:  Upgrade Process includes clusterrole with missing statements in section “Upgrading from 2.4.0 to 2.5.0”

**Changes Proposed in PR**: Updated cluster roles to provide access to routes resource for service account

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema