### PR TITLE
Fix for empty pool members in AS3 declaration in case of hubmode

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -9,6 +9,7 @@ Bug Fixes
 * :issues:`2337` Fix for EDNS pool deletion with invalid server config
 * Fix Invalid Allow with Custom HTTP Port
 * :issues:`2484` Fix scalability issue with IPAM processing
+* :issues:`2464` Fix pool members empty issue with HubMode
 
 FIC Bug Fixes
 `````````````


### PR DESCRIPTION
**Description**:  Fix for empty pool members in AS3 declaration in case of hubmode

**Changes Proposed in PR**:  Replaced use of endpoint informer with kubeclient to fetch endpoints as in case of hubmode with namespace specified, cis doesn't watch all namespaces.

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema