### PR TITLE
Changes in Pool and Monitor Name Format for CRD

### DIFF
--- a/pkg/controller/nativeResourceWorker.go
+++ b/pkg/controller/nativeResourceWorker.go
@@ -457,6 +457,7 @@ func (ctlr *Controller) prepareResourceConfigFromRoute(
 			route.Spec.To.Name,
 			servicePort,
 			"",
+			"",
 		),
 		Partition:       rsCfg.Virtual.Partition,
 		ServiceName:     route.Spec.To.Name,

--- a/pkg/controller/resourceConfig_test.go
+++ b/pkg/controller/resourceConfig_test.go
@@ -101,11 +101,11 @@ var _ = Describe("Resource Config Tests", func() {
 			Expect(name).To(Equal("My_VS_80"), "Invalid VirtualServer Name")
 		})
 		It("Pool Name", func() {
-			name := formatPoolName(namespace, "svc1", intstr.IntOrString{IntVal: 80}, "app=test")
-			Expect(name).To(Equal("svc1_80_default_app_test"), "Invalid Pool Name")
+			name := formatPoolName(namespace, "svc1", intstr.IntOrString{IntVal: 80}, "app=test", "foo")
+			Expect(name).To(Equal("svc1_80_default_foo_app_test"), "Invalid Pool Name")
 		})
 		It("Monitor Name", func() {
-			name := formatMonitorName(namespace, "svc1", "http", 80)
+			name := formatMonitorName(namespace, "svc1", "http", 80, "")
 			Expect(name).To(Equal("svc1_default_http_80"), "Invalid Monitor Name")
 		})
 		It("Rule Name", func() {

--- a/pkg/controller/routing.go
+++ b/pkg/controller/routing.go
@@ -79,6 +79,7 @@ func (ctlr *Controller) prepareVirtualServerRules(
 			vs.ObjectMeta.Namespace,
 			pl,
 			intstr.IntOrString{IntVal: pl.ServicePort},
+			vs.Spec.Host,
 		)
 		ruleName := formatVirtualServerRuleName(vs.Spec.Host, vs.Spec.HostGroup, path, poolName)
 		var err error

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -2547,6 +2547,7 @@ func (ctlr *Controller) processIngressLink(
 				svc.ObjectMeta.Name,
 				svcPort,
 				"",
+				"",
 			),
 			Partition:   rsCfg.Virtual.Partition,
 			ServiceName: svc.ObjectMeta.Name,


### PR DESCRIPTION
**Description**:  Changes in Pool and Monitor Name Format for CRD to support HostGroup with same path and same service-name with different host and health monitor strings.

**Changes Proposed in PR**:

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema