### PR TITLE
Fix for handling fail-over scenarios

### DIFF
--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -218,6 +218,27 @@ func (agent *Agent) PostConfig(rsConfig ResourceConfigRequest) {
 	}
 }
 
+// removeDeletedTenantsForBigIP will check the tenant exists on bigip or not
+// if tenant exists and rsConfig does not have tenant, update the tenant with empty PartitionConfig
+func (agent *Agent) removeDeletedTenantsForBigIP(rsConfig *ResourceConfigRequest, cisLabel string) {
+	//Fetching the latest BIGIP Configuration and identify if any tenant needs to be deleted
+	as3Config, err := agent.PostManager.GetAS3DeclarationFromBigIP()
+	if err != nil {
+		log.Errorf("[AS3] Could not fetch the latest AS3 declaration from BIG-IP")
+	}
+	for k, v := range as3Config {
+		if decl, ok := v.(map[string]interface{}); ok {
+			if label, found := decl["label"]; found && label == cisLabel && k != agent.Partition+"_gtm" {
+				if _, ok := rsConfig.ltmConfig[k]; !ok {
+					// adding an empty tenant to delete the tenant from BIGIP
+					priority := 1
+					rsConfig.ltmConfig[k] = &PartitionConfig{Priority: &priority}
+				}
+			}
+		}
+	}
+}
+
 // agentWorker blocks on postChan
 // whenever it gets unblocked, it creates an as3 declaration for modified tenants and posts the request
 func (agent *Agent) agentWorker() {
@@ -626,10 +647,11 @@ func (agent *Agent) createAS3GTMConfigADC(config ResourceConfigRequest, adc as3A
 		sharedApp := as3Application{}
 		sharedApp["class"] = "Application"
 		sharedApp["template"] = "shared"
-
+		cisLabel := agent.Partition
 		tenantDecl := as3Tenant{
 			"class":              "Tenant",
 			as3SharedApplication: sharedApp,
+			"label":              cisLabel,
 		}
 		adc[DEFAULT_GTM_PARTITION] = tenantDecl
 
@@ -712,10 +734,15 @@ func (agent *Agent) createAS3GTMConfigADC(config ResourceConfigRequest, adc as3A
 
 func (agent *Agent) createAS3LTMConfigADC(config ResourceConfigRequest) as3ADC {
 	adc := as3ADC{}
+	cisLabel := agent.Partition
+	// if this is the first post delete the tenant which is monitored by CIS and current request does not contain it
+	if agent.firstPost {
+		agent.removeDeletedTenantsForBigIP(&config, cisLabel)
+	}
 	for tenant := range agent.cachedTenantDeclMap {
 		if _, ok := config.ltmConfig[tenant]; !ok && !agent.isGTMTenant(tenant) {
 			// Remove partition
-			adc[tenant] = getDeletedTenantDeclaration(agent.Partition, tenant)
+			adc[tenant] = getDeletedTenantDeclaration(agent.Partition, tenant, cisLabel)
 		}
 	}
 	for tenantName, partitionConfig := range config.ltmConfig {
@@ -727,7 +754,7 @@ func (agent *Agent) createAS3LTMConfigADC(config ResourceConfigRequest) as3ADC {
 		partitionConfig.PriorityMutex.RUnlock()
 		if len(partitionConfig.ResourceMap) == 0 {
 			// Remove partition
-			adc[tenantName] = getDeletedTenantDeclaration(agent.Partition, tenantName)
+			adc[tenantName] = getDeletedTenantDeclaration(agent.Partition, tenantName, cisLabel)
 			continue
 		}
 		// Create Shared as3Application object
@@ -753,13 +780,14 @@ func (agent *Agent) createAS3LTMConfigADC(config ResourceConfigRequest) as3ADC {
 			"class":              "Tenant",
 			"defaultRouteDomain": config.defaultRouteDomain,
 			as3SharedApplication: sharedApp,
+			"label":              cisLabel,
 		}
 		adc[tenantName] = tenantDecl
 	}
 	return adc
 }
 
-func getDeletedTenantDeclaration(defaultPartition, tenant string) as3Tenant {
+func getDeletedTenantDeclaration(defaultPartition, tenant, cisLabel string) as3Tenant {
 	if defaultPartition == tenant {
 		// Flush Partition contents
 		sharedApp := as3Application{}
@@ -768,6 +796,7 @@ func getDeletedTenantDeclaration(defaultPartition, tenant string) as3Tenant {
 		return as3Tenant{
 			"class":              "Tenant",
 			as3SharedApplication: sharedApp,
+			"label":              cisLabel,
 		}
 	}
 	return as3Tenant{

--- a/pkg/controller/backend_test.go
+++ b/pkg/controller/backend_test.go
@@ -19,6 +19,8 @@ var _ = Describe("Backend Tests", func() {
 				Sections:  make(map[string]interface{}),
 			}
 			agent = newMockAgent(writer)
+			agent.PostManager = &PostManager{PostParams: PostParams{BIGIPURL: "https://192.168.1.1"}}
+			agent.Partition = "test"
 			agent.userAgent = "as3"
 
 			mem1 = PoolMember{
@@ -283,7 +285,7 @@ var _ = Describe("Backend Tests", func() {
 
 			zero := 0
 			config.ltmConfig["default"] = &PartitionConfig{ResourceMap: make(ResourceMap), Priority: &zero}
-
+			agent.BIGIPURL = "https://192.168.1.1"
 			as3decl := agent.createTenantAS3Declaration(config)
 			var as3Config map[string]interface{}
 			_ = json.Unmarshal([]byte(as3decl), &as3Config)
@@ -425,9 +427,10 @@ var _ = Describe("Backend Tests", func() {
 			Expect(val).NotTo(BeNil())
 		})
 		It("Test Deleted Partition", func() {
-			deletedPartition := getDeletedTenantDeclaration("test", "test")
+			cisLabel := "test"
+			deletedPartition := getDeletedTenantDeclaration("test", "test", cisLabel)
 			Expect(deletedPartition[as3SharedApplication]).NotTo(BeNil())
-			deletedPartition = getDeletedTenantDeclaration("test", "default")
+			deletedPartition = getDeletedTenantDeclaration("test", "default", cisLabel)
 			Expect(deletedPartition[as3SharedApplication]).To(BeNil())
 		})
 	})

--- a/pkg/controller/postManager.go
+++ b/pkg/controller/postManager.go
@@ -366,6 +366,35 @@ func (postMgr *PostManager) GetBigipRegKey() (string, error) {
 	return "", fmt.Errorf("Error response from BIGIP with status code %v", httpResp.StatusCode)
 }
 
+func (postMgr *PostManager) GetAS3DeclarationFromBigIP() (map[string]interface{}, error) {
+	url := postMgr.getAS3APIURL([]string{})
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		log.Errorf("[AS3] Creating new HTTP request error: %v ", err)
+		return nil, err
+	}
+
+	log.Debugf("[AS3] posting GET BIGIP AS3 declaration request on %v", url)
+	req.SetBasicAuth(postMgr.BIGIPUsername, postMgr.BIGIPPassword)
+
+	httpResp, responseMap := postMgr.httpReq(req)
+	if httpResp == nil || responseMap == nil {
+		return nil, fmt.Errorf("Internal Error")
+	}
+
+	switch httpResp.StatusCode {
+	case http.StatusOK:
+		return responseMap, err
+	case http.StatusNotFound:
+		responseMap["code"] = int(responseMap["code"].(float64))
+		if responseMap["code"] == http.StatusNotFound {
+			return nil, fmt.Errorf("AS3 RPM is not installed on BIGIP,"+
+				" Error response from BIGIP with status code %v", httpResp.StatusCode)
+		}
+	}
+	return nil, fmt.Errorf("Error response from BIGIP with status code %v", httpResp.StatusCode)
+}
+
 func (postMgr *PostManager) httpReq(request *http.Request) (*http.Response, map[string]interface{}) {
 	httpResp, err := postMgr.httpClient.Do(request)
 	if err != nil {


### PR DESCRIPTION
**Description**:  Fix for handling fail-over scenarios

**Changes Proposed in PR**: With these changes we will we performing following actions at CIS startup so we delete any partition which is not monitored by CIS HA.

1. Get AS3 Declaration
2. Compare tenants got from BigIP AS3 declaration with current rsConfig tenants 
3. Any tenant which is not there in current rsConfig needs to be removed from BIGIP. 
4. Add an empty partition config in rsConfig to delete the tenant.

Note: We are using tenant label to identify that tenant is created by this CIS instance. Tenant label consist of BIGIP-IP and default partition to identify unique CIS instance.


## General Checklist
- [x] Smoke testing completed
