### PR TITLE
Fix monitor not creating for VS CRD when send string is missing

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -13,6 +13,7 @@ Added Functionality
 Bug Fixes
 ````````````
 * Exclude the removal of static ARP entries for Flannel CNI during CIS restart
+* `Issue 2800 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2800>`_: Fix monitor not creating for VS CRD when send string is missing
 
 2.13.0
 -------------

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -497,7 +497,7 @@ func (ctlr *Controller) prepareRSConfigFromVirtualServer(
 			}
 			if pl.Monitor.Name != "" && pl.Monitor.Reference == "bigip" {
 				pool.MonitorNames = append(pool.MonitorNames, MonitorName{Name: pl.Monitor.Name, Reference: pl.Monitor.Reference})
-			} else if pl.Monitor.Send != "" && pl.Monitor.Type != "" {
+			} else if pl.Monitor.Type != "" {
 				if pl.Name == "" {
 					monitorName = formatMonitorName(svcNamespace, SvcBackend.Name, pl.Monitor.Type, pl.ServicePort, vs.Spec.Host, pl.Path)
 				}


### PR DESCRIPTION
**Description**: Fix monitor not creating for VS CRD when send string is missing

**Changes Proposed in PR**: Fix monitor not creating for VS CRD when send string is missing

**Fixes**:  #2800 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema