### PR TITLE
Update ExternalIP of associated services of Type LB for VS CR and IngressLink CR

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -15,6 +15,7 @@ Added Functionality
 
 Bug Fixes
 ````````````
+* :issues:`2586` Update ExternalIP of associated services of Type LB for VS and IngressLink CR
 
 2.10.1
 -------------

--- a/pkg/controller/responseHandler.go
+++ b/pkg/controller/responseHandler.go
@@ -67,6 +67,13 @@ func (ctlr *Controller) responseHandler(respChan chan resourceStatusMeta) {
 				if virtual.Namespace+"/"+virtual.Name == rscKey {
 					ctlr.updateVirtualServerStatus(virtual, virtual.Status.VSAddress, "Ok")
 				}
+				// Update Corresponding Service Status of Type LB
+				for _, pool := range virtual.Spec.Pools {
+					svc := ctlr.GetService(virtual.Namespace, pool.Service)
+					if svc.Spec.Type == v1.ServiceTypeLoadBalancer {
+						ctlr.setLBServiceIngressStatus(svc, virtual.Status.VSAddress)
+					}
+				}
 			case TransportServer:
 				// update status
 				crInf, ok := ctlr.getNamespacedCRInformer(ns)


### PR DESCRIPTION


**Description**:  Update ExternalIP of associated services of Type LB for VS and IngressLink CR as the associated service resource is in pending state if not updated for service Type LB.

**Changes Proposed in PR**:

**Fixes**: resolves #2586 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema