### PR TITLE
Add sslProfile to https health monitors for Ingress

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -24,6 +24,8 @@ Added Functionality
         * Support for allowVlans with policy CR.
         * Support for custom persistence profile. See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/VirtualServer/persistenceProfile>`_
         * :issues:`2585` Support for multiple clientssl & serverssl profiles in TLS Profiles. See `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/customResource/VirtualServer/virtual-with-hostGroup>`_
+    * Ingress
+        * Support for sslProfile in HTTPS health monitors for ingress. `Examples <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/ingress/ingress-with-health-monitors.yaml>`_
 
 Bug Fixes
 ````````````

--- a/docs/config_examples/ingress/ingress-with-health-monitors.yaml
+++ b/docs/config_examples/ingress/ingress-with-health-monitors.yaml
@@ -6,6 +6,10 @@ metadata:
   annotations:
     virtual-server.f5.com/ip:        "1.2.3.4"
     virtual-server.f5.com/partition: "k8s"
+    # Health monitor with sslProfile
+    # virtual-server.f5.com/health: '[{
+    #  "type": "https", "path": "/", "send": "HTTPS GET /", "interval": 2,"timeout": 5,"sslProfile": "/Common/serverssl"
+    # }]'
     virtual-server.f5.com/health: |
       [
         {

--- a/pkg/agent/as3/as3Common.go
+++ b/pkg/agent/as3/as3Common.go
@@ -508,6 +508,11 @@ func createMonitorDecl(cfg *ResourceConfig, sharedApp as3Application) {
 		monitor.Adaptive = false
 		monitor.Dscp = &val
 		monitor.TimeUnitilUp = &val
+		if v.SslProfile != "" {
+			monitor.ClientTLS = &as3ResourcePointer{
+				BigIP: fmt.Sprintf("%v", v.SslProfile),
+			}
+		}
 		sharedApp[as3FormattedString(v.Name, cfg.MetaData.ResourceType)] = monitor
 	}
 

--- a/pkg/agent/as3/as3Common_test.go
+++ b/pkg/agent/as3/as3Common_test.go
@@ -1,0 +1,79 @@
+package as3
+
+import (
+	. "github.com/F5Networks/k8s-bigip-ctlr/pkg/resource"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("AS3Common Tests", func() {
+	It("Creates AS3 monitor declaration", func() {
+		// HTTPS health monitor
+		healthMonitor := "test_https_hm"
+		cfg := &ResourceConfig{
+			MetaData: MetaData{
+				ResourceType: ResourceTypeIngress,
+			},
+			Monitors: []Monitor{
+				{Name: healthMonitor, Partition: "test", Interval: 2, Type: "https", Send: "HTTPS GET /test1",
+					Timeout: 3, SslProfile: "/Common/serverssl"},
+			},
+		}
+		sharedApp := as3Application{}
+		sharedApp = make(map[string]interface{})
+		createMonitorDecl(cfg, sharedApp)
+		hm, ok := sharedApp[as3FormattedString(healthMonitor, cfg.MetaData.ResourceType)]
+		Expect(ok).To(Equal(true), "Health monitor not created for AS3 declaration.")
+		targetAddr := ""
+		targetPort := 0
+		dscp := 0
+		timeUnitilUp := 0
+		expectedHM := &as3Monitor{
+			Class:         "Monitor",
+			Dscp:          &dscp,
+			Interval:      2,
+			MonitorType:   "https",
+			TargetAddress: &targetAddr,
+			TimeUnitilUp:  &timeUnitilUp,
+			Timeout:       3,
+			Adaptive:      false,
+			Send:          "HTTPS GET /test1",
+			Receive:       "none",
+			TargetPort:    &targetPort,
+			ClientTLS: &as3ResourcePointer{
+				BigIP: "/Common/serverssl",
+			},
+		}
+		Expect(hm).To(Equal(expectedHM), "Incorrect Health monitor created for AS3 declaration.")
+
+		// Http health monitor
+		healthMonitor = "test_http_hm"
+		cfg = &ResourceConfig{
+			MetaData: MetaData{
+				ResourceType: ResourceTypeIngress,
+			},
+			Monitors: []Monitor{
+				{Name: healthMonitor, Partition: "test", Interval: 2, Recv: "/test3", Type: "http", Send: "HTTP GET /test2",
+					Timeout: 3},
+			},
+		}
+		sharedApp = make(map[string]interface{})
+		createMonitorDecl(cfg, sharedApp)
+		hm, ok = sharedApp[as3FormattedString(healthMonitor, cfg.MetaData.ResourceType)]
+		Expect(ok).To(Equal(true), "Health monitor not created for AS3 declaration.")
+		expectedHM = &as3Monitor{
+			Class:         "Monitor",
+			Dscp:          &dscp,
+			Interval:      2,
+			MonitorType:   "http",
+			Receive:       "/test3",
+			TargetAddress: &targetAddr,
+			Timeout:       3,
+			TimeUnitilUp:  &timeUnitilUp,
+			Adaptive:      false,
+			Send:          "HTTP GET /test2",
+			TargetPort:    &targetPort,
+		}
+		Expect(hm).To(Equal(expectedHM), "Incorrect Health monitor created for AS3 declaration.")
+	})
+})

--- a/pkg/agent/as3/as3Types.go
+++ b/pkg/agent/as3/as3Types.go
@@ -162,19 +162,20 @@ type (
 	// - Monitor_HTTP
 	// - Monitor_HTTPS
 	as3Monitor struct {
-		Class             string  `json:"class,omitempty"`
-		Interval          int     `json:"interval,omitempty"`
-		MonitorType       string  `json:"monitorType,omitempty"`
-		TargetAddress     *string `json:"targetAddress,omitempty"`
-		Timeout           int     `json:"timeout,omitempty"`
-		TimeUnitilUp      *int    `json:"timeUntilUp,omitempty"`
-		Adaptive          bool    `json:"adaptive,omitempty"`
-		Dscp              *int    `json:"dscp,omitempty"`
-		Receive           string  `json:"receive,omitempty"`
-		Send              string  `json:"send,omitempty"`
-		TargetPort        *int    `json:"targetPort,omitempty"`
-		ClientCertificate string  `json:"clientCertificate,omitempty"`
-		Ciphers           string  `json:"ciphers,omitempty"`
+		Class             string              `json:"class,omitempty"`
+		Interval          int                 `json:"interval,omitempty"`
+		MonitorType       string              `json:"monitorType,omitempty"`
+		TargetAddress     *string             `json:"targetAddress,omitempty"`
+		Timeout           int                 `json:"timeout,omitempty"`
+		TimeUnitilUp      *int                `json:"timeUntilUp,omitempty"`
+		Adaptive          bool                `json:"adaptive,omitempty"`
+		Dscp              *int                `json:"dscp,omitempty"`
+		Receive           string              `json:"receive,omitempty"`
+		Send              string              `json:"send,omitempty"`
+		TargetPort        *int                `json:"targetPort,omitempty"`
+		ClientCertificate string              `json:"clientCertificate,omitempty"`
+		Ciphers           string              `json:"ciphers,omitempty"`
+		ClientTLS         *as3ResourcePointer `json:"clientTLS,omitempty"`
 	}
 
 	// as3CABundle maps to CA_Bundle in AS3 Resources

--- a/pkg/appmanager/healthMonitors.go
+++ b/pkg/appmanager/healthMonitors.go
@@ -98,6 +98,9 @@ func (appMgr *Manager) assignMonitorToPool(
 				Recv:      ruleData.HealthMon.Recv,
 				Timeout:   ruleData.HealthMon.Timeout,
 			}
+			if monitorType == "https" && ruleData.HealthMon.SslProfile != "" {
+				monitor.SslProfile = ruleData.HealthMon.SslProfile
+			}
 			updated = cfg.SetMonitor(&cfg.Pools[poolNdx], monitor)
 		}
 	}

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -132,13 +132,14 @@ type (
 
 	// Pool health monitor
 	Monitor struct {
-		Name      string `json:"name"`
-		Partition string `json:"-"`
-		Interval  int    `json:"interval,omitempty"`
-		Type      string `json:"type,omitempty"`
-		Send      string `json:"send,omitempty"`
-		Recv      string `json:"recv,omitempty"`
-		Timeout   int    `json:"timeout,omitempty"`
+		Name       string `json:"name"`
+		Partition  string `json:"-"`
+		Interval   int    `json:"interval,omitempty"`
+		Type       string `json:"type,omitempty"`
+		Send       string `json:"send,omitempty"`
+		Recv       string `json:"recv,omitempty"`
+		Timeout    int    `json:"timeout,omitempty"`
+		SslProfile string `json:"sslProfile,omitempty"`
 	}
 	Monitors []Monitor
 
@@ -322,12 +323,13 @@ type (
 	// This is the format for each item in the health monitor annotation used
 	// in the Ingress and Route objects.
 	AnnotationHealthMonitor struct {
-		Path     string `json:"path"`
-		Interval int    `json:"interval"`
-		Send     string `json:"send"`
-		Recv     string `json:"recv"`
-		Timeout  int    `json:"timeout"`
-		Type     string `json:"type"`
+		Path       string `json:"path"`
+		Interval   int    `json:"interval"`
+		Send       string `json:"send"`
+		Recv       string `json:"recv"`
+		Timeout    int    `json:"timeout"`
+		Type       string `json:"type"`
+		SslProfile string `json:"sslProfile"`
 	}
 	AnnotationHealthMonitors []AnnotationHealthMonitor
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/f5devcentral/f5-ctlr-agent.git@cf60fe8b70b1159aed7cce931a98a7e5169d4aef#egg=f5-ctlr-agent
--e git+https://github.com/f5devcentral/f5-cccl.git@01bc6986261a8b33af9c5ba3bde75e7c42a8614e#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-ctlr-agent.git@644d72059530b6c667e49b351d3c30e3e0fea3f0#egg=f5-ctlr-agent
+-e git+https://github.com/f5devcentral/f5-cccl.git@9ce9f3b1aaf5a5b2edd5f722b206261269b65b9e#egg=f5-cccl


### PR DESCRIPTION
**Description**:  Add sslProfile to https health monitors for Ingress

**Changes Proposed in PR**:  Add sslProfile to https health monitors for Ingress

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema