### PR TITLE
Support to create Health Monitor from the pod liveness probe that route exposes

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -12,6 +12,7 @@ Added Functionality
         * Policy CR integration with extended ConfigMap
         * Support for TLS profiles as K8S secrets in next generation routes. See `Example <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/next-gen-routes/configmap>`_
         * Support Path based A/B deployment for Re-encrypt termination
+        * Support to create Health Monitor from the pod liveness probe that route exposes. Refer `Documentation <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/next-gen-routes>`_ for more details
     * CRD
         * CIS configures GTM configuration in default partition
         * Pool reselect support for VS and TS

--- a/docs/config_examples/next-gen-routes/deployment/deployment-pod-with-livenessprobe.yaml
+++ b/docs/config_examples/next-gen-routes/deployment/deployment-pod-with-livenessprobe.yaml
@@ -1,0 +1,51 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    name: svc-pytest-foo-1-com
+  name: svc-pytest-foo-1-com
+  namespace: foo
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 1
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: svc-pytest-foo-1-com
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      labels:
+        app: svc-pytest-foo-1-com
+    spec:
+      containers:
+        - env:
+            - name: service_name
+              value: svc-pytest-foo-1-com
+          image: f5networksdevel/test-nginx:latest
+          imagePullPolicy: IfNotPresent
+          livenessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 80
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
+          name: svc-pytest-foo-1-com
+          ports:
+            - containerPort: 80
+              protocol: TCP
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30


### PR DESCRIPTION


**Description**:  Support to create Health Monitor from the pod liveness probe that route exposes

**Changes Proposed in PR**: Added Support to create Health Monitor from the pod liveness probe that route exposes

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema