### PR TITLE
Renamed svcNamespace field in Pool of Virtualserver CR to serviceNamespace

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -62,16 +62,16 @@ type ServiceAddress struct {
 
 // Pool defines a pool object in BIG-IP.
 type Pool struct {
-	Name            string    `json:"name,omitempty"`
-	Path            string    `json:"path,omitempty"`
-	Service         string    `json:"service"`
-	ServicePort     int32     `json:"servicePort"`
-	NodeMemberLabel string    `json:"nodeMemberLabel,omitempty"`
-	Monitor         Monitor   `json:"monitor"`
-	Monitors        []Monitor `json:"monitors"`
-	Rewrite         string    `json:"rewrite,omitempty"`
-	Balance         string    `json:"loadBalancingMethod,omitempty"`
-	SvcNamespace    string    `json:"svcNamespace,omitempty"`
+	Name             string    `json:"name,omitempty"`
+	Path             string    `json:"path,omitempty"`
+	Service          string    `json:"service"`
+	ServicePort      int32     `json:"servicePort"`
+	NodeMemberLabel  string    `json:"nodeMemberLabel,omitempty"`
+	Monitor          Monitor   `json:"monitor"`
+	Monitors         []Monitor `json:"monitors"`
+	Rewrite          string    `json:"rewrite,omitempty"`
+	Balance          string    `json:"loadBalancingMethod,omitempty"`
+	ServiceNamespace string    `json:"serviceNamespace,omitempty"`
 }
 
 // Monitor defines a monitor object in BIG-IP.

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -17,7 +17,7 @@ Added Functionality
         * AllowSourceRange support for VirtualServer CRs and Policy CRs. See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/>`_
         * :issues:`2201` Support for linking existing healthmonitor on bigip with virtualSever and TransportServer CRs.
         * :issues:`2361` Allow monitoring of an alias port in VirtualServer and TransportServer
-        * :issues:`1933` Added svcNamespace field in Pools for VirtualServer CR that allows to define a pool service from another namespace in a Virtual server CR.
+        * :issues:`1933` Added serviceNamespace field in Pools for VirtualServer CR that allows to define a pool service from another namespace in a Virtual server CR.
           See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/>`_
         * Added TCP Health Monitor support for VS CRs
         * Added monitors support for VS and TS CRs

--- a/docs/config_examples/customResource/CustomResource.md
+++ b/docs/config_examples/customResource/CustomResource.md
@@ -63,16 +63,16 @@ This page is created to document the behaviour of CIS in CRD Mode.
 
 **Pool Components**
 
-| PARAMETER       | TYPE    | REQUIRED | DEFAULT | DESCRIPTION                                                                                                         |
-|-----------------|---------| ------ | ------ |---------------------------------------------------------------------------------------------------------------------|
-| path            | String  | Required | NA | Path to access the service                                                                                          |
-| service         | String  | Required | NA | Service deployed in kubernetes cluster                                                                              |
-| nodeMemberLabel | String  | Optional | NA | List of Nodes to consider in NodePort Mode as BIG-IP pool members. This Option is only applicable for NodePort Mode |
-| servicePort     | String  | Required | NA | Port to access Service                                                                                              |
-| monitor         | String  | Optional | NA | Health Monitor to check the health of Pool Members                                                                  |
-| monitors        | monitor | Optional | NA | Specifies multiple monitors for VS Pool                                                                             |
-| rewrite         | String  | Optional | NA | Rewrites the path in the HTTP Header while submitting the request to Server in the pool                             |
-| svcNamespace | String | Optional | NA | Namespace of service, define it if service is present in a namespace other than the one where VS CR is present |
+| PARAMETER        | TYPE    | REQUIRED | DEFAULT | DESCRIPTION                                                                                                         |
+|------------------|---------| ------ | ------ |---------------------------------------------------------------------------------------------------------------------|
+| path             | String  | Required | NA | Path to access the service                                                                                          |
+| service          | String  | Required | NA | Service deployed in kubernetes cluster                                                                              |
+| nodeMemberLabel  | String  | Optional | NA | List of Nodes to consider in NodePort Mode as BIG-IP pool members. This Option is only applicable for NodePort Mode |
+| servicePort      | String  | Required | NA | Port to access Service                                                                                              |
+| monitor          | String  | Optional | NA | Health Monitor to check the health of Pool Members                                                                  |
+| monitors         | monitor | Optional | NA | Specifies multiple monitors for VS Pool                                                                             |
+| rewrite          | String  | Optional | NA | Rewrites the path in the HTTP Header while submitting the request to Server in the pool                             |
+| serviceNamespace | String | Optional | NA | Namespace of service, define it if service is present in a namespace other than the one where Virtual Server Custom Resource is present |
 
 **Service_Address Components**
 

--- a/docs/config_examples/customResource/VirtualServer/virtual-with-pool-svc-different-ns/vs-with-pool-svc-diff-ns.yaml
+++ b/docs/config_examples/customResource/VirtualServer/virtual-with-pool-svc-different-ns/vs-with-pool-svc-diff-ns.yaml
@@ -12,8 +12,8 @@ spec:
       service: svc-1
       servicePort: 80
     - path: /tea
-      # svcNamespace is the namespace of the service, define it if service is present in a namespace other than the one
+      # serviceNamespace is the namespace of the service, define it if service is present in a namespace other than the one
       # where VS CR is present
-      svcNamespace: tea
+      serviceNamespace: tea
       service: svc-2
       servicePort: 80

--- a/docs/config_examples/customResourceDefinitions/customresourcedefinitions.yml
+++ b/docs/config_examples/customResourceDefinitions/customresourcedefinitions.yml
@@ -127,7 +127,7 @@ spec:
                       rewrite:
                         type: string
                         pattern: '^\/([A-z0-9-_+]+\/)*([A-z0-9]+\/?)*$'
-                      svcNamespace:
+                      serviceNamespace:
                         type: string
                       monitor:
                         type: object

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -399,8 +399,8 @@ func (ctlr *Controller) prepareRSConfigFromVirtualServer(
 	framedPools := make(map[string]struct{})
 	for _, pl := range vs.Spec.Pools {
 		svcNamespace := vs.Namespace
-		if pl.SvcNamespace != "" {
-			svcNamespace = pl.SvcNamespace
+		if pl.ServiceNamespace != "" {
+			svcNamespace = pl.ServiceNamespace
 		}
 		targetPort = ctlr.fetchTargetPort(svcNamespace, pl.Service, pl.ServicePort)
 


### PR DESCRIPTION
**Description**:  Renamed svcNamespace field in Pool of Virtualserver CR to serviceNamespace

**Changes Proposed in PR**: Renamed svcNamespace field in Pool of Virtualserver CR to serviceNamespace

**Fixes**: resolves #1933

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema