### PR TITLE
Fix CIS adding both VIPs to GTM pool members for ingresslinks

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -13,6 +13,7 @@ Bug Fixes
 * :issues:`2549` Fix trafficGroup regex
 * : Fix issue with inconsistent pool names for VS
 * :issues:`2492` Fix for adding unique pool members in nodePort mode
+* :issues:`847`  Fix issue with adding both VIPs to GTM pool members for IngressLink
 
 2.10.0
 -------------

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -2271,6 +2271,13 @@ func (ctlr *Controller) processExternalDNS(edns *cisapiv1.ExternalDNS, isDelete 
 				if vs.MetaData.Protocol == "http" && (vs.MetaData.httpTraffic == TLSRedirectInsecure || vs.MetaData.httpTraffic == TLSAllowInsecure) {
 					continue
 				}
+				// add only one VS member to pool.
+				if len(pool.Members) > 0 && strings.HasPrefix(vsName, "ingress_link_") {
+					if strings.HasSuffix(vsName, "_443") {
+						pool.Members[0] = fmt.Sprintf("%v:/%v/Shared/%v", pl.DataServerName, DEFAULT_PARTITION, vsName)
+					}
+					continue
+				}
 				log.Debugf("Adding WideIP Pool Member: %v", fmt.Sprintf("%v:/%v/Shared/%v",
 					pl.DataServerName, DEFAULT_PARTITION, vsName))
 				pool.Members = append(
@@ -2612,7 +2619,7 @@ func (ctlr *Controller) processIngressLink(
 
 		rsCfg := &ResourceConfig{}
 		rsCfg.Virtual.Partition = ctlr.Partition
-		rsCfg.MetaData.ResourceType = "TransportServer"
+		rsCfg.MetaData.ResourceType = TransportServer
 		rsCfg.MetaData.hosts = append(rsCfg.MetaData.hosts, ingLink.Spec.Host)
 		rsCfg.Virtual.Mode = "standard"
 		rsCfg.Virtual.TranslateServerAddress = true


### PR DESCRIPTION
**Description**: Fix CIS adding both VIPs to GTM pool members for ingresslinks

**Changes Proposed in PR**:  Fix to add only one member to pool for IngressLink

**Fixes**: gitswarm issue #847 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema