### PR TITLE
Add support for setting http profile analytics from policy in NextGen and VS cr

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -272,14 +272,24 @@ type ExternalDNSList struct {
 }
 
 type PolicySpec struct {
-	L7Policies  L7PolicySpec  `json:"l7Policies,omitempty"`
-	L3Policies  L3PolicySpec  `json:"l3Policies,omitempty"`
-	LtmPolicies LtmIRulesSpec `json:"ltmPolicies,omitempty"`
-	IRules      LtmIRulesSpec `json:"iRules,omitempty"`
-	IRuleList   IRuleListSpec `json:"iRuleList,omitempty"`
-	Profiles    ProfileSpec   `json:"profiles,omitempty"`
-	SNAT        string        `json:"snat,omitempty"`
-	AutoLastHop string        `json:"autoLastHop,omitempty"`
+	L7Policies        L7PolicySpec      `json:"l7Policies,omitempty"`
+	L3Policies        L3PolicySpec      `json:"l3Policies,omitempty"`
+	LtmPolicies       LtmIRulesSpec     `json:"ltmPolicies,omitempty"`
+	IRules            LtmIRulesSpec     `json:"iRules,omitempty"`
+	IRuleList         IRuleListSpec     `json:"iRuleList,omitempty"`
+	Profiles          ProfileSpec       `json:"profiles,omitempty"`
+	AnalyticsProfiles AnalyticsProfiles `json:"analyticsProfiles,omitempty"`
+	SNAT              string            `json:"snat,omitempty"`
+	AutoLastHop       string            `json:"autoLastHop,omitempty"`
+}
+
+type AnalyticsProfiles struct {
+	HTTPAnalyticsProfile HTTPAnalyticsProfile `json:"http,omitempty"`
+}
+
+type HTTPAnalyticsProfile struct {
+	BigIP string `json:"bigip,omitempty"`
+	Apply string `json:"apply,omitempty"`
 }
 
 type L7PolicySpec struct {

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -14,12 +14,14 @@ Added Functionality
         * Add Support of server-side http2 profile
         * Support setting Auto-LastHop option from policy CR
         * Support setting http mrf router option from policy CR (applied for HTTPS virtual server only)
+        * Support for setting http analytics profile from policy CR
     * Ingress
         *
     * CRD
         * Support for configuring multiple iRules with policyCR
         * Add Support of ServerSide HTTP2 Profile in Policy CR and VS CR
         * Support setting http mrf router option from policy CR(applicable only to VS cr)
+        * Support for setting http analytics profile from policy CR
     * Static route support added for ovn-k8s,flannel and antrea CNI.
     * Support for operator in openshift 4.12
 Bug Fixes

--- a/docs/config_examples/customResource/Policy/README.md
+++ b/docs/config_examples/customResource/Policy/README.md
@@ -12,8 +12,9 @@ Policy is used to apply existing BIG-IP profiles and policy with Routes, Virtual
 | l3Policies  | Object | Optional | N/A     | BIG-IP l3Policies in Policy CR.                                                                                                                                                       |
 | ltmPolicies | Object | Optional | N/A     | BIG-IP LTM Policies in Policy CR.                                                                                                                                                     |
 | iRules      | Object | Optional | N/A     | BIG-IP iRules in Policy CR.                                                                                                                                                           |
- | iRuleList  |  Object | Optional | N/A    |  List of BIGIP iRules to attach to virtuals via policy CR                                                                                                                             |
-| profiles    | Object | Optional | N/A     | Various BIG-IP Profiles in Policy CR.                                                                                                                                                 |
+ | iRuleList  |  Object | Optional | N/A    | List of BIGIP iRules to attach to virtuals via policy CR                                                                                                                              |
+| profiles    | Object | Optional | N/A     | Various BIG-IP Profiles in Policy CR.                                                                                                                                                 
+| analyticsProfiles    | Object | Optional | N/A     | Configures different analytics profiles on BIGIP virtual server.                                                                                                                      |
 | tcp         | Object | Optional | N/A     | BIG-IP TCP client and server profiles in Policy CR.                                                                                                                                   |
 | snat        | String | Optional | auto    | Reference to SNAT pool on BIG-IP. The other allowed values are: `auto` (default) and `none`. VirtualServer or TransportServer CRD resource takes precedence over Policy CRD resource. |
 | autoLastHop    | String | Optional | N/A     | Reference to Auto Last Hop on BIG-IP. Allowed values [default, auto, disable]                                                                                                         |
@@ -83,3 +84,16 @@ Policy is used to apply existing BIG-IP profiles and policy with Routes, Virtual
 | --------- | ------ | -------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | client    | String | Required | N/A Custom\_TCP | CIS uses the AS3 default TCP client profile. Allowed values are existing BIG-IP TCP Client profiles.                             |
 | server    | String | Optional | N/A             | Allowed values are existing BIG-IP TCP Server profiles. **Note: Server TCP Profile can only be used along with Client profile.** |
+
+### Analytics Profiles Components
+
+| Parameter | Type   | Required | Default         | Description                                                                                                                      |
+| --------- | ------ | -------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| http    | Object | Optional | N/A  | CIS will configure http analytics profile on virtual server.
+
+### HTTP Analytics Profile Components
+
+| Parameter | Type   | Required | Default         | Description                                                                                                                      |
+| --------- | ------ | -------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| bigip    | String | Optional | N/A  | Reference to existing http analytics profile on BIGIP
+| apply    | String | Optional | N/A  | allowed values are [http, https , both] 

--- a/docs/config_examples/customResource/Policy/policy-with-http-analytics-profile.yaml
+++ b/docs/config_examples/customResource/Policy/policy-with-http-analytics-profile.yaml
@@ -1,0 +1,20 @@
+# valid values for apply are [http, https, both]
+# if no value is specified for apply, then analytics profile will be applied for http and https VS
+# analyticsProfiles is supported in Virtual Server custom resource and NextGen routes
+apiVersion: cis.f5.com/v1
+kind: Policy
+metadata:
+  labels:
+    f5cr: "true"
+  name: cr-policy1
+  namespace: test
+spec:
+  analyticsProfiles:
+    http:
+      bigip: /Common/analytics
+      apply: http
+  iRuleList: {}
+  iRules: {}
+  l3Policies: {}
+  l7Policies: {}
+  profiles: {}

--- a/docs/config_examples/customResourceDefinitions/customresourcedefinitions.yml
+++ b/docs/config_examples/customResourceDefinitions/customresourcedefinitions.yml
@@ -869,6 +869,19 @@ spec:
                       type: array
                     httpMrfRoutingEnabled:
                       type: boolean
+                analyticsProfiles: 
+                  type: object
+                  properties:
+                    http:
+                      type: object
+                      properties:
+                        apply:
+                          type: string
+                          enum: [http, https, both]
+                        bigip:
+                          type: string
+                          pattern: '^\/[a-zA-Z]+([A-z0-9-_+]+\/)+([-A-z0-9_.:]+\/?)*$'
+
                 autoLastHop:
                   type: string
                   enum: [ default, auto, disable ]

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -1142,6 +1142,12 @@ func createServiceDecl(cfg *ResourceConfig, sharedApp as3Application, tenant str
 		svc.HttpMrfRoutingEnabled = *cfg.Virtual.HttpMrfRoutingEnabled
 	}
 	svc.AutoLastHop = cfg.Virtual.AutoLastHop
+
+	if cfg.Virtual.AnalyticsProfiles.HTTPAnalyticsProfile.BigIP != "" {
+		svc.HttpAnalyticsProfile = &as3ResourcePointer{
+			BigIP: cfg.Virtual.AnalyticsProfiles.HTTPAnalyticsProfile.BigIP,
+		}
+	}
 	processCommonDecl(cfg, svc)
 	sharedApp[cfg.Virtual.Name] = svc
 }

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -1859,6 +1859,16 @@ func (ctlr *Controller) handleVSResourceConfigForPolicy(
 		rsCfg.Virtual.HttpMrfRoutingEnabled = plc.Spec.Profiles.HttpMrfRoutingEnabled
 	}
 
+	if plc.Spec.AnalyticsProfiles.HTTPAnalyticsProfile.BigIP != "" &&
+		(rsCfg.MetaData.Protocol == HTTP || rsCfg.MetaData.Protocol == HTTPS) {
+		//  Apply : both or empty -> analytics will be applied for both HTTP and HTTPS
+		if plc.Spec.AnalyticsProfiles.HTTPAnalyticsProfile.Apply == "both" ||
+			plc.Spec.AnalyticsProfiles.HTTPAnalyticsProfile.Apply == "" ||
+			rsCfg.MetaData.Protocol == plc.Spec.AnalyticsProfiles.HTTPAnalyticsProfile.Apply {
+			rsCfg.Virtual.AnalyticsProfiles.HTTPAnalyticsProfile.BigIP = plc.Spec.AnalyticsProfiles.HTTPAnalyticsProfile.BigIP
+		}
+	}
+
 	if len(plc.Spec.Profiles.LogProfiles) > 0 {
 		rsCfg.Virtual.LogProfiles = append(rsCfg.Virtual.LogProfiles, plc.Spec.Profiles.LogProfiles...)
 	}

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -215,9 +215,19 @@ type (
 		HttpMrfRoutingEnabled      *bool                 `json:"httpMrfRoutingEnabled,omitempty"`
 		IpIntelligencePolicy       string                `json:"ipIntelligencePolicy,omitempty"`
 		AutoLastHop                string                `json:"lastHop,omitempty"`
+		AnalyticsProfiles          AnalyticsProfiles     `json:"analyticsProfiles,omitempty"`
 	}
 	// Virtuals is slice of virtuals
 	Virtuals []Virtual
+
+	AnalyticsProfiles struct {
+		HTTPAnalyticsProfile HTTPAnalyticsProfile `json:"http,omitempty"`
+	}
+
+	HTTPAnalyticsProfile struct {
+		BigIP string `json:"bigip,omitempty"`
+		Apply string `json:"apply,omitempty"`
+	}
 
 	ProfileTCP struct {
 		Client string `json:"client,omitempty"`
@@ -922,6 +932,7 @@ type (
 		ProfileBotDefense      as3MultiTypeParam    `json:"profileBotDefense,omitempty"`
 		HttpMrfRoutingEnabled  bool                 `json:"httpMrfRoutingEnabled,omitempty"`
 		IpIntelligencePolicy   as3MultiTypeParam    `json:"ipIntelligencePolicy,omitempty"`
+		HttpAnalyticsProfile   *as3ResourcePointer  `json:"profileAnalytics,omitempty"`
 	}
 
 	// as3ServiceAddress maps to VirtualAddress in AS3 Resources


### PR DESCRIPTION

**Description**:  Add support for setting http profile analytics from policy in NextGen and VS cr

**Changes Proposed in PR**: Add support for setting http profile analytics from policy in NextGen and VS cr

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema