### PR TITLE
Fix for adding unique pool members in nodePort mode

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -12,6 +12,7 @@ Bug Fixes
 * :issues:`2394` Fix to set ingress https monitor send string
 * :issues:`2549` Fix trafficGroup regex
 * : Fix issue with inconsistent pool names for VS
+* :issues:`2492` Fix for adding unique pool members in nodePort mode
 
 2.10.0
 -------------

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -3524,7 +3524,13 @@ func (appMgr *Manager) getEndpoints(selector, namespace string) []Member {
 		} else { // Controller is in NodePort mode.
 			if service.Spec.Type == v1.ServiceTypeNodePort {
 				for _, port := range service.Spec.Ports {
-					members = append(members, appMgr.getEndpointsForNodePort(port.NodePort, port.Port)...)
+					endpointMembers := appMgr.getEndpointsForNodePort(port.NodePort, port.Port)
+					for _, newMember := range endpointMembers {
+						if _, ok := uniqueMembersMap[newMember]; !ok {
+							uniqueMembersMap[newMember] = struct{}{}
+							members = append(members, newMember)
+						}
+					}
 				}
 			} /* else {
 				msg := fmt.Sprintf("[CORE] Requested service backend '%+v' not of NodePort type", service.Name)


### PR DESCRIPTION
**Description**:  Fix for adding unique pool members in nodePort mode

**Changes Proposed in PR**: Fix for adding unique pool members in nodePort mode

**Fixes**: resolves #2492

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema