### PR TITLE
Fix AS3 label not working in AS3 configmap with filter-tenants

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -16,6 +16,7 @@ Added Functionality
 
 Bug Fixes
 ````````````
+* `Issue 2725 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2725>`_: AS3 label not working with AS3 configmap when filter-tenants set to true.
 
 2.12.0
 -------------

--- a/pkg/agent/as3/as3ConfigMap.go
+++ b/pkg/agent/as3/as3ConfigMap.go
@@ -84,6 +84,7 @@ func (am *AS3Manager) prepareResourceAS3ConfigMaps() (
 			cfgmap := &AS3ConfigMap{
 				Name:      rscCfgMap.Name,
 				Namespace: rscCfgMap.Namespace,
+				Validated: true,
 			}
 			rscCfgMap.Data = am.getTenantObjects(tenants)
 			tenantMap, endPoints := am.processCfgMap(rscCfgMap)


### PR DESCRIPTION
**Description**:  Fix  for AS3 label not working in AS3 configmap with filter-tenants

**Fixes**: resolves #2725 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed
