### PR TITLE
Added support for netmask for Virtual server

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -1185,6 +1185,7 @@ func getAppManagerParams() appmanager.Params {
 		ProcessAgentLabels:     getProcessAgentLabelFunc(),
 		DefaultRouteDomain:     *defaultRouteDomain,
 		PoolMemberType:         *poolMemberType,
+		Agent:                  *agent,
 	}
 }
 

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -9,7 +9,7 @@ Added Functionality
 * Added Support for AS3 3.38.0
 * CRD:
         * AllowSourceRange support for VirtualServer CRs and Policy CRs. See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/>`_
-
+* Added support to configure netmask for Virtual Server for Ingress. See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/ingress/>`_
 Bug Fixes
 ````````````
 * :issues:`2361` Allow monitoring of an alias port in VirtualServer and TransportServer

--- a/docs/config_examples/ingress/ingress-with-vs-ip-cidr.yaml
+++ b/docs/config_examples/ingress/ingress-with-vs-ip-cidr.yaml
@@ -1,0 +1,22 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    # Virtual server IP address with CIDR
+    virtual-server.f5.com/ip: 10.8.0.4/31
+  name: ingress-svc-foo
+  namespace: default
+spec:
+  rules:
+    - host: foo.com
+      http:
+        paths:
+          - backend:
+              service:
+                name: svc-1
+                port:
+                  number: 80
+            path: /foo
+            pathType: ImplementationSpecific
+  tls:
+    - secretName: foo-secret

--- a/pkg/agent/as3/as3Utils.go
+++ b/pkg/agent/as3/as3Utils.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"regexp"
 	"strconv"
 	"strings"
 
