### PR TITLE
Add missing '$' to fix devel-image make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,7 @@ vet:
 	$(CURDIR)/build-tools/vet.sh
 
 devel-image:
-	docker build --build-arg RUN_TESTS=0 --build-arg BUILD_VERSION=$(BUILD_VERSION) --build-arg BUILD_INFO=$(BUILD_INFO) -t k8s-bigip-ctlr-devel:latest -f build-tools/Dockerfile.(BASE_OS) .
+	docker build --build-arg RUN_TESTS=0 --build-arg BUILD_VERSION=$(BUILD_VERSION) --build-arg BUILD_INFO=$(BUILD_INFO) -t k8s-bigip-ctlr-devel:latest -f build-tools/Dockerfile.$(BASE_OS) .
 
 # Enable certain funtionalities only on a developer build
 dev-patch:


### PR DESCRIPTION
**Description**: 
Adds a missing `$` in front of the `BASE_OS` variable.

**Changes Proposed in PR**:
Minor change to target in Makefile.

**Fixes**: resolves #2654 

## General Checklist

## CRD Checklist