### PR TITLE
Bypass IPv6 node address FDB entry creation

### DIFF
--- a/pkg/vxlan/vxlanMgr.go
+++ b/pkg/vxlan/vxlanMgr.go
@@ -128,6 +128,11 @@ func (vxm *VxlanMgr) ProcessNodeUpdate(obj interface{}, err error) {
 		nodeAddrs := node.Status.Addresses
 		rec := fdbRecord{}
 		for _, addr := range nodeAddrs {
+			ip := strings.Split(addr.Address, ".")
+			if len(ip) != 4 {
+				log.Warningf("[VxLAN] IPv6 is not supported for FDB record: %s", addr.Address)
+				continue
+			}
 			if addr.Type == addrType {
 				rec.Endpoint = addr.Address
 				// Initially set the name to a fake MAC (for OpenShift use)


### PR DESCRIPTION
IPv6 node address FDB entry creation is not supported for now
bypass IPv6 node address, and log warning if user run dual stack
cluster

Signed-off-by: Vincent Li <v.li@f5.com>

**Description**:  _Add Issue/Feature description_

Users run dual stack, CIS attempt to create node IPv6 address FDB entry on BIG-IP, result in error

**Changes Proposed in PR**:
bypass IPv6 node address for FDB entry creation

**Fixes**: resolves #_Github issue id_
https://github.com/F5Networks/k8s-bigip-ctlr/issues/2555

## General Checklist
- [ ] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation
- [ ] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema