### PR TITLE
Support to select the Virtual Server for applying an HTTP profile

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -320,7 +320,7 @@ type IRuleListSpec struct {
 type ProfileSpec struct {
 	TCP                   ProfileTCP   `json:"tcp,omitempty"`
 	UDP                   string       `json:"udp,omitempty"`
-	HTTP                  string       `json:"http,omitempty"`
+	HTTP                  ProfileHTTP  `json:"http,omitempty"`
 	HTTP2                 ProfileHTTP2 `json:"http2,omitempty"`
 	RewriteProfile        string       `json:"rewriteProfile,omitempty"`
 	PersistenceProfile    string       `json:"persistenceProfile,omitempty"`
@@ -337,6 +337,11 @@ type ProfileTCP struct {
 type ProfileHTTP2 struct {
 	Client string `json:"client,omitempty"`
 	Server string `json:"server,omitempty"`
+}
+
+type ProfileHTTP struct {
+	BigIP string `json:"bigip,omitempty"`
+	Apply string `json:"apply,omitempty"`
 }
 
 // +genclient

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -15,6 +15,7 @@ Added Functionality
         * Support setting Auto-LastHop option from policy CR
         * Support setting http mrf router option from policy CR (applied for HTTPS virtual server only)
         * Support for setting http analytics profile from policy CR
+        * Support for selecting the Virtual Server (secured/unsecured/both) on which an HTTP profile (from policyCR) has to be applied
     * Ingress
         *
     * CRD
@@ -22,6 +23,7 @@ Added Functionality
         * Add Support of ServerSide HTTP2 Profile in Policy CR and VS CR
         * Support setting http mrf router option from policy CR(applicable only to VS cr)
         * Support for setting http analytics profile from policy CR
+        * Support for selecting the Virtual Server (secured/unsecured/both) on which an HTTP profile (from policyCR) has to be applied
     * Static route support added for ovn-k8s,flannel and antrea CNI.
     * Support for operator in openshift 4.12
 Bug Fixes

--- a/docs/config_examples/customResource/Policy/README.md
+++ b/docs/config_examples/customResource/Policy/README.md
@@ -66,17 +66,17 @@ Policy is used to apply existing BIG-IP profiles and policy with Routes, Virtual
 
 ### Profile Components
 
-| Parameter          | Type           | Required | Default                                                           | Description                                                                                                                                                                                                                                |
-| ------------------ | -------------- | -------- | ----------------------------------------------------------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| udp                | String         | Optional | N/A                                                               | Pathname of existing BIG-IP UDP profile.                                                                                                                                                                                                   |
-| http               | String         | Optional | N/A                                                               | Pathname of existing BIG-IP HTTP profile.                                                                                                                                                                                                  |
-| https              | String         | Optional | N/A                                                               | Pathname of existing BIG-IP SSL profile.                                                                                                                                                                                                   |
-| http2              | String         | Optional | N/A                                                               | Pathname of existing BIG-IP HTTP2 profile.                                                                                                                                                                                                 |
-| logProfiles        | List of string | Optional | N/A                                                               | Pathname of existing BIG-IP log profile.                                                                                                                                                                                                   |
-| persistenceProfile | String         | Optional | VirtualServer uses `cookie` TransportServer uses `source-address` | CIS uses the AS3 default persistence profile. VirtualServer or TransportServer CRD resource takes precedence over Policy CRD resource. Allowed values are existing BIG-IP Persistence profiles and custom Persistence profiles.            |
-| profileMultiplex   | String         | Optional | N/A                                                               | CIS uses the AS3 default profileMultiplex profile. Allowed values are existing BIG-IP profileMultiplex profiles.                                                                                                                           |
-| profileL4          | String         | Optional | basic                                                             | The default value is `basic` but it is not configurable if the profileL4 spec is not included in TS or Policy CR. Transport CRD resource takes precedence over Policy CRD resource. Allowed values are existing BIG-IP profileL4 profiles. |
-| httpMrfRoutingEnabled    | Boolean | Optional | N/A     | Reference to Http mrf router on BIGIP.|
+| Parameter             | Type           | Required | Default                                                           | Description                                                                                                                                                                                                                                |
+|-----------------------| -------------- | -------- | ----------------------------------------------------------------- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| udp                   | String         | Optional | N/A                                                               | Pathname of existing BIG-IP UDP profile.                                                                                                                                                                                                   |
+| http                  | Object         | Optional | N/A                                                               | Pathname of existing BIG-IP HTTP profile.                                                                                                                                                                                                  |
+| https                 | String         | Optional | N/A                                                               | Pathname of existing BIG-IP SSL profile.                                                                                                                                                                                                   |
+| http2                 | Object         | Optional | N/A                                                               | Pathname of existing BIG-IP HTTP2 profile.                                                                                                                                                                                                 |
+| logProfiles           | List of string | Optional | N/A                                                               | Pathname of existing BIG-IP log profile.                                                                                                                                                                                                   |
+| persistenceProfile    | String         | Optional | VirtualServer uses `cookie` TransportServer uses `source-address` | CIS uses the AS3 default persistence profile. VirtualServer or TransportServer CRD resource takes precedence over Policy CRD resource. Allowed values are existing BIG-IP Persistence profiles and custom Persistence profiles.            |
+| profileMultiplex      | String         | Optional | N/A                                                               | CIS uses the AS3 default profileMultiplex profile. Allowed values are existing BIG-IP profileMultiplex profiles.                                                                                                                           |
+| profileL4             | String         | Optional | basic                                                             | The default value is `basic` but it is not configurable if the profileL4 spec is not included in TS or Policy CR. Transport CRD resource takes precedence over Policy CRD resource. Allowed values are existing BIG-IP profileL4 profiles. |
+| httpMrfRoutingEnabled | Boolean | Optional | N/A     | Reference to Http mrf router on BIGIP. |
 
 ### TCP Profile Components
 
@@ -97,3 +97,17 @@ Policy is used to apply existing BIG-IP profiles and policy with Routes, Virtual
 | --------- | ------ | -------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | bigip    | String | Optional | N/A  | Reference to existing http analytics profile on BIGIP
 | apply    | String | Optional | N/A  | allowed values are [http, https , both] 
+
+### HTTP Profile Components
+
+| Parameter | Type   | Required | Default         | Description                                                                                                                      |
+| --------- | ------ | -------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| bigip    | String | Optional | N/A  | Reference to existing http profile on BIGIP
+| apply    | String | Optional | N/A  | allowed values are [http, https , both] 
+
+### HTTP2 Profile Components
+
+| Parameter | Type   | Required | Default | Description                                           |
+| --------- | ------ | -------- |---------|-------------------------------------------------------|
+| client    | String | Required | N/A     | Reference to existing ingress HTTP2 profile on BIG-IP |
+| server    | String | Optional | N/A     | Reference to existing egress HTTP2 profile on BIG-IP  |

--- a/docs/config_examples/customResource/Policy/policy-with-http-profile.yaml
+++ b/docs/config_examples/customResource/Policy/policy-with-http-profile.yaml
@@ -1,0 +1,19 @@
+# Example of policyCR with the http profile
+# CIS now allows for greater control over which Virtual Server(secured, unsecured or both) HTTP profile is applied on.
+# HTTP profile field supports two parameters: bigip and apply
+# bigip: specifies BIG-IP reference for the HTTP profile. By default, it's empty.
+# apply: determines on which Virtual Server(secured, unsecured or both) the HTTP profile is applied on. By default, it's applied on both the Virtual servers(secured and unsecured VS)
+# valid values for apply are [http, https, both]
+apiVersion: cis.f5.com/v1
+kind: Policy
+metadata:
+  labels:
+    f5cr: "true"
+  name: cr-policy1
+  namespace: test
+spec:
+  profiles:
+    http:
+      bigip: /Common/http
+      # if no apply field is specified, or it's set to both then http profile is applied on both secure and unsecure VS
+      # else if apply is set to http or https then profile is applied only on the respective VS

--- a/docs/config_examples/customResource/Policy/sample-policy.yaml
+++ b/docs/config_examples/customResource/Policy/sample-policy.yaml
@@ -24,7 +24,8 @@ spec:
       client: /Common/f5-tcp-lan
       server: /Common/f5-tcp-wan
     udp: /Common/udp
-    http: /Common/http
+    http:
+      bigip: /Common/http
     http2:
       client: /Common/Samplehttp2Client
       server: /Common/Samplehttp2Server

--- a/docs/config_examples/customResourceDefinitions/customresourcedefinitions.yml
+++ b/docs/config_examples/customResourceDefinitions/customresourcedefinitions.yml
@@ -839,8 +839,14 @@ spec:
                       type: string
                       pattern: '^\/[a-zA-Z]+([A-z0-9-_+]+\/)+([-A-z0-9_.:]+\/?)*$'
                     http:
-                      type: string
-                      pattern: '^\/[a-zA-Z]+([A-z0-9-_+]+\/)+([-A-z0-9_.:]+\/?)*$'
+                      type: object
+                      properties:
+                        apply:
+                          type: string
+                          enum: [ http, https, both ]
+                        bigip:
+                          type: string
+                          pattern: '^\/[a-zA-Z]+([A-z0-9-_+]+\/)+([-A-z0-9_.:]+\/?)*$'
                     http2:
                       type: object
                       properties:

--- a/docs/upgradeProcess.md
+++ b/docs/upgradeProcess.md
@@ -280,3 +280,8 @@ Refer Release Notes for [CIS v2.11.1](https://github.com/F5Networks/k8s-bigip-ct
 ### **Upgrading from 2.12.1 to 2.13.0:**
 * CIS extended to leverage server-side http2 profile on virtual Server which requires modification in the existing Policy CRD in case of using http2 functionality.
   * Please change the PolicyCRD accordingly with this [example](https://github.com/F5Networks/k8s-bigip-ctlr/blob/master/docs/config_examples/customResource/Policy/sample-policy.yaml)
+* CIS now allows for greater control over which Virtual Server(secured, unsecured or both) HTTP profile is applied, which requires modifying the existing Policy CRD if an HTTP profile is in use.
+  * HTTP profile field in policyCR has been updated with two parameters: bigip and apply
+  * bigip: specify the HTTP profile reference. By default, it's empty.
+  * apply: determines on which Virtual Server(secured, unsecured or both) the HTTP profile is applied on. By default, it's applied on both the Virtual servers(secured and unsecured VS)
+  * Please change the PolicyCRD accordingly with the [example](https://github.com/F5Networks/k8s-bigip-ctlr/blob/master/docs/config_examples/customResource/Policy) for http profile.

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -1876,12 +1876,17 @@ func (ctlr *Controller) handleVSResourceConfigForPolicy(
 	// Profiles common for both HTTP and HTTPS
 	// service_HTTP supports profileTCP and profileHTTP
 	// service_HTTPS supports profileTCP, profileHTTP and profileHTTP2
-	if len(plc.Spec.Profiles.HTTP) > 0 {
-		rsCfg.Virtual.Profiles = append(rsCfg.Virtual.Profiles, ProfileRef{
-			Name:         plc.Spec.Profiles.HTTP,
-			Context:      "http",
-			BigIPProfile: true,
-		})
+	// If Apply: both or empty, HTTPProfile is applied on both HTTP and HTTPS Virtual Servers else if
+	// Apply: http/https, HTTPProfile is applied on the respective HTTP or HTTPs Virtual Server
+	if plc.Spec.Profiles.HTTP.BigIP != "" && (rsCfg.MetaData.Protocol == HTTP || rsCfg.MetaData.Protocol == HTTPS) {
+		if (plc.Spec.Profiles.HTTP.Apply == "" || plc.Spec.Profiles.HTTP.Apply == "both") ||
+			(rsCfg.MetaData.Protocol == plc.Spec.Profiles.HTTP.Apply) {
+			rsCfg.Virtual.Profiles = append(rsCfg.Virtual.Profiles, ProfileRef{
+				Name:         plc.Spec.Profiles.HTTP.BigIP,
+				Context:      "http",
+				BigIPProfile: true,
+			})
+		}
 	}
 
 	switch rsCfg.MetaData.Protocol {


### PR DESCRIPTION
**Description**:  Support for selecting the Virtual Server (secured/unsecured/both) on which an HTTP profile (from policyCR) has to be applied

**Changes Proposed in PR**: CIS now allows for greater control over which Virtual Server(secured, unsecured or both) HTTP profile is applied.
  * HTTP profile field in policyCR has been updated with two parameters: bigip and apply
  * bigip: specify the HTTP profile reference. By default, it's empty.
  * apply: determines on which Virtual Server(secured, unsecured or both) the HTTP profile is applied on. By default, it's applied on both the Virtual servers(secured and unsecured VS)

**Fixes**: resolves #_Github issue id_

## General Checklist
- [ ] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation
- [ ] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema