### PR TITLE
Add Support of CiliumTunnelName parameter

### DIFF
--- a/cmd/k8s-bigip-ctlr/main_test.go
+++ b/cmd/k8s-bigip-ctlr/main_test.go
@@ -449,7 +449,7 @@ var _ = Describe("Main Tests", func() {
 			Expect(len(*openshiftSDNName)).To(Equal(0),
 				"Openshift sdn name variable should not be set.")
 			Expect(len(*flannelName)).To(Equal(0), "Flannel name variable should not be set.")
-
+			Expect(len(*ciliumTunnelName)).To(Equal(0), "Cilium name variable should not be set.")
 			os.Args = []string{
 				"./bin/k8s-bigip-ctlr",
 				"--namespace=testing",
@@ -478,13 +478,13 @@ var _ = Describe("Main Tests", func() {
 				"--bigip-url=bigip.example.com",
 				"--bigip-username=admin",
 				"--openshift-sdn-name=vxlan500",
-				"--flannel-name=vxlan500",
+				"--cilium-name=vxlan500",
 			}
 
 			flags.Parse(os.Args)
 			err = verifyArgs()
 			Expect(err).ToNot(BeNil())
-			Expect(err.Error()).To(Equal("Cannot have both openshift-sdn-name and flannel-name specified."))
+			Expect(err.Error()).To(Equal("Cannot have openshift-sdn-name,cilium-name specified"))
 		})
 
 		It("handles empty vxlan flags", func() {

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -25,8 +25,9 @@ Added Functionality
         * Add Support of ServerSide HTTP2 Profile in Policy CR and VS CR
         * Support setting http mrf router option from policy CR(applicable only to VS cr)
         * Support for setting http analytics profile from policy CR
-    * Static route support added for ovn-k8s,flannel and antrea CNI.
+    * Static route support added for ovn-k8s,flannel, cilium and antrea CNI.
     * Support for operator in openshift 4.12
+    * Add --cilium-name to specify BIG-IP tunnel name for Cilium VXLAN integration
 Bug Fixes
 ````````````
 * `Issue 2632 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2632>`_: Fix hubmode support with NodePortLocal

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -151,6 +151,7 @@ type Manager struct {
 	AgentName     string
 	//vxlan
 	vxlanName         string
+	ciliumTunnelName  string
 	vxlanMode         string
 	configWriter      writer.Writer
 	staticRoutingMode bool
@@ -227,6 +228,7 @@ type Params struct {
 	//vxlan
 	VXLANName         string
 	VXLANMode         string
+	CiliumTunnelName  string
 	StaticRoutingMode bool
 	OrchestrationCNI  string
 }
@@ -396,6 +398,7 @@ func NewManager(params *Params) *Manager {
 		AgentName:              params.Agent,
 		vxlanName:              params.VXLANName,
 		vxlanMode:              params.VXLANMode,
+		ciliumTunnelName:       params.CiliumTunnelName,
 		eventChan:              params.EventChan,
 		configWriter:           params.ConfigWriter,
 		staticRoutingMode:      params.StaticRoutingMode,
@@ -3629,7 +3632,7 @@ func (appMgr *Manager) setOtherSDNType() {
 	if appMgr.TeemData.SDNType == "other" || appMgr.TeemData.SDNType == "flannel" {
 		kubePods, err := appMgr.kubeClient.CoreV1().Pods("").List(context.TODO(), metav1.ListOptions{})
 		if nil != err {
-			log.Errorf("Could not list Kubernetes Pods for CNI Chek: %v", err)
+			log.Errorf("Could not list Kubernetes Pods for CNI Check: %v", err)
 			return
 		}
 		for _, kPod := range kubePods.Items {
@@ -3681,6 +3684,7 @@ func (appMgr *Manager) setupNodeProcessing() error {
 		vxMgr, err := vxlan.NewVxlanMgr(
 			appMgr.vxlanMode,
 			tunnelName,
+			appMgr.ciliumTunnelName,
 			appMgr.UseNodeInternal(),
 			appMgr.configWriter,
 			appMgr.eventChan,

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -129,6 +129,7 @@ func NewController(params Params) *Controller {
 		nodeLabelSelector:  params.NodeLabelSelector,
 		vxlanName:          params.VXLANName,
 		vxlanMode:          params.VXLANMode,
+		ciliumTunnelName:   params.CiliumTunnelName,
 		StaticRoutingMode:  params.StaticRoutingMode,
 		OrchestrationCNI:   params.OrchestrationCNI,
 	}

--- a/pkg/controller/node_poll_handler.go
+++ b/pkg/controller/node_poll_handler.go
@@ -50,6 +50,7 @@ func (ctlr *Controller) SetupNodeProcessing() error {
 		vxMgr, err := vxlan.NewVxlanMgr(
 			ctlr.vxlanMode,
 			tunnelName,
+			ctlr.ciliumTunnelName,
 			ctlr.UseNodeInternal,
 			ctlr.Agent.ConfigWriter,
 			ctlr.Agent.EventChan,

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -61,6 +61,7 @@ type (
 		nodeLabelSelector      string
 		vxlanMode              string
 		vxlanName              string
+		ciliumTunnelName       string
 		initialSvcCount        int
 		resourceQueue          workqueue.RateLimitingInterface
 		Partition              string
@@ -106,6 +107,7 @@ type (
 		PoolMemberType     string
 		VXLANName          string
 		VXLANMode          string
+		CiliumTunnelName   string
 		UseNodeInternal    bool
 		NodePollInterval   int
 		NodeLabelSelector  string

--- a/pkg/vxlan/vxlanMgr_test.go
+++ b/pkg/vxlan/vxlanMgr_test.go
@@ -89,23 +89,23 @@ var _ = Describe("VxlanMgr Tests", func() {
 			Sections:  make(map[string]interface{}),
 		}
 
-		vxMgr, err := NewVxlanMgr("", "vxlan500", true, mock, nil)
+		vxMgr, err := NewVxlanMgr("", "vxlan500", "", true, mock, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(vxMgr).To(BeNil())
 
-		vxMgr, err = NewVxlanMgr("gobbledy-goo", "vxlan500", true, mock, nil)
+		vxMgr, err = NewVxlanMgr("gobbledy-goo", "vxlan500", "", true, mock, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(vxMgr).To(BeNil())
 
-		vxMgr, err = NewVxlanMgr("maintain", "", true, mock, nil)
+		vxMgr, err = NewVxlanMgr("maintain", "", "", true, mock, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(vxMgr).To(BeNil())
 
-		vxMgr, err = NewVxlanMgr("maintain", "vxlan500", true, nil, nil)
+		vxMgr, err = NewVxlanMgr("maintain", "vxlan500", "", true, nil, nil)
 		Expect(err).To(HaveOccurred())
 		Expect(vxMgr).To(BeNil())
 
-		vxMgr, err = NewVxlanMgr("maintain", "vxlan500", true, mock, nil)
+		vxMgr, err = NewVxlanMgr("maintain", "vxlan500", "", true, mock, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(vxMgr).ToNot(BeNil())
 	})
@@ -116,7 +116,7 @@ var _ = Describe("VxlanMgr Tests", func() {
 			Sections:  make(map[string]interface{}),
 		}
 
-		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", true, mock, nil)
+		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", "", true, mock, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(func() {
 			vxMgr.ProcessNodeUpdate(struct{}{})
@@ -130,7 +130,7 @@ var _ = Describe("VxlanMgr Tests", func() {
 			Sections:  make(map[string]interface{}),
 		}
 
-		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", true, mock, nil)
+		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", "", true, mock, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(func() {
 			vxMgr.ProcessNodeUpdate(struct{}{})
@@ -146,7 +146,7 @@ var _ = Describe("VxlanMgr Tests", func() {
 
 		nodeList := getNodeList()
 
-		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", true, mock, nil)
+		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", "", true, mock, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(func() {
 			vxMgr.ProcessNodeUpdate(nodeList)
@@ -268,7 +268,7 @@ var _ = Describe("VxlanMgr Tests", func() {
 
 		nodeList := getNodeList()
 
-		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", true, mock, nil)
+		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", "", true, mock, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(func() {
 			vxMgr.ProcessNodeUpdate(nodeList)
@@ -284,7 +284,7 @@ var _ = Describe("VxlanMgr Tests", func() {
 
 		nodeList := getNodeList()
 
-		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", true, mock, nil)
+		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", "", true, mock, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(func() {
 			vxMgr.ProcessNodeUpdate(nodeList)
@@ -300,7 +300,7 @@ var _ = Describe("VxlanMgr Tests", func() {
 
 		nodeList := getNodeList()
 
-		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", true, mock, nil)
+		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", "", true, mock, nil)
 		Expect(err).ToNot(HaveOccurred())
 		Expect(func() {
 			vxMgr.ProcessNodeUpdate(nodeList)
@@ -315,7 +315,7 @@ var _ = Describe("VxlanMgr Tests", func() {
 		}
 		fakeClient := fake.NewSimpleClientset()
 		eventChan := make(chan interface{})
-		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", true, mock, eventChan)
+		vxMgr, err := NewVxlanMgr("maintain", "vxlan500", "", true, mock, eventChan)
 		Expect(err).ToNot(HaveOccurred())
 		vxMgr.useNodeInt = true
 


### PR DESCRIPTION
**Description**:  
Cilium VTEP support for BIG-IP has been added in Cilium 1.12.0 release https://isovalent.com/blog/post/cilium-release-112/#vtep-support

add --cilium-name to allow user to specify --cilium-name=<tunnel name> for Cilium VXLAN and BIG-IP VXLAN integration, see deployment guide
https://github.com/f5devcentral/f5-ci-docs/blob/master/docs/cilium/cilium-bigip-info.rst

**Changes Proposed in PR**: #2825 
add --cilium-name to specify BIG-IP tunnel name for Cilium VXLAN integration, so user will not be confused when asked to use --flannel-name to specify BIG-IP tunnel name

Co-developed-by: Vincent Li <v.li@f5.com> 

**Fixes**: resolves #2825, #2826

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema