### PR TITLE
Remove unused ingress health monitors

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -9,6 +9,7 @@ Added Functionality
 
 Bug Fixes
 ````````````
+* Fix to remove unused ingress health monitors
 
 2.11.0
 -------------

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -1921,6 +1921,7 @@ func (appMgr *Manager) syncIngresses(
 								rsName, rsCfg, ing, monitors)
 						}
 					}
+					RemoveUnusedHealthMonitors(rsCfg)
 					rsCfg.SortMonitors()
 				}
 				// Collect all service names on this Ingress.

--- a/pkg/appmanager/healthMonitors.go
+++ b/pkg/appmanager/healthMonitors.go
@@ -329,3 +329,21 @@ func (appMgr *Manager) handleRouteHealthMonitors(
 		stats.vsUpdated += 1
 	}
 }
+
+// RemoveUnusedHealthMonitors removes unused health monitors if there are any
+func RemoveUnusedHealthMonitors(rsCfg *ResourceConfig) {
+	var exists = struct{}{}
+	monitors := make(map[string]struct{})
+	for _, pl := range rsCfg.Pools {
+		for _, mn := range pl.MonitorNames {
+			monitors[mn] = exists
+		}
+	}
+	var usedMonitors []Monitor
+	for _, mn := range rsCfg.Monitors {
+		if _, ok := monitors["/"+mn.Partition+"/"+mn.Name]; ok {
+			usedMonitors = append(usedMonitors, mn)
+		}
+	}
+	rsCfg.Monitors = usedMonitors
+}

--- a/pkg/appmanager/healthMonitors_test.go
+++ b/pkg/appmanager/healthMonitors_test.go
@@ -981,6 +981,31 @@ var _ = Describe("Health Monitor Tests", func() {
 			checkMultiServiceHealthMonitor(vsCfgBar, svc2Name, svc2Port, true)
 			checkMultiServiceHealthMonitor(vsCfgBaz, svc3Name, svc3Port, true)
 		})
+		It("Removes unused health monitors", func() {
+			rcfg := &ResourceConfig{}
+			//rcfg.Monitors = make([]Monitor, 0)
+			//rcfg.Pools = make([]Pool, 0)
+			rcfg.Pools = []Pool{
+				Pool{Name: "svc1", Partition: "test", MonitorNames: []string{"/test/hm1", "/test/hm2"}},
+				Pool{Name: "svc2", Partition: "test", MonitorNames: []string{"/test/hm3", "/test/hm4"}},
+			}
+			rcfg.Monitors = []Monitor{
+				Monitor{Name: "hm0", Partition: "test"},
+				Monitor{Name: "hm1", Partition: "test"},
+				Monitor{Name: "hm2", Partition: "test"},
+				Monitor{Name: "hm3", Partition: "test"},
+				Monitor{Name: "hm4", Partition: "test"},
+				Monitor{Name: "hm5", Partition: "test"},
+			}
+			expectedMonitors := Monitors([]Monitor{
+				Monitor{Name: "hm1", Partition: "test"},
+				Monitor{Name: "hm2", Partition: "test"},
+				Monitor{Name: "hm3", Partition: "test"},
+				Monitor{Name: "hm4", Partition: "test"},
+			})
+			RemoveUnusedHealthMonitors(rcfg)
+			Expect(rcfg.Monitors).To(Equal(expectedMonitors))
+		})
 	})
 
 	Context("route health monitors", func() {


### PR DESCRIPTION
**Description**: Remove unused ingress health monitors

**Changes Proposed in PR**: Removing health monitors if no pool uses it

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema