### PR TITLE
Support for TLS profiles as K8S secrets in nextGenRoutes

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -12,7 +12,7 @@ Added Functionality
     * CIS configures GTM configuration in default partition
     * Pool reselect support for VS and TS
     * :issues:`2469` Support for virtual server grouping by hostgroup across namespaces.From 2.11, hostGroup should be unique across namespaces.See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/VirtualServer/virtual-with-hostGroup>`_
-
+    * Support for TLS profiles as K8S secrets in next generation routes. See `Example <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/next-gen-routes/configmap>`_
 Bug Fixes
 ````````````
 

--- a/docs/config_examples/next-gen-routes/configmap/extendedRouteConfigWithTLSCertsK8SSecrets.yaml
+++ b/docs/config_examples/next-gen-routes/configmap/extendedRouteConfigWithTLSCertsK8SSecrets.yaml
@@ -1,0 +1,21 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: default-extended-route-spec
+  namespace: kube-system
+data:
+  extendedSpec: |
+    baseRouteSpec:
+     tlsCipher:
+         tlsVersion: 1.2
+         ciphers: DEFAULT
+         cipherGroup: /Common/f5-default
+    extendedRouteSpec:
+    - namespace: default
+      vserverAddr: 10.8.3.11
+      vserverName: nextgenroutes
+      allowOverride: true
+      tls:
+        clientSSL: clientssl-secret
+        serverSSL: serverssl-secret
+        reference: secret

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -1862,7 +1862,7 @@ func (ctlr *Controller) handleRouteTLS(
 	bigIPSSLProfiles := BigIPSSLProfiles{}
 
 	//If TLS config is present in the global configmap look for the bigIPReference
-	if extdSpec.TLS != (TLS{}) && extdSpec.TLS.Reference == BIGIP {
+	if extdSpec.TLS != (TLS{}) && (extdSpec.TLS.Reference == BIGIP || extdSpec.TLS.Reference == Secret) {
 		tlsReferenceType = extdSpec.TLS.Reference
 		if route.Spec.TLS.Termination != routeapi.TLSTerminationPassthrough {
 			if extdSpec.TLS.ClientSSL == "" {

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -213,7 +213,10 @@ func (ctlr *Controller) processResources() bool {
 		secret := rKey.rsc.(*v1.Secret)
 		switch ctlr.mode {
 		case OpenShiftMode:
-			ctlr.processRoutes(ctlr.getRouteGroupForSecret(secret), false)
+			routeGroup := ctlr.getRouteGroupForSecret(secret)
+			if routeGroup != "" {
+				ctlr.processRoutes(routeGroup, false)
+			}
 		default:
 			tlsProfiles := ctlr.getTLSProfilesForSecret(secret)
 			for _, tlsProfile := range tlsProfiles {


### PR DESCRIPTION
**Description**:  Support for TLS profiles as K8S secrets in nextGenRoutes

**Changes Proposed in PR**:  TLS certs as K8S secrets can be specified in the extended Config map.

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema