### PR TITLE
Skip recreating IPAM CR

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -297,21 +297,6 @@ func (ctlr *Controller) createIPAMResource() error {
 		return nil
 	}
 
-	if strings.Contains(err.Error(), "already exists") {
-		err = ctlr.ipamCli.Delete(IPAMNamespace, crName, metaV1.DeleteOptions{})
-		if err != nil {
-			log.Debugf("[ipam] Delete failed. Error: %s", err.Error())
-		}
-
-		time.Sleep(3 * time.Second)
-
-		ipamCR, err = ctlr.ipamCli.Create(f5ipam)
-		if err == nil {
-			log.Debugf("[ipam] Created IPAM Custom Resource: \n%v\n", ipamCR)
-			return nil
-		}
-	}
-
 	log.Debugf("[ipam] error while creating IPAM custom resource. %v", err.Error())
 	return err
 }

--- a/pkg/controller/responseHandler.go
+++ b/pkg/controller/responseHandler.go
@@ -2,6 +2,8 @@ package controller
 
 import (
 	"container/list"
+	ficV1 "github.com/F5Networks/f5-ipam-controller/pkg/ipamapis/apis/fic/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"strings"
 	"sync"
 
@@ -52,6 +54,7 @@ func (ctlr *Controller) responseHandler(respChan chan resourceStatusMeta) {
 				continue
 			}
 			for rscKey, kind := range meta {
+				ctlr.removeUnusedIPAMEntries(kind)
 				ns := strings.Split(rscKey, "/")[0]
 				switch kind {
 				case VirtualServer:
@@ -168,4 +171,53 @@ func (ctlr *Controller) dequeueReq(id int, failedTenantsLen int) requestMeta {
 	}
 
 	return rm
+}
+
+func (ctlr *Controller) removeUnusedIPAMEntries(kind string) {
+	// Remove Unused IPAM entries in IPAM CR after CIS restarts, applicable to only first PostCall
+	if !ctlr.firstPostResponse && ctlr.ipamCli != nil && (kind == VirtualServer || kind == TransportServer) {
+		ctlr.firstPostResponse = true
+		toRemoveIPAMEntries := &ficV1.IPAM{
+			ObjectMeta: metav1.ObjectMeta{
+				Labels: make(map[string]string),
+			},
+		}
+		ipamCR := ctlr.getIPAMCR()
+		for _, hostSpec := range ipamCR.Spec.HostSpecs {
+			found := false
+			ctlr.cacheIPAMHostSpecs.Lock()
+			for cacheIndex, cachehostSpec := range ctlr.cacheIPAMHostSpecs.IPAM.Spec.HostSpecs {
+				if (hostSpec.IPAMLabel == cachehostSpec.IPAMLabel && hostSpec.Host == cachehostSpec.Host) ||
+					(hostSpec.IPAMLabel == cachehostSpec.IPAMLabel && hostSpec.Key == cachehostSpec.Key) ||
+					(hostSpec.IPAMLabel == cachehostSpec.IPAMLabel && hostSpec.Key == cachehostSpec.Key && hostSpec.Host == cachehostSpec.Host) {
+					if len(ctlr.cacheIPAMHostSpecs.IPAM.Spec.HostSpecs) > cacheIndex {
+						ctlr.cacheIPAMHostSpecs.IPAM.Spec.HostSpecs = append(ctlr.cacheIPAMHostSpecs.IPAM.Spec.HostSpecs[:cacheIndex], ctlr.cacheIPAMHostSpecs.IPAM.Spec.HostSpecs[cacheIndex+1:]...)
+					}
+					found = true
+					break
+				}
+			}
+			ctlr.cacheIPAMHostSpecs.Unlock()
+			if !found {
+				// To remove
+				toRemoveIPAMEntries.Spec.HostSpecs = append(toRemoveIPAMEntries.Spec.HostSpecs, hostSpec)
+			}
+		}
+		for _, removeIPAMentry := range toRemoveIPAMEntries.Spec.HostSpecs {
+			ipamCR = ctlr.getIPAMCR()
+			for index, hostSpec := range ipamCR.Spec.HostSpecs {
+				if (hostSpec.IPAMLabel == removeIPAMentry.IPAMLabel && hostSpec.Host == removeIPAMentry.Host) ||
+					(hostSpec.IPAMLabel == removeIPAMentry.IPAMLabel && hostSpec.Key == removeIPAMentry.Key) ||
+					(hostSpec.IPAMLabel == removeIPAMentry.IPAMLabel && hostSpec.Key == removeIPAMentry.Key && hostSpec.Host == removeIPAMentry.Host) {
+					_, err := ctlr.RemoveIPAMCRHostSpec(ipamCR, removeIPAMentry.Key, index)
+					if err != nil {
+						log.Errorf("[ipam] ipam hostspec update error: %v", err)
+					}
+					break
+				}
+			}
+		}
+		// Delete cacheIPAMHostSpecs
+		ctlr.cacheIPAMHostSpecs = CacheIPAM{}
+	}
 }

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -71,6 +71,7 @@ type (
 		oldNodes               []Node
 		UseNodeInternal        bool
 		initState              bool
+		firstPostResponse      bool
 		dgPath                 string
 		shareNodes             bool
 		ipamCli                *ipammachinery.IPAMClient
@@ -82,6 +83,7 @@ type (
 		ipamHostSpecEmpty      bool
 		StaticRoutingMode      bool
 		OrchestrationCNI       string
+		cacheIPAMHostSpecs     CacheIPAM
 		resourceContext
 	}
 	resourceContext struct {
@@ -393,7 +395,10 @@ type (
 		Weight            int32              `json:"weight,omitempty"`
 		AlternateBackends []AlternateBackend `json:"alternateBackends"`
 	}
-
+	CacheIPAM struct {
+		IPAM *ficV1.IPAM
+		sync.Mutex
+	}
 	// AlternateBackends lists backend svc of A/B
 	AlternateBackend struct {
 		Service          string `json:"service"`

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -1593,6 +1593,26 @@ func (ctlr *Controller) requestIP(ipamLabel string, host string, key string) (st
 		return "", InvalidInput
 	}
 
+	// Add all processed IPAM entries till first PostCall.
+	if !ctlr.firstPostResponse {
+		if ctlr.cacheIPAMHostSpecs == (CacheIPAM{}) {
+			ctlr.cacheIPAMHostSpecs = CacheIPAM{
+				IPAM: &ficV1.IPAM{
+					TypeMeta: metav1.TypeMeta{
+						Kind:       "IPAM",
+						APIVersion: "v1",
+					},
+				},
+			}
+		}
+		ctlr.cacheIPAMHostSpecs.Lock()
+		ctlr.cacheIPAMHostSpecs.IPAM.Spec.HostSpecs = append(ctlr.cacheIPAMHostSpecs.IPAM.Spec.HostSpecs, &ficV1.HostSpec{
+			Host:      host,
+			Key:       key,
+			IPAMLabel: ipamLabel,
+		})
+		ctlr.cacheIPAMHostSpecs.Unlock()
+	}
 	if host != "" {
 		//For VS server
 		for _, ipst := range ipamCR.Status.IPStatus {

--- a/pkg/controller/worker_test.go
+++ b/pkg/controller/worker_test.go
@@ -205,9 +205,6 @@ var _ = Describe("Worker Tests", func() {
 		It("Create IPAM Custom Resource", func() {
 			err := mockCtlr.createIPAMResource()
 			Expect(err).To(BeNil(), "Failed to Create IPAM Custom Resource")
-			err = mockCtlr.createIPAMResource()
-			Expect(err).To(BeNil(), "Failed to Create IPAM Custom Resource")
-
 		})
 
 		It("Get IPAM Resource", func() {


### PR DESCRIPTION
**Description**:  Skip recreating IPAM CR

**Changes Proposed in PR**: Comparing all the CIS processed IPAM entries with the existing IPAM CR entries and removing the unused iPAM entries from the IPAM CR after the first Post Call. 

**Fixes**: resolves #_Github issue id_

## General Checklist
- [ ] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation
- [ ] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema