### PR TITLE
Added support for BigIP ClientSSL/ServerSSL profile reference in NextGen Routes

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -10,6 +10,7 @@ Added Functionality
 **What’s new:**
     * Next generation routes
         * Added support for namespaceLabel in global extended ConfigMap
+        * Added support for BigIP ClientSSL/ServerSSL profile reference in global extended ConfigMap
     * CRD:
         * AllowSourceRange support for VirtualServer CRs and Policy CRs. See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/>`_
     * Added support to configure netmask for Virtual Server for Ingress. See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/ingress/>`_

--- a/docs/config_examples/nativeResources/configmap/extendedRouteConfig.yaml
+++ b/docs/config_examples/nativeResources/configmap/extendedRouteConfig.yaml
@@ -10,6 +10,10 @@ data:
       vserverAddr: 10.8.3.11
       vserverName: nextgenroutes
       allowOverride: true
+      tls:
+        clientSSL: /Common/clientssl
+        serverSSL: /Common/serverssl
+        reference: bigip
       healthMonitors:
       - path: "mysite1.f5demo.com/app/health"
         send: "HTTP GET /"

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -1024,6 +1024,13 @@ type (
 		SNAT           string   `yaml:"snat"`
 		WAF            string   `yaml:"waf"`
 		IRules         []string `yaml:"iRules,omitempty"`
+		TLS            TLS      `yaml:"tls"`
 		HealthMonitors Monitors `yaml:"healthMonitors,omitempty"`
+	}
+
+	TLS struct {
+		ClientSSL string `yaml:"clientSSL,omitempty"`
+		ServerSSL string `yaml:"serverSSL,omitempty"`
+		Reference string `yaml:"reference,omitempty"`
 	}
 )


### PR DESCRIPTION
**Description**:  Add support for BigIP ClientSSL/ServerSSL profile in NextGen Routes

**Changes Proposed in PR**: Added support to refer to bigip ClientSSL/ServerSSL 

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema