### PR TITLE
Fix to set ingress https monitor send string

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -9,7 +9,7 @@ Added Functionality
 
 Bug Fixes
 ````````````
-
+* :issues:`2394` Fix to set ingress https monitor send string
 
 2.10.0
 -------------

--- a/docs/config_examples/ingress/ingress-https-monitor.yaml
+++ b/docs/config_examples/ingress/ingress-https-monitor.yaml
@@ -1,0 +1,27 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    ingress.kubernetes.io/allow-http: "false"
+    ingress.kubernetes.io/ssl-redirect: "true"
+    virtual-server.f5.com/balance: least-connections-node
+    virtual-server.f5.com/clientssl: '[{"bigIpProfile": "/Common/pytest-foo-clientssl"}]'
+    virtual-server.f5.com/health: '[{"path": "/",
+                                    "send": "HTTP GET /",
+                                    "type": "https",
+                                    "interval": 4,
+                                    "timeout": 5 }]'
+    virtual-server.f5.com/http-port: "80"
+    virtual-server.f5.com/https-port: "443"
+    virtual-server.f5.com/ip: 10.8.3.123
+    virtual-server.f5.com/partition: test
+    virtual-server.f5.com/serverssl: /Common/pytest-foo-serverssl
+  name: svc-1
+  namespace: default
+spec:
+  defaultBackend:
+    service:
+      name: svc-1
+      port:
+        number: 443
+  ingressClassName: f5

--- a/pkg/agent/as3/as3Common.go
+++ b/pkg/agent/as3/as3Common.go
@@ -515,6 +515,7 @@ func createMonitorDecl(cfg *ResourceConfig, sharedApp as3Application) {
 		case "https":
 			//Todo: For https monitor type
 			adaptiveFalse := false
+			monitor.Send = v.Send
 			monitor.Adaptive = &adaptiveFalse
 		}
 		sharedApp[as3FormattedString(v.Name, cfg.MetaData.ResourceType)] = monitor


### PR DESCRIPTION
**Description**:  Fix to set ingress https monitor send string

**Changes Proposed in PR**:  Support given to set send string for ingress https monitor

**Fixes**:  #2394 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema