### PR TITLE
Fix to remove old ingress monitor when type is modified

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -15,7 +15,12 @@ Added Functionality
 
 Bug Fixes
 ````````````
+
 * :issues:`2586` Update ExternalIP of associated services of Type LB for VS and IngressLink CR
+* Fix to remove old ingress monitor when type gets modified
+* Fix to send AS3 declaration for the recreated domain after IPAM controller restart
+
+
 
 2.10.1
 -------------

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1913,6 +1913,7 @@ func (appMgr *Manager) syncIngresses(
 						if nil != ing.Spec.DefaultBackend {
 							fullPoolName := fmt.Sprintf("/%s/%s", rsCfg.Virtual.Partition,
 								FormatIngressPoolName(sKey.Namespace, sKey.ServiceName))
+							RemoveUnReferredHealthMonitors(rsCfg, fullPoolName, monitors)
 							appMgr.handleSingleServiceV1IngressHealthMonitors(
 								rsName, fullPoolName, rsCfg, ing, monitors)
 						} else {

--- a/pkg/appmanager/healthMonitors.go
+++ b/pkg/appmanager/healthMonitors.go
@@ -120,6 +120,33 @@ func (appMgr *Manager) notifyUnusedHealthMonitorRules(
 	}
 }
 
+func RemoveUnReferredHealthMonitors(rsCfg *ResourceConfig, fullPoolName string, monitors AnnotationHealthMonitors) {
+	// For this pool remove the monitor names that are not present in - monitors
+	for pi, pool := range rsCfg.Pools {
+		_, poolName := SplitBigipPath(fullPoolName, false)
+		if pool.Name == poolName {
+			foundMon := make([]string, 0)
+			for _, monName := range pool.MonitorNames {
+				found := false
+				for _, mon := range monitors {
+					monType := mon.Type
+					if monType == "" {
+						monType = "http"
+					}
+					if strings.HasSuffix(monName, monType) {
+						found = true
+					}
+				}
+				if found {
+					foundMon = append(foundMon, monName)
+				}
+			}
+			rsCfg.Pools[pi].MonitorNames = foundMon
+			break
+		}
+	}
+}
+
 // TODO remove the function once v1beta1.Ingress is deprecated in k8s 1.22
 func (appMgr *Manager) handleSingleServiceHealthMonitors(
 	rsName,


### PR DESCRIPTION
**Description**:  CIS fails to remove old HTTP ingress monitor when type is modified.

**Changes Proposed in PR**: Fix to remove old ingress monitor when type is modified

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema