### PR TITLE
Fix for confusing EDNS Pool name

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -1,6 +1,12 @@
 Release Notes for Container Ingress Services for Kubernetes & OpenShift
 =======================================================================
 
+Next Release
+-------------
+Bug Fixes
+````````````
+* :issues:`2336` Fix for confusing EDNS Pool name
+
 2.9.0
 -------------
 Added Functionality

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -1327,8 +1327,10 @@ func AS3NameFormatter(name string) string {
 		"/": "_",
 		"%": ".",
 		"-": "_",
+		"[": "",
+		"]": "",
 		"=": "_"}
-	SpecialChars := [6]string{".", ":", "/", "%", "-", "="}
+	SpecialChars := [8]string{".", ":", "/", "%", "-", "[", "]", "="}
 	for _, key := range SpecialChars {
 		name = strings.ReplaceAll(name, key, modifySpecialChars[key])
 	}

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -2239,7 +2239,7 @@ func (ctlr *Controller) processExternalDNS(edns *cisapiv1.ExternalDNS, isDelete 
 	log.Debugf("Processing WideIP: %v", edns.Spec.DomainName)
 
 	for _, pl := range edns.Spec.Pools {
-		UniquePoolName := edns.Spec.DomainName + "_" + strings.ReplaceAll(edns.GetCreationTimestamp().Format(time.RFC3339Nano), ":", "-")
+		UniquePoolName := edns.Spec.DomainName + "_" + AS3NameFormatter(strings.TrimPrefix(ctlr.Agent.BIGIPURL, "https://")) + "_" + ctlr.Partition
 		log.Debugf("Processing WideIP Pool: %v", UniquePoolName)
 		pool := GSLBPool{
 			Name:          UniquePoolName,

--- a/pkg/controller/worker_test.go
+++ b/pkg/controller/worker_test.go
@@ -70,6 +70,14 @@ var _ = Describe("Worker Tests", func() {
 				IRules:           nil,
 				ServiceIPAddress: nil,
 			})
+		mockCtlr.Partition = "test"
+		mockCtlr.Agent = &Agent{
+			PostManager: &PostManager{
+				PostParams: PostParams{
+					BIGIPURL: "10.10.10.1",
+				},
+			},
+		}
 		mockCtlr.kubeCRClient = crdfake.NewSimpleClientset(vrt1)
 		mockCtlr.kubeClient = k8sfake.NewSimpleClientset(svc1)
 		mockCtlr.mode = CustomResourceMode


### PR DESCRIPTION
Signed-off-by: Vivek Lohiya <vklohiya@live.com>

**Description**:  Fix for confusing EDNS Pool name

**Changes Proposed in PR**: Instead of unique timestamp we will be using the bigip hostname and partition for creating the poolName.

**Fixes**: resolves #2336

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed
