### PR TITLE
Add support for log-file to store the CIS logs

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -11,22 +11,25 @@ Added Functionality
     * Next generation routes
         * Added support for namespaceLabel in global extended ConfigMap
         * Added support for BigIP ClientSSL/ServerSSL profile reference in global extended ConfigMap
-        * Add support for path rewrite
-        * Add base config block for TLSCipher for NextGen Routes
+        * Added support for path rewrite
+        * Added base config block for TLSCipher for NextGen Routes
     * CRD:
         * AllowSourceRange support for VirtualServer CRs and Policy CRs. See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/>`_
         * :issues:`2201` Support for linking existing healthmonitor on bigip with virtualSever and TransportServer CRs.
         * :issues:`2361` Allow monitoring of an alias port in VirtualServer and TransportServer
         * :issues:`1933` Added svcNamespace field in Pools for VirtualServer CR that allows to define a pool service from another namespace in a Virtual server CR.
           See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/>`_
-        * Add TCP Health Monitor support for VS CRs
-        * Add monitors support for VS and TS CRs
-    * Added support to configure netmask for Virtual Server for Ingress. See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/ingress/>`_
+        * Added TCP Health Monitor support for VS CRs
+        * Added monitors support for VS and TS CRs
+    * Ingress:
+        * Added support to configure netmask for Virtual Server for Ingress. See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/ingress/>`_
+    * Added support for --log-file deployment parameter to store the CIS logs in a file
     * Added Support for AS3 3.38.0
 
 Bug Fixes
 ````````````
 * :issues:`2325` Supporting Prometheus service in CRDs
+* :issues:`2158` CIS send logs to file from container
 
 2.9.1
 -------------

--- a/pkg/vlogger/README.md
+++ b/pkg/vlogger/README.md
@@ -43,6 +43,7 @@ The following types of loggers are currently provided as subpackages:
 
     func NewConsoleLogger() Logger
     func NewSyslogLogger(facility syslog.Priority, progname string) Logger
+    func NewFileLogger(filename string) Logger
     func NewSeelogLogger(filename string) Logger
     func NewLogrusLogger() Logger
 
@@ -116,11 +117,10 @@ statements to the console:
 
     import (
       log  "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger"
-      "github.com/F5Networks/k8s-bigip-ctlr/pkg/vlogger/console"
-
+    )
     func init() {
-      // Log all messages to the user's console
-      log.RegisterLogger(log.LL_MIN_LEVEL, log.LL_MAX_LEVEL, console.NewConsoleLogger())
+      // Log all messages to the user's logger
+      log.RegisterLogger(log.LL_MIN_LEVEL, log.LL_MAX_LEVEL, log.NewConsoleLogger())
       // only report errors at the LL_INFO level and above
       log.SetLogLevel(log.LL_INFO)
     }

--- a/pkg/vlogger/doc.go
+++ b/pkg/vlogger/doc.go
@@ -123,7 +123,7 @@ to the console:
 
   func init() {
     // Log all messages to the user's console
-    log.RegisterLogger(log.LL_MIN_LEVEL, log.LL_MAX_LEVEL, console.NewConsoleLogger())
+    log.RegisterLogger(log.LL_MIN_LEVEL, log.LL_MAX_LEVEL, logger.NewConsoleLogger())
     // only report errors at the LL_INFO level and above
     log.SetLogLevel(log.LL_INFO)
   }


### PR DESCRIPTION
Signed-off-by: Vivek Lohiya <vklohiya@live.com>

**Description**:  Add support for log-file deployment parameter to store the CIS logs in a file

**Changes Proposed in PR**: We can specify the --log-file deployment parameter in CIS which enables redirects all the logs to the specified log file. If --log-file deployment parameter is not defined CIS will put the logs in stdout & stderr streams.

**Fixes**: resolves #2158 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed