### PR TITLE
Enable tcp monitor for VS crd without send string

### DIFF
--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -497,7 +497,7 @@ func (ctlr *Controller) prepareRSConfigFromVirtualServer(
 			}
 			if pl.Monitor.Name != "" && pl.Monitor.Reference == "bigip" {
 				pool.MonitorNames = append(pool.MonitorNames, MonitorName{Name: pl.Monitor.Name, Reference: pl.Monitor.Reference})
-			} else if pl.Monitor.Send != "" && pl.Monitor.Type != "" {
+			} else if (pl.Monitor.Send != "" && pl.Monitor.Type != "") || pl.Monitor.Type == "tcp" {
 				if pl.Name == "" {
 					monitorName = formatMonitorName(svcNamespace, SvcBackend.Name, pl.Monitor.Type, pl.ServicePort, vs.Spec.Host, pl.Path)
 				}


### PR DESCRIPTION
**Description**:  Enable tcp monitor for VS crd without send string

**Changes Proposed in PR**: Enable tcp monitor for VS crd without send string

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema