### PR TITLE
Add HTTP Monitor Support for Transport Server CR

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -25,13 +25,16 @@ Added Functionality
         * Add Support of ServerSide HTTP2 Profile in Policy CR and VS CR
         * Support setting http mrf router option from policy CR(applicable only to VS cr)
         * Support for setting http analytics profile from policy CR
+        * Support HTTP Monitor for Transport Server CR
     * Static route support added for ovn-k8s,flannel, cilium and antrea CNI.
     * Support for operator in openshift 4.12
     * Add --cilium-name to specify BIG-IP tunnel name for Cilium VXLAN integration
+
 Bug Fixes
 ````````````
 * `Issue 2632 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2632>`_: Fix hubmode support with NodePortLocal
 * `Issue 2821 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2821>`_: Fix for additionalVirtualAddresses with serviceAddress config
+* `Issue 2550 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2550>`_: Ability to specify monitors for TransportServer CR
 
 Upgrade notes
 ``````````````

--- a/docs/config_examples/customResource/TransportServer/monitors-transport-server.yaml
+++ b/docs/config_examples/customResource/TransportServer/monitors-transport-server.yaml
@@ -18,6 +18,10 @@ spec:
         type: tcp
       - name: /Common/http
         reference: bigip
+      - interval: 10
+        targetPort: 8080
+        timeout: 10
+        type: http
     service: pytest-svc-1
     servicePort: 1344
   snat: auto

--- a/docs/config_examples/customResourceDefinitions/incubator/customresourcedefinitions.yml
+++ b/docs/config_examples/customResourceDefinitions/incubator/customresourcedefinitions.yml
@@ -492,7 +492,7 @@ spec:
                       properties:
                         type:
                           type: string
-                          enum: [tcp, udp]
+                          enum: [tcp, udp, http, https]
                         interval:
                           type: integer
                         timeout:
@@ -505,6 +505,10 @@ spec:
                         reference:
                           type: string
                           enum: [bigip]
+                        send:
+                          type: string
+                        recv:
+                          type: string
                     monitors:
                       type: array
                       items:
@@ -512,7 +516,7 @@ spec:
                         properties:
                             type:
                               type: string
-                              enum: [ tcp, udp ]
+                              enum: [ tcp, udp, http, https ]
                             interval:
                               type: integer
                             timeout:
@@ -525,6 +529,10 @@ spec:
                             reference:
                               type: string
                               enum: [bigip]
+                            send:
+                              type: string
+                            recv:
+                              type: string
                     reselectTries:
                       type: integer
                       minimum: 0

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -1728,8 +1728,8 @@ func (ctlr *Controller) prepareRSConfigFromTransportServer(
 			Partition:  rsCfg.Virtual.Partition,
 			Type:       vs.Spec.Pool.Monitor.Type,
 			Interval:   vs.Spec.Pool.Monitor.Interval,
-			Send:       "",
-			Recv:       "",
+			Send:       vs.Spec.Pool.Monitor.Send,
+			Recv:       vs.Spec.Pool.Monitor.Recv,
 			Timeout:    vs.Spec.Pool.Monitor.Timeout,
 			TargetPort: vs.Spec.Pool.Monitor.TargetPort,
 		}
@@ -1756,8 +1756,8 @@ func (ctlr *Controller) prepareRSConfigFromTransportServer(
 					Partition:  rsCfg.Virtual.Partition,
 					Type:       monitor.Type,
 					Interval:   monitor.Interval,
-					Send:       "",
-					Recv:       "",
+					Send:       monitor.Send,
+					Recv:       monitor.Recv,
 					Timeout:    monitor.Timeout,
 					TargetPort: monitor.TargetPort,
 				}

--- a/pkg/controller/resourceConfig_test.go
+++ b/pkg/controller/resourceConfig_test.go
@@ -383,6 +383,29 @@ var _ = Describe("Resource Config Tests", func() {
 			Expect(rsCfg.Pools[0].ServiceNamespace).To(Equal("test"), "Incorrect namespace defined for pool")
 		})
 
+		It("Prepare Resource Config from a TransportServer with HTTP Monitor", func() {
+			ts := test.NewTransportServer(
+				"SampleTS",
+				namespace,
+				cisapiv1.TransportServerSpec{
+					Pool: cisapiv1.Pool{
+						Service:          "svc1",
+						ServicePort:      intstr.IntOrString{IntVal: 80},
+						ServiceNamespace: "test",
+						Monitor: cisapiv1.Monitor{
+							Type:       "http",
+							Send:       "GET /health",
+							Interval:   15,
+							Timeout:    10,
+							TargetPort: 80,
+						},
+					},
+				},
+			)
+			err := mockCtlr.prepareRSConfigFromTransportServer(rsCfg, ts)
+			Expect(err).To(BeNil(), "Failed to Prepare Resource Config from TransportServer with HTTP Monitor")
+			Expect(rsCfg.Pools[0].ServiceNamespace).To(Equal("test"), "Incorrect namespace defined for pool")
+		})
 		It("Prepare Resource Config from a TransportServer", func() {
 			ts := test.NewTransportServer(
 				"SampleTS",
@@ -403,6 +426,20 @@ var _ = Describe("Resource Config Tests", func() {
 								Timeout:    10,
 								Interval:   10,
 								TargetPort: 22,
+							},
+							{
+								Type:       "http",
+								Timeout:    20,
+								Interval:   20,
+								TargetPort: 32,
+							},
+							{
+								Type:       "http",
+								Timeout:    30,
+								Interval:   30,
+								TargetPort: 42,
+								Send:       "Get /api HTTP 1.1",
+								Recv:       "200",
 							},
 						},
 					},


### PR DESCRIPTION
**Description**:  Add HTTP Monitor Support for Transport Server CR

**Changes Proposed in PR**:
Add HTTP Monitor Support for Transport Server CR

**Fixes**: resolves #2550

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [ ] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema