### PR TITLE
Support for Default SSL profiles from baseRouteSpec in extended Configmap

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -13,6 +13,7 @@ Added Functionality
         * Support for TLS profiles as K8S secrets in next generation routes. See `Example <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/next-gen-routes/configmap>`_
         * Support Path based A/B deployment for Re-encrypt termination
         * Support to create Health Monitor from the pod liveness probe that route exposes. Refer `Documentation <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/next-gen-routes>`_ for more details
+        * Support for Default SSL profiles from baseRouteSpec in extended Configmap
     * CRD
         * CIS configures GTM configuration in default partition
         * Pool reselect support for VS and TS

--- a/docs/config_examples/next-gen-routes/configmap/extendedRouteConfigwithBaseConfig.yaml
+++ b/docs/config_examples/next-gen-routes/configmap/extendedRouteConfigwithBaseConfig.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: default-extended-route-spec
+  name: global-spec-config
   namespace: kube-system
 data:
   extendedSpec: |
@@ -10,12 +10,19 @@ data:
          tlsVersion: 1.2
          ciphers: DEFAULT
          cipherGroup: /Common/f5-default 
+     defaultTLS:
+       clientSSL: /Common/clientssl
+       serverSSL: /Common/serverssl
+       reference: bigip
     extendedRouteSpec:
     - namespace: default
-      vserverAddr: 10.8.3.11
+      vserverAddr: 10.8.0.4
       vserverName: nextgenroutes
       allowOverride: true
       tls:
         clientSSL: /Common/clientssl
         serverSSL: /Common/serverssl
         reference: bigip
+    - allowOverride: false
+      namespace: bar
+      vserverAddr: 10.8.0.5

--- a/pkg/controller/nativeResourceWorker_test.go
+++ b/pkg/controller/nativeResourceWorker_test.go
@@ -158,6 +158,33 @@ var _ = Describe("Routes", func() {
 
 		})
 		It("Check Valid Route", func() {
+			var cm *v1.ConfigMap
+			var data map[string]string
+			cmName := "escm"
+			cmNamespace := "system"
+			mockCtlr.routeSpecCMKey = cmNamespace + "/" + cmName
+			mockCtlr.resources = NewResourceStore()
+			data = make(map[string]string)
+			cm = test.NewConfigMap(
+				cmName,
+				"v1",
+				cmNamespace,
+				data)
+			data["extendedSpec"] = `
+baseRouteSpec: 
+    tlsCipher:
+      tlsVersion : 1.2
+extendedRouteSpec:
+    - namespace: default
+      vserverAddr: 10.8.3.11
+      vserverName: nextgenroutes
+      allowOverride: true
+    - namespace: new
+      vserverAddr: 10.8.3.12
+      allowOverride: true
+`
+			_, _ = mockCtlr.processConfigMap(cm, false)
+
 			spec1 := routeapi.RouteSpec{
 				Host: "foo.com",
 				Path: "/foo",
@@ -536,6 +563,7 @@ var _ = Describe("Routes", func() {
 							"DEFAULT",
 							"/Common/f5-default",
 						},
+						DefaultSSLProfile{},
 					},
 				},
 			}

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -1076,7 +1076,7 @@ type (
 	}
 
 	Meta struct {
-		DependsOnTLSCipher bool
+		DependsOnTLS bool
 	}
 
 	TLS struct {
@@ -1086,13 +1086,19 @@ type (
 	}
 
 	BaseRouteConfig struct {
-		TLSCipher TLSCipher `yaml:"tlsCipher"`
+		TLSCipher  TLSCipher         `yaml:"tlsCipher"`
+		DefaultTLS DefaultSSLProfile `yaml:"defaultTLS,omitempty"`
 	}
 
 	TLSCipher struct {
 		TLSVersion  string `yaml:"tlsVersion,omitempty"`
 		Ciphers     string `yaml:"ciphers,omitempty"`
 		CipherGroup string `yaml:"cipherGroup,omitempty"` // by default this is bigip reference
+	}
+	DefaultSSLProfile struct {
+		ClientSSL string `yaml:"clientSSL,omitempty"`
+		ServerSSL string `yaml:"serverSSL,omitempty"`
+		Reference string `yaml:"reference,omitempty"`
 	}
 )
 


### PR DESCRIPTION
…gmap

**Description**:  Support for Default SSL profiles from baseRouteSpec in extended Confi…

**Changes Proposed in PR**: Added support for default client and server server SSL profiles in nextGen routes

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema