### PR TITLE
Add support for setting client and server ssl profiles from policy in NextGen

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -292,6 +292,11 @@ type PolicySpec struct {
 	AutoLastHop       string            `json:"autoLastHop,omitempty"`
 }
 
+type SSLProfiles struct {
+	ClientProfiles []string `json:"clientProfiles,omitempty"`
+	ServerProfiles []string `json:"serverProfiles,omitempty"`
+}
+
 type AnalyticsProfiles struct {
 	HTTPAnalyticsProfile HTTPAnalyticsProfile `json:"http,omitempty"`
 }
@@ -337,6 +342,7 @@ type ProfileSpec struct {
 	ProfileL4             string       `json:"profileL4,omitempty"`
 	ProfileMultiplex      string       `json:"profileMultiplex,omitempty"`
 	HttpMrfRoutingEnabled *bool        `json:"httpMrfRoutingEnabled,omitempty"`
+	SSLProfiles           SSLProfiles  `json:"sslProfiles,omitempty"`
 }
 type ProfileTCP struct {
 	Client string `json:"client,omitempty"`

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -15,6 +15,7 @@ Added Functionality
         * Support setting Auto-LastHop option from policy CR
         * Support setting http mrf router option from policy CR (applied for HTTPS virtual server only)
         * Support for setting http analytics profile from policy CR
+        * Support for setting client and server ssl profiles from policy CR
     * Ingress
         *
     * CRD

--- a/docs/config_examples/customResource/Policy/README.md
+++ b/docs/config_examples/customResource/Policy/README.md
@@ -76,7 +76,11 @@ Policy is used to apply existing BIG-IP profiles and policy with Routes, Virtual
 | persistenceProfile | String         | Optional | VirtualServer uses `cookie` TransportServer uses `source-address` | CIS uses the AS3 default persistence profile. VirtualServer or TransportServer CRD resource takes precedence over Policy CRD resource. Allowed values are existing BIG-IP Persistence profiles and custom Persistence profiles.            |
 | profileMultiplex   | String         | Optional | N/A                                                               | CIS uses the AS3 default profileMultiplex profile. Allowed values are existing BIG-IP profileMultiplex profiles.                                                                                                                           |
 | profileL4          | String         | Optional | basic                                                             | The default value is `basic` but it is not configurable if the profileL4 spec is not included in TS or Policy CR. Transport CRD resource takes precedence over Policy CRD resource. Allowed values are existing BIG-IP profileL4 profiles. |
-| httpMrfRoutingEnabled    | Boolean | Optional | N/A     | Reference to Http mrf router on BIGIP.|
+| httpMrfRoutingEnabled    | Boolean | Optional | N/A     | Reference to Http mrf router on BIGIP.                                                                                                                                                                                                     |
+| sslProfiles    | Object | Optional | N/A     | Reference to existing ssl profiles on BIGIP. Policy sslProfiles will have the highest precedence and will override route level profiles                                                                                                    |
+
+**Note**:
+* sslProfiles is only applicable to NextGen routes
 
 ### TCP Profile Components
 
@@ -97,3 +101,13 @@ Policy is used to apply existing BIG-IP profiles and policy with Routes, Virtual
 | --------- | ------ | -------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | bigip    | String | Optional | N/A  | Reference to existing http analytics profile on BIGIP
 | apply    | String | Optional | N/A  | allowed values are [http, https , both] 
+
+### SSL Profile Components
+
+| Parameter | Type   | Required | Default         | Description                                                                                                                      |
+| --------- | ------ | -------- | --------------- | -------------------------------------------------------------------------------------------------------------------------------- |
+| clientProfiles    | Array | Optional | N/A  | Reference to list of existing client SSL profiles on BIGIP
+| serverProfiles    | Array | Optional | N/A  | Reference to list of existing server SSL profiles on BIGIP
+
+**Note**:
+* SSL profile components are only applicable to NextGen routes

--- a/docs/config_examples/customResource/Policy/policy-with-client-server-ssl-profile.yaml
+++ b/docs/config_examples/customResource/Policy/policy-with-client-server-ssl-profile.yaml
@@ -1,0 +1,21 @@
+# sslProfiles in policy is applicable only to nextGen routes
+# CIS in custom resource mode will not process sslProfiles from policy
+# to configure ssl profiles in CRD mode, we recommend to use tls profiles
+apiVersion: cis.f5.com/v1
+kind: Policy
+metadata:
+  labels:
+    f5cr: "true"
+  name: cr-policy1
+  namespace: test
+spec:
+  iRuleList: {}
+  iRules: {}
+  l3Policies: {}
+  l7Policies: {}
+  profiles:
+    sslProfiles:
+      clientProfiles:
+        - /Common/clientssl
+      serverProfiles:
+        - /Common/serverssl

--- a/docs/config_examples/customResourceDefinitions/customresourcedefinitions.yml
+++ b/docs/config_examples/customResourceDefinitions/customresourcedefinitions.yml
@@ -891,6 +891,20 @@ spec:
                       type: array
                     httpMrfRoutingEnabled:
                       type: boolean
+                    sslProfiles:
+                      type: object
+                      properties:
+                        clientProfiles:
+                          items:
+                            type: string
+                            pattern: '^\/[a-zA-Z]+([A-z0-9-_+]+\/)+([-A-z0-9_.:]+\/?)*$'
+                          type: array
+                        serverProfiles:
+                          items:
+                            type: string
+                            pattern: '^\/[a-zA-Z]+([A-z0-9-_+]+\/)+([-A-z0-9_.:]+\/?)*$'
+                          type: array
+
                 analyticsProfiles: 
                   type: object
                   properties:

--- a/docs/upgradeProcess.md
+++ b/docs/upgradeProcess.md
@@ -280,3 +280,7 @@ Refer Release Notes for [CIS v2.11.1](https://github.com/F5Networks/k8s-bigip-ct
 ### **Upgrading from 2.12.1 to 2.13.0:**
 * CIS extended to leverage server-side http2 profile on virtual Server which requires modification in the existing Policy CRD in case of using http2 functionality.
   * Please change the PolicyCRD accordingly with this [example](https://github.com/F5Networks/k8s-bigip-ctlr/blob/master/docs/config_examples/customResource/Policy/sample-policy.yaml)
+* In NextGen mode CIS supports setting client and server ssl profiles from policy
+  * This setting is exclusive for NextGen mode and not applicable for CRD resources
+  * Policy level ssl profiles will have the highest precedence and will override route level profiles
+  * In CRD mode CIS will process ssl profiles from tls profile

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -1124,6 +1124,13 @@ type (
 		tlsCipher                TLSCipher
 	}
 
+	rgPlcSSLProfiles struct {
+		plcNamespace string
+		plcName      string
+		clientSSLs   []string
+		serverSSLs   []string
+	}
+
 	poolPathRef struct {
 		path           string
 		poolName       string


### PR DESCRIPTION

**Description**: Add support for setting client and server ssl profiles from policy in NextGen

**Changes Proposed in PR**: Add support for setting client and server ssl profiles from policy in NextGen

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema