### PR TITLE
Fix CIS fail to send as3 for recreated domain after IPAM restart

### DIFF
--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -74,6 +74,7 @@ type (
 		TeemData               *teem.TeemsData
 		requestQueue           *requestQueue
 		namespaceLabel         string
+		ipamHostSpecEmpty      bool
 		resourceContext
 	}
 	resourceContext struct {


### PR DESCRIPTION
**Description**: CIS fails to send AS3 declaration for the recreated domain after IPAM controller restart.

**Changes Proposed in PR**: Fixed issue 

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema