### PR TITLE
Ignore virtualservername if hostgroup configured

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -14,6 +14,7 @@ Bug Fixes
 ````````````
 * Exclude the removal of static ARP entries for Flannel CNI during CIS restart
 * `Issue 2800 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2800>`_: Fix monitor not creating for VS CRD when send string is missing
+* `Issue 2867 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2867>`_: Ignore virtualServerName if hostGroup configured
 
 2.13.0
 -------------

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -1076,10 +1076,19 @@ func (ctlr *Controller) processVirtualServers(
 		// TODO: Add Route Domain
 		var rsName string
 		if virtual.Spec.VirtualServerName != "" {
-			rsName = formatCustomVirtualServerName(
-				virtual.Spec.VirtualServerName,
-				portStruct.port,
-			)
+			if virtual.Spec.HostGroup != "" {
+				//Ignore virtualServerName if hostgroup is configured on virtual
+				log.Warningf("virtualServerName is ignored as hostgroup is configured on virtualserver %v", virtual.Name)
+				rsName = formatVirtualServerName(
+					ip,
+					portStruct.port,
+				)
+			} else {
+				rsName = formatCustomVirtualServerName(
+					virtual.Spec.VirtualServerName,
+					portStruct.port,
+				)
+			}
 		} else {
 			rsName = formatVirtualServerName(
 				ip,


### PR DESCRIPTION
**Description**:  Ignore virtualservername if hostgroup parameter is  configured on virtualserver CR

**Fixes**: resolves #2867

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed

