### PR TITLE
Enqueue update event for resources during node update

### DIFF
--- a/pkg/controller/node_poll_handler.go
+++ b/pkg/controller/node_poll_handler.go
@@ -98,7 +98,7 @@ func (ctlr *Controller) ProcessNodeUpdate(
 								VirtualServer,
 								vs.ObjectMeta.Name,
 								vs,
-								Create,
+								Update,
 							}
 							ctlr.rscQueue.Add(qKey)
 						}
@@ -112,7 +112,7 @@ func (ctlr *Controller) ProcessNodeUpdate(
 								TransportServer,
 								vs.ObjectMeta.Name,
 								vs,
-								Create,
+								Update,
 							}
 							ctlr.rscQueue.Add(qKey)
 						}
@@ -130,7 +130,7 @@ func (ctlr *Controller) ProcessNodeUpdate(
 								VirtualServer,
 								virtual.ObjectMeta.Name,
 								virtual,
-								Create,
+								Update,
 							}
 							ctlr.rscQueue.Add(qKey)
 						}
@@ -140,7 +140,7 @@ func (ctlr *Controller) ProcessNodeUpdate(
 								TransportServer,
 								virtual.ObjectMeta.Name,
 								virtual,
-								Create,
+								Update,
 							}
 							ctlr.rscQueue.Add(qKey)
 						}


### PR DESCRIPTION
**Description**:  Enqueue update event for resources during node update

**Changes Proposed in PR**:
- Previously, create event was getting enqueued, and since the resource is already processed, the resource wasn't getting processed. Fixed to include an update event while enqueuing