### PR TITLE
Allow allowOverride value to be a string in nextgen route spec

### DIFF
--- a/pkg/controller/nativeResourceWorker_test.go
+++ b/pkg/controller/nativeResourceWorker_test.go
@@ -2,10 +2,11 @@ package controller
 
 import (
 	"fmt"
+	"time"
+
 	"github.com/F5Networks/k8s-bigip-ctlr/pkg/teem"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"time"
 
 	"github.com/F5Networks/k8s-bigip-ctlr/pkg/test"
 	. "github.com/onsi/ginkgo"
@@ -73,7 +74,7 @@ var _ = Describe("Routes", func() {
 				global: &ExtendedRouteGroupSpec{
 					VServerName:    "samplevs",
 					VServerAddr:    "10.10.10.10",
-					AllowOverride:  false,
+					AllowOverride:  "false",
 					SNAT:           "auto",
 					WAF:            "/Common/WAFPolicy",
 					IRules:         []string{"/Common/iRule1"},
@@ -92,7 +93,7 @@ var _ = Describe("Routes", func() {
 				global: &ExtendedRouteGroupSpec{
 					VServerName:   "samplevs",
 					VServerAddr:   "10.10.10.10",
-					AllowOverride: false,
+					AllowOverride: "False",
 					SNAT:          "auto",
 					WAF:           "/Common/WAFPolicy",
 					IRules:        []string{"/Common/iRule1"},
@@ -379,6 +380,20 @@ extendedRouteSpec:
     - namespace: default
       vserverAddr: 10.8.3.11
       vserverName: nextgenroutes
+      allowOverride: invalid
+    - namespace: new
+      vserverAddr: 10.8.3.12
+      allowOverride: true
+`
+			err, ok = mockCtlr.processConfigMap(cm, false)
+			Expect(err).ToNot(BeNil(), "invalid allowOverride value")
+			Expect(ok).To(BeFalse())
+
+			data["extendedSpec"] = `
+extendedRouteSpec:
+    - namespace: default
+      vserverAddr: 10.8.3.11
+      vserverName: nextgenroutes
       allowOverride: true
     - namespace: new
       vserverAddr: 10.8.3.12
@@ -567,7 +582,7 @@ extendedRouteSpec:
 					VServerName:   "defaultServer",
 					VServerAddr:   "10.8.3.11",
 					WAF:           "/Common/defaultWAF",
-					AllowOverride: false,
+					AllowOverride: "0",
 				},
 			}
 			newExtdSpecMap["new"] = &extendedParsedSpec{
@@ -577,7 +592,7 @@ extendedRouteSpec:
 					VServerName:   "newServer",
 					VServerAddr:   "10.8.3.12",
 					WAF:           "/Common/newWAF",
-					AllowOverride: false,
+					AllowOverride: "f",
 				},
 			}
 			deletedSpecs, modifiedSpecs, updatedSpecs, createdSpecs := getOperationalExtendedConfigMapSpecs(
@@ -595,7 +610,7 @@ extendedRouteSpec:
 					VServerName:   "defaultServer",
 					VServerAddr:   "10.8.3.11",
 					WAF:           "/Common/defaultWAF",
-					AllowOverride: false,
+					AllowOverride: "false",
 				},
 			}
 			cachedExtdSpecMap["new"] = &extendedParsedSpec{
@@ -605,7 +620,7 @@ extendedRouteSpec:
 					VServerName:   "newServer",
 					VServerAddr:   "10.8.3.12",
 					WAF:           "/Common/newWAF",
-					AllowOverride: false,
+					AllowOverride: "FALSE",
 				},
 			}
 
@@ -647,7 +662,7 @@ extendedRouteSpec:
 					VServerName:   "defaultServer",
 					VServerAddr:   "10.8.3.11",
 					WAF:           "/Common/defaultWAF",
-					AllowOverride: false,
+					AllowOverride: "false",
 				},
 			}
 			deletedSpecs, modifiedSpecs, updatedSpecs, createdSpecs = getOperationalExtendedConfigMapSpecs(

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -20,13 +20,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/client-go/tools/cache"
 	"net"
 	"reflect"
 	"sort"
 	"strconv"
 	"strings"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/tools/cache"
 
 	routeapi "github.com/openshift/api/route/v1"
 

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -18,9 +18,10 @@ package controller
 
 import (
 	"container/list"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	"net/http"
 	"sync"
+
+	"k8s.io/apimachinery/pkg/util/intstr"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
@@ -928,7 +929,7 @@ type (
 	ExtendedRouteGroupSpec struct {
 		VServerName    string   `yaml:"vserverName"`
 		VServerAddr    string   `yaml:"vserverAddr"`
-		AllowOverride  bool     `yaml:"allowOverride"`
+		AllowOverride  string   `yaml:"allowOverride"`
 		SNAT           string   `yaml:"snat"`
 		WAF            string   `yaml:"waf"`
 		IRules         []string `yaml:"iRules,omitempty"`


### PR DESCRIPTION
Signed-off-by: Sravya Pondugula <sravyap135@gmail.com>

**Description**:  Allow allowOverride value to be a string in nextgen route spec

**Changes Proposed in PR**:
- modify allowOverride value to be string 
- added and modified UT 

**Fixes**: internal 