### PR TITLE
Validate insecure Virtual Server CR

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -7,6 +7,7 @@ Next Release
 Added Functionality
 ```````````````````
 * `Issue 2682 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2682>`_: Support to Enable "HTTP MRF Router" on VirtualServer CRD required for HTTP2 Full Proxy feature
+* `Issue 2686 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2686>`_: Validate insecure Virtual Server CR
 
 Bug Fixes
 `````````

--- a/pkg/controller/validate.go
+++ b/pkg/controller/validate.go
@@ -42,6 +42,12 @@ func (ctlr *Controller) checkValidVirtualServer(
 		log.Infof("VirtualServer %s is invalid", vsName)
 		return false
 	}
+	// Check if HTTPTraffic is set for insecure VS
+	if vsResource.Spec.TLSProfileName == "" && vsResource.Spec.HTTPTraffic != "" {
+		log.Errorf("HTTPTraffic not allowed to be set for insecure VirtualServer: %v", vsName)
+		return false
+	}
+
 	bindAddr := vsResource.Spec.VirtualServerAddress
 	if ctlr.ipamCli == nil {
 

--- a/pkg/controller/worker_test.go
+++ b/pkg/controller/worker_test.go
@@ -1720,6 +1720,15 @@ var _ = Describe("Worker Tests", func() {
 				_, ok := mockCtlr.nsInformers[namespace]
 				Expect(ok).To(Equal(false), "Namespace not deleted")
 
+				// verify HTTPTraffic is not set for insecure virtual server
+				vs.Spec.HTTPTraffic = TLSAllowInsecure
+				vs.Spec.TLSProfileName = ""
+				valid = mockCtlr.checkValidVirtualServer(vs)
+				Expect(valid).To(BeFalse(), "HTTPTraffic not allowed to be set for insecure VS")
+				vs.Spec.HTTPTraffic = TLSRedirectInsecure
+				valid = mockCtlr.checkValidVirtualServer(vs)
+				Expect(valid).To(BeFalse(), "HTTPTraffic not allowed to be set for insecure VS")
+
 			})
 			It("Virtual Server with IPAM", func() {
 				go mockCtlr.Agent.agentWorker()


### PR DESCRIPTION
**Description**:  Validate insecure Virtual Server CR

**Changes Proposed in PR**: Added check to ensure HTTPTraffic is not set for insecure VS

**Fixes**: resolves #2686

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Updated the documentation
- [x] Smoke testing completed