### PR TITLE
NextGen Route Controller takes precedence over Legacy Route deployment parameters

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -331,7 +331,8 @@ func _init() {
 	namespaceLabel = kubeFlags.String("namespace-label", "",
 		"Optional, used to watch for namespaces with this label")
 	manageRoutes = kubeFlags.Bool("manage-routes", false,
-		"Optional, specify whether or not to manage Route resources")
+		"Optional, specify whether or not to manage Legacy Route resources  "+
+			"Please use controller-mode option for NextGen Route Controller ")
 	manageIngress = kubeFlags.Bool("manage-ingress", true,
 		"Optional, specify whether or not to manage Ingress resources")
 	manageConfigMaps = kubeFlags.Bool("manage-configmaps", true,
@@ -561,7 +562,7 @@ func verifyArgs() error {
 	if *hubMode && !(*manageConfigMaps) {
 		return fmt.Errorf("Hubmode is supported only for configmaps")
 	}
-	if *manageRoutes {
+	if *manageRoutes && *controllerMode == "" {
 		if len(*routeVserverAddr) == 0 {
 			return fmt.Errorf("Missing required parameter route-vserver-addr")
 		}
@@ -1042,7 +1043,7 @@ func main() {
 
 	// creates the clientset
 	appMgrParms.KubeClient = kubeClient
-	if *manageRoutes {
+	if *manageRoutes && *controllerMode == "" {
 		var rclient *routeclient.RouteV1Client
 		rclient, err = routeclient.NewForConfig(config)
 		if nil != err {

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -10,6 +10,7 @@ Added Functionality
     * Next generation routes. See `Documentation <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/next-gen-routes>`_ for more details.
         * Fix issue with liveness probe in NextGen
         * Skip processing OSCP system services to enhance performance
+        * NextGen Route controller takes precedence over Legacy Route deployment parameters
     * Ingress
         *
     * CRD

--- a/docs/config_examples/next-gen-routes/README.md
+++ b/docs/config_examples/next-gen-routes/README.md
@@ -115,6 +115,8 @@ Follow this for easy migration [Migration Guide](https://github.com/F5Networks/k
 * Routegroup specific config for each namespace/namespaceLabel is provided as part of extendedSpec through ConfigMap.
 * Global ConfigMap can be set using CIS deployment argument --route-spec-configmap="namespace/configmap-name"
 * Controller mode should be set to Openshift to enable multiple VIP support(--controller-mode="openshift")
+* NextGen Route controller deployment parameters (--controller-mode="openshift") takes precedence over legacy route deployment parameters (--manage-routes)
+* Recommendation is to avoid using legacy Route deployment parameters while using NextGen Route controller.
 
 ## Extended Spec ConfigMap:
 


### PR DESCRIPTION

**Description**: NextGen Route Controller takes precedence over Legacy Route deployment parameters

**Changes Proposed in PR**:

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [x] Updated the documentation
- [ ] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema