### PR TITLE
Remove repeated `omitempty` struct tag option from `TrafficGroup` fields

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -56,7 +56,7 @@ type ServiceAddress struct {
 	ArpEnabled         bool   `json:"arpEnabled,omitempty"`
 	ICMPEcho           string `json:"icmpEcho,omitempty"`
 	RouteAdvertisement string `json:"routeAdvertisement,omitempty"`
-	TrafficGroup       string `json:"trafficGroup,omitempty,omitempty"`
+	TrafficGroup       string `json:"trafficGroup,omitempty"`
 	SpanningEnabled    bool   `json:"spanningEnabled,omitempty"`
 }
 

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -868,7 +868,7 @@ type (
 		ArpEnabled         bool   `json:"arpEnabled"`
 		ICMPEcho           string `json:"icmpEcho,omitempty"`
 		RouteAdvertisement string `json:"routeAdvertisement,omitempty"`
-		TrafficGroup       string `json:"trafficGroup,omitempty,omitempty"`
+		TrafficGroup       string `json:"trafficGroup,omitempty"`
 		SpanningEnabled    bool   `json:"spanningEnabled"`
 	}
 

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -49,7 +49,7 @@ type (
 		ArpEnabled         bool   `json:"arpEnabled,omitempty"`
 		ICMPEcho           string `json:"icmpEcho,omitempty"`
 		RouteAdvertisement string `json:"routeAdvertisement,omitempty"`
-		TrafficGroup       string `json:"trafficGroup,omitempty,omitempty"`
+		TrafficGroup       string `json:"trafficGroup,omitempty"`
 		SpanningEnabled    bool   `json:"spanningEnabled,omitempty"`
 	}
 


### PR DESCRIPTION
**Description**:
Removes an unnecessary extra `omitempty` struct tag option on `TrafficGroup` fields in the `ServiceAddress` types.

**Changes Proposed in PR**:

**Fixes**:

## General Checklist

## CRD Checklist