@@ -143,6 +144,13 @@ func DeepEqualJSON(decl1, decl2 as3Declaration) bool {
 
 func ExtractVirtualAddressAndPort(str string) (string, int) {
 	destination := strings.Split(str, "/")
+	// Handle CIDR if specified
+	if len(destination) >= 2 {
+		matched, _ := regexp.MatchString(`(^\d+[:.]\d+$)|(^\d+%\d+[:.]\d+$)`, destination[len(destination)-1])
+		if matched {
+			destination[len(destination)-1] = destination[len(destination)-2] + "/" + destination[len(destination)-1]
+		}
+	}
 	// split separator is in accordance with SetVirtualAddress function - ipv4/6 format
 	ipPort := strings.Split(destination[len(destination)-1], ":")
 	if len(ipPort) != 2 {

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -147,6 +147,7 @@ type Manager struct {
 	nplStore map[string]NPLAnnoations
 	// Mutex to control access to nplStore map
 	nplStoreMutex sync.Mutex
+	AgentName     string
 }
 
 // Store of processed host-Path map
@@ -312,6 +313,7 @@ func NewManager(params *Params) *Manager {
 		agentCfgMapSvcCache:    make(map[string]*SvcEndPointsCache),
 		defaultRouteDomain:     params.DefaultRouteDomain,
 		poolMemberType:         params.PoolMemberType,
+		AgentName:              params.Agent,
 	}
 	manager.processedResources = make(map[string]bool)
 	manager.processedHostPath.processedHostPathMap = make(map[string]metav1.Time)
@@ -3025,7 +3027,7 @@ func (appMgr *Manager) setIngressStatus(
 	appInf *appInformer,
 ) {
 	// Set the ingress status to include the virtual IP
-	ip, _ := Split_ip_with_route_domain(rsCfg.Virtual.VirtualAddress.BindAddr)
+	ip, _, _ := Split_ip_with_route_domain_cidr(rsCfg.Virtual.VirtualAddress.BindAddr)
 	lbIngress := v1.LoadBalancerIngress{IP: ip}
 	if len(ing.Status.LoadBalancer.Ingress) == 0 {
 		ing.Status.LoadBalancer.Ingress = append(ing.Status.LoadBalancer.Ingress, lbIngress)

--- a/pkg/appmanager/resourceConfig.go
+++ b/pkg/appmanager/resourceConfig.go
@@ -282,7 +282,7 @@ func (appMgr *Manager) createRSConfigFromIngress(
 		cfg.Virtual.Enabled = true
 		SetProfilesForMode("http", &cfg)
 		cfg.Virtual.SourceAddrTranslation = SetSourceAddrTranslation(snatPoolName)
-		cfg.Virtual.SetVirtualAddress(bindAddr, pStruct.port)
+		cfg.Virtual.SetVirtualAddress(bindAddr, pStruct.port, true)
 		cfg.Pools = append(cfg.Pools, pools...)
 		if plcy != nil {
 			cfg.SetPolicy(*plcy)
@@ -547,7 +547,7 @@ func (appMgr *Manager) createRSConfigFromRoute(
 		if routeConfig.RouteVSAddr != "" {
 			bindAddr = routeConfig.RouteVSAddr
 		}
-		rsCfg.Virtual.SetVirtualAddress(bindAddr, pStruct.port)
+		rsCfg.Virtual.SetVirtualAddress(bindAddr, pStruct.port, true)
 		rsCfg.Pools = append(rsCfg.Pools, pool)
 	}
 

--- a/pkg/appmanager/schema.go
+++ b/pkg/appmanager/schema.go
@@ -30,13 +30,17 @@ type BigIPv4FormatChecker struct{}
 
 func (f BigIPv4FormatChecker) IsFormat(input interface{}) bool {
 	var strInput = input.(string)
-	ip, rd := Split_ip_with_route_domain(strInput)
+	ip, rd, cidr := Split_ip_with_route_domain_cidr(strInput)
 	if rd != "" {
 		if _, err := strconv.Atoi(rd); err != nil {
 			return false
 		}
 	}
-
+	if cidr != "" {
+		if _, _, err := net.ParseCIDR(ip + "/" + cidr); err != nil {
+			return false
+		}
+	}
 	address := net.ParseIP(ip)
 	if nil == address.To4() {
 		return false
@@ -48,13 +52,17 @@ type BigIPv6FormatChecker struct{}
 
 func (f BigIPv6FormatChecker) IsFormat(input interface{}) bool {
 	var strInput = input.(string)
-	ip, rd := Split_ip_with_route_domain(strInput)
+	ip, rd, cidr := Split_ip_with_route_domain_cidr(strInput)
 	if rd != "" {
 		if _, err := strconv.Atoi(rd); err != nil {
 			return false
 		}
 	}
-
+	if cidr != "" {
+		if _, _, err := net.ParseCIDR(ip + "/" + cidr); err != nil {
+			return false
+		}
+	}
 	address := net.ParseIP(ip)
 	if nil == address.To16() {
 		return false

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -1103,6 +1103,7 @@ func createRuleAction(rl *Rule, rulesData *as3Rule) {
 
 //Extract virtual address and port from host URL
 func extractVirtualAddressAndPort(str string) (string, int) {
+
 	destination := strings.Split(str, "/")
 	// split separator is in accordance with SetVirtualAddress function - ipv4/6 format
 	ipPort := strings.Split(destination[len(destination)-1], ":")

--- a/pkg/resource/resourceConfig_test.go
+++ b/pkg/resource/resourceConfig_test.go
@@ -52,7 +52,7 @@ func newResourceConfig(
 	cfg.Pools[0].ServiceName = key.ServiceName
 	cfg.Pools[0].ServicePort = key.ServicePort
 	cfg.Virtual.Name = rsName
-	cfg.Virtual.SetVirtualAddress(bindAddr, bindPort)
+	cfg.Virtual.SetVirtualAddress(bindAddr, bindPort, false)
 	return &cfg
 }
 
@@ -492,6 +492,40 @@ var _ = Describe("Resource Config Tests", func() {
 			Expect(len(added)).To(BeZero())
 			Expect(len(removed)).To(Equal(4))
 			Expect(len(rs.objDeps)).To(BeZero())
+		})
+
+		It("Verifies whether netmask is set properly", func() {
+			v := Virtual{}
+			v.SetVirtualAddressNetMask("1.2.3.4")
+			Expect(v.Mask).To(Equal(""))
+
+			v.SetVirtualAddressNetMask("1.2.3.4/31")
+			Expect(v.Mask).To(Equal("255.255.255.254"))
+
+			v.Mask = ""
+			v.SetVirtualAddressNetMask("1.2.3.4/30%5")
+			Expect(v.Mask).To(Equal("255.255.255.252"))
+
+			v.Mask = ""
+			v.SetVirtualAddressNetMask("1.2.3.4%5/30")
+			Expect(v.Mask).To(Equal(""))
+
+			v.Mask = ""
+			v.SetVirtualAddressNetMask("2001:0DB8:ABCD:0012:0000:0000:0000:0000")
+			Expect(v.Mask).To(Equal(""))
+
+			v.Mask = ""
+			v.SetVirtualAddressNetMask("2001:1234:5678:1234:5678:ABCD:EF12:1234/64")
+			Expect(v.Mask).To(Equal("ffff:ffff:ffff:ffff:0000:0000:0000:0000"))
+
+			v.Mask = ""
+			v.SetVirtualAddressNetMask("2002::1234:abcd:ffff:c0a8:101/31")
+			Expect(v.Mask).To(Equal("ffff:fffe:0000:0000:0000:0000:0000:0000"))
+
+			v.Mask = ""
+			v.SetVirtualAddressNetMask("2002::1234:abcd:ffff:c0a8:101/30%5")
+			Expect(v.Mask).To(Equal("ffff:fffc:0000:0000:0000:0000:0000:0000"))
+
 		})
 	})
 

--- a/pkg/resource/routeDomain_test.go
+++ b/pkg/resource/routeDomain_test.go
@@ -24,38 +24,80 @@ import (
 var _ = Describe("Route Domain", func() {
 	It("split_ip_with_route_domain", func() {
 		type testDataType struct {
-			address    string
-			expectedIP string
-			expectedRD string
+			address      string
+			expectedIP   string
+			expectedRD   string
+			expectedCIDR string
 		}
 		testData := []testDataType{
 			{
-				address:    "",
-				expectedIP: "",
-				expectedRD: "",
+				address:      "",
+				expectedIP:   "",
+				expectedRD:   "",
+				expectedCIDR: "",
 			}, {
-				address:    "1.2.3.4",
-				expectedIP: "1.2.3.4",
-				expectedRD: "",
+				address:      "1.2.3.4",
+				expectedIP:   "1.2.3.4",
+				expectedRD:   "",
+				expectedCIDR: "",
 			}, {
-				address:    "fe80::",
-				expectedIP: "fe80::",
-				expectedRD: "",
+				address:      "fe80::",
+				expectedIP:   "fe80::",
+				expectedRD:   "",
+				expectedCIDR: "",
 			}, {
-				address:    "1.2.3.4%56",
-				expectedIP: "1.2.3.4",
-				expectedRD: "56",
+				address:      "1.2.3.4%56",
+				expectedIP:   "1.2.3.4",
+				expectedRD:   "56",
+				expectedCIDR: "",
 			}, {
-				address:    "fe80::%0",
-				expectedIP: "fe80::",
-				expectedRD: "0",
+				address:      "fe80::%0",
+				expectedIP:   "fe80::",
+				expectedRD:   "0",
+				expectedCIDR: "",
+			}, {
+				address:      "fe80::/40",
+				expectedIP:   "fe80::",
+				expectedRD:   "",
+				expectedCIDR: "40",
+			}, {
+				address:      "1.2.3.4/31",
+				expectedIP:   "1.2.3.4",
+				expectedRD:   "",
+				expectedCIDR: "31",
+			}, {
+				address:      "1.2.3.4/31%56",
+				expectedIP:   "1.2.3.4",
+				expectedRD:   "56",
+				expectedCIDR: "31",
+			}, {
+				address:      "fe80::/35%5",
+				expectedIP:   "fe80::",
+				expectedRD:   "5",
+				expectedCIDR: "35",
+			}, {
+				address:      "1.2.3.4%56/31",
+				expectedIP:   "1.2.3.4%56/31",
+				expectedRD:   "",
+				expectedCIDR: "",
+			}, {
+				address:      "fe80::%5/35",
+				expectedIP:   "fe80::%5/35",
+				expectedRD:   "",
+				expectedCIDR: "",
+			}, {
+				address:      "fe80::%ab",
+				expectedIP:   "fe80::%ab",
+				expectedRD:   "",
+				expectedCIDR: "",
 			},
 		}
 
 		for _, td := range testData {
-			ip, rd := Split_ip_with_route_domain(td.address)
+			ip, rd, cidr := Split_ip_with_route_domain_cidr(td.address)
 			Expect(ip).To(Equal(td.expectedIP))
 			Expect(rd).To(Equal(td.expectedRD))
+			Expect(cidr).To(Equal(td.expectedCIDR))
 		}
 	})
 })

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -95,6 +95,7 @@ type (
 		Profiles              ProfileRefs           `json:"profiles,omitempty"`
 		Description           string                `json:"description,omitempty"`
 		VirtualAddress        *VirtualAddress       `json:"-"`
+		Mask                  string                `json:"mask,omitempty"`
 	}
 	Virtuals []Virtual
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 -e git+https://github.com/f5devcentral/f5-ctlr-agent.git@cf60fe8b70b1159aed7cce931a98a7e5169d4aef#egg=f5-ctlr-agent
--e git+https://github.com/f5devcentral/f5-cccl.git@c3ba16f7684f3da078a11f795dda8458e925b97d#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@01bc6986261a8b33af9c5ba3bde75e7c42a8614e#egg=f5-cccl


### PR DESCRIPTION
**Description**:  Added support to configure netmask for Virtual Server for Ingress

**Changes Proposed in PR**: CIDR notation is allowed for virtual-server.f5.com/ip in the annotation of ingress resources.

**Fixes**: resolves #1850

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema