### PR TITLE
Moving the node informers at appManager level

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -751,6 +751,10 @@ func GetNamespaces(appMgr *appmanager.Manager) {
 func setupWatchers(appMgr *appmanager.Manager, resyncPeriod time.Duration) {
 	label := resource.DefaultConfigMapLabel
 
+	err := appMgr.AddNodeInformer(resyncPeriod)
+	if nil != err {
+		log.Warningf("[INIT] Failed to add node informer for the controller:%v", err)
+	}
 	if len(*namespaceLabel) == 0 {
 		// For periodic monitoring
 		// Non monitoring namespaces will not be processed

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -15,6 +15,7 @@ Bug Fixes
 * Exclude the removal of static ARP entries for Flannel CNI during CIS restart
 * `Issue 2800 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2800>`_: Fix monitor not creating for VS CRD when send string is missing
 * `Issue 2867 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2867>`_: Ignore virtualServerName if hostGroup configured
+* `Issue 2898 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2898>`_: Fix for CIS crash with namespace-label parameter
 
 2.13.0
 -------------

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -406,8 +406,7 @@ func (m *mockAppManager) addNamespace(ns *v1.Namespace) bool {
 }
 
 func (m *mockAppManager) addNode(node *v1.Node, ns string) {
-	appInf, _ := m.appMgr.getNamespaceInformer(ns)
-	appInf.nodeInformer.GetStore().Add(node)
+	m.appMgr.nodeInformer.nodeInformer.GetStore().Add(node)
 	m.appMgr.setupNodeProcessing()
 }
 

--- a/pkg/appmanager/ingress_test.go
+++ b/pkg/appmanager/ingress_test.go
@@ -1039,6 +1039,8 @@ var _ = Describe("V1 Ingress Tests", func() {
 			Expect(err).To(BeNil())
 			mockMgr.appMgr.useNodeInternal = true
 			mockMgr.appMgr.WatchedNS = WatchedNamespaces{Namespaces: []string{namespace}}
+			_ = mockMgr.appMgr.AddNodeInformer(0)
+			mockMgr.appMgr.startAndSyncNodeInformer()
 			// Ingress first
 			ingressConfig := netv1.IngressSpec{
 				IngressClassName: &IngressClassName,
@@ -1067,8 +1069,7 @@ var _ = Describe("V1 Ingress Tests", func() {
 			node := test.NewNode("node1", "1", false,
 				[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.1"}}, []v1.Taint{})
 			mockMgr.addNode(node, namespace)
-			appInf, _ := mockMgr.appMgr.getNamespaceInformer(namespace)
-			Expect(len(appInf.nodeInformer.GetIndexer().List())).To(Equal(1))
+			Expect(len(mockMgr.appMgr.nodeInformer.nodeInformer.GetIndexer().List())).To(Equal(1))
 
 			// Create the services
 			fooSvc := test.NewService("foo", "1", namespace, "NodePort",


### PR DESCRIPTION
**Description**:  Moving the node informers at appManager level

**Changes Proposed in PR**: Currently we are creating node informer for each namespace in namespace mode. With this PR we will be creating a single node informer at controller level

**Fixes**: resolves #2898 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed