### PR TITLE
Revert "Add Timeit function for timecost calculations."

### DIFF
--- a/pkg/agent/as3/as3Common.go
+++ b/pkg/agent/as3/as3Common.go
@@ -60,8 +60,6 @@ func (am *AS3Manager) validateAS3Template(template string) bool {
 }
 
 func (am *AS3Manager) processResourcesForAS3(sharedApp as3Application) {
-	defer log.Timeit("debug")("")
-
 	for _, cfg := range am.Resources.RsCfgs {
 		//Create policies
 		createPoliciesDecl(cfg, sharedApp)

--- a/pkg/agent/as3/as3Manager.go
+++ b/pkg/agent/as3/as3Manager.go
@@ -213,7 +213,6 @@ func updateTenantMap(tempAS3Config AS3Config) AS3Config {
 }
 
 func (am *AS3Manager) postAS3Declaration(rsReq ResourceRequest) (bool, string) {
-	defer log.Timeit("debug")("")
 
 	am.ResourceRequest = rsReq
 

--- a/pkg/agent/as3/as3Resource.go
+++ b/pkg/agent/as3/as3Resource.go
@@ -25,7 +25,6 @@ import (
 )
 
 func (am *AS3Manager) prepareAS3ResourceConfig() as3ADC {
-	defer log.Timeit("debug")("")
 	adc := am.generateAS3ResourceDeclaration()
 	// Support `Controls` class for TEEMs in user-defined AS3 configMap.
 	controlObj := make(as3Control)
@@ -35,8 +34,6 @@ func (am *AS3Manager) prepareAS3ResourceConfig() as3ADC {
 }
 
 func (am *AS3Manager) generateAS3ResourceDeclaration() as3ADC {
-	defer log.Timeit("debug")("")
-
 	// Create Shared as3Application object for Routes
 	adc := as3ADC{}
 	adc.initDefault(DEFAULT_PARTITION, am.defaultRouteDomain)

--- a/pkg/appmanager/agentRequestHandler.go
+++ b/pkg/appmanager/agentRequestHandler.go
@@ -3,13 +3,10 @@ package appmanager
 import (
 	cisAgent "github.com/F5Networks/k8s-bigip-ctlr/pkg/agent"
 	. "github.com/F5Networks/k8s-bigip-ctlr/pkg/resource"
-
-	log "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
 )
 
 // Method to deploy resources on configured agent
 func (appMgr *Manager) deployResource() error {
-	defer log.Timeit("debug")("")
 	// Generate Agent Request
 
 	// Prepare Custom Profiles Copy

--- a/pkg/vlogger/log.go
+++ b/pkg/vlogger/log.go
@@ -21,9 +21,7 @@ import (
 	"fmt"
 	"log/syslog" // For LOG level definitions
 	"os"
-	"runtime"
 	"strings"
-	"time"
 )
 
 // LogLevel is used for global (package-level) filtering of log messages based on their priority
@@ -249,36 +247,6 @@ func Panicf(format string, params ...interface{}) {
 	msg := fmt.Sprintf(format, params...)
 	vlog[LL_CRITICAL].Critical(msg)
 	panic(msg)
-}
-
-// Timeit send a debug or info message to the logger object.
-// It will help to calculate function level execution timecosts.
-// Usage:
-// 1) Add `defer log.Timeit("[debug|info]")(msg)` to the beginning of the function.
-// 2) Calculate the timecost of partial logic of a function by:
-//    Get tmFunc at the start of the code piece:
-//      `tmFunc := log.Timeit("debug")`
-//    Run tmFunc at the end of the code piece:
-//      `tmFunc("Some valuable info as fmt.Printf, %s", x)`
-func Timeit(logLevel string) func(format string, a ...interface{}) {
-	pc := make([]uintptr, 1)
-	runtime.Callers(2, pc)
-	f := runtime.FuncForPC(pc[0])
-
-	level := NewLogLevel(logLevel)
-
-	start := time.Now()
-
-	return func(format string, a ...interface{}) {
-		tc := time.Since(start)
-		exstr := fmt.Sprintf(format, a...)
-		if *level == LL_DEBUG {
-			fn, ln := f.FileLine(pc[0])
-			Debugf("%s %d %s (%d ms): %s", fn, ln, f.Name(), tc.Milliseconds(), exstr)
-		} else {
-			Infof("%s (%d ms): %s", f.Name(), tc.Milliseconds(), exstr)
-		}
-	}
 }
 
 // SetLogLevel sets the current package-level filtering

--- a/pkg/vxlan/vxlanMgr.go
+++ b/pkg/vxlan/vxlanMgr.go
@@ -214,8 +214,6 @@ func (vxm *VxlanMgr) ProcessAppmanagerEvents(kubeClient kubernetes.Interface) {
 }
 
 func (vxm *VxlanMgr) addArpForPods(pods interface{}, kubeClient kubernetes.Interface) {
-	defer log.Timeit("debug")("")
-
 	arps := arpSection{}
 	kubePods, err := kubeClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
 	if nil != err {


### PR DESCRIPTION
Reverts F5Networks/k8s-bigip-ctlr#2194


@zongzw , After integration we are observing that these logs are very frequent and almost increase the CIS logs by 33%. 

As it's not used by any customer, I would advice you to move it to a new log level called TRACE or Otherwise you can also create a new environment variable to enable such logs only for your usecase.