### PR TITLE
handle node notready update 

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -15,6 +15,7 @@ Added Functionality
         * `Issue 2682 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2682>`_: Support to Enable "HTTP MRF Router" on VirtualServer CRD required for HTTP2 Full Proxy feature
         * `Issue 2686 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2686>`_: Validate insecure Virtual Server CR
         * `Issue 2666 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2666>`_: Support multiple virtual addresses on VirtualServer CR
+    * `Issue 2677 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2677>`_: Remove NotReady state nodes from BIGIP poolmembers in NodePortMode
 
 Bug Fixes
 `````````

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -3476,6 +3476,16 @@ func (appMgr *Manager) getNodes(
 
 	// Append list of nodes to watchedNodes
 	for _, node := range nodes {
+		// Ignore the Nodes with status NotReady
+		var notExecutable bool
+		for _, t := range node.Spec.Taints {
+			if v1.TaintEffectNoExecute == t.Effect {
+				notExecutable = true
+			}
+		}
+		if notExecutable == true {
+			continue
+		}
 		nodeAddrs := node.Status.Addresses
 		for _, addr := range nodeAddrs {
 			if addr.Type == addrType {

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -944,8 +944,16 @@ var _ = Describe("AppManager Tests", func() {
 							Effect: v1.TaintEffectNoSchedule,
 						},
 					}),
+				*test.NewNode("node7", "7", false, []v1.NodeAddress{
+					{Type: "ExternalIP", Address: "127.0.0.7"}},
+					[]v1.Taint{
+						{
+							Key:    "node-role.kubernetes.io/worker",
+							Effect: v1.TaintEffectNoExecute,
+						},
+					}),
 			}
-
+			// should ignore nodes with NotReady state(v1.TaintEffectNoExecute)
 			expectedOgSet := []Node{
 				{Name: "node0", Addr: "127.0.0.0"},
 				{Name: "node1", Addr: "127.0.0.1"},

--- a/pkg/controller/node_poll_handler.go
+++ b/pkg/controller/node_poll_handler.go
@@ -203,6 +203,16 @@ func (ctlr *Controller) getNodes(
 
 	// Append list of nodes to watchedNodes
 	for _, node := range nodes {
+		// Ignore the Nodes with status NotReady
+		var notExecutable bool
+		for _, t := range node.Spec.Taints {
+			if v1.TaintEffectNoExecute == t.Effect {
+				notExecutable = true
+			}
+		}
+		if notExecutable == true {
+			continue
+		}
 		nodeAddrs := node.Status.Addresses
 		for _, addr := range nodeAddrs {
 			if addr.Type == addrType {


### PR DESCRIPTION
**Description**:  Remove nodes with NotReady state from bigip pool members in NodePortMode.

**Fixes**: resolves #2677 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed

