### PR TITLE
Enable shareNodes by default for pool-member-type NodePort

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -140,6 +140,11 @@ func NewController(params Params) *Controller {
 			workqueue.DefaultControllerRateLimiter(), "custom-resource-controller")
 	}
 
+	//If pool-member-type type is nodeport, enable shareNodes by default
+	if ctlr.PoolMemberType == "nodeport" {
+		ctlr.shareNodes = true
+	}
+
 	if err := ctlr.setupClients(params.Config); err != nil {
 		log.Errorf("Failed to Setup Clients: %v", err)
 	}


### PR DESCRIPTION
**Description**:  [GITLAB #919] [NextGenRoutes] CIS havent enabled sharedNodes for NodePort mode

**Changes Proposed in PR**: if pool-member-type is nodeport enabled shareNodes by default

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema