### PR TITLE
Code Refactoring for extended configmap support in crd mode

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -186,7 +186,8 @@ var (
 	clientSSL        *string
 	serverSSL        *string
 
-	routeSpecConfigmap *string
+	extendedSpecConfigmap *string
+	routeSpecConfigmap    *string
 
 	gtmBigIPURL      *string
 	gtmBigIPUsername *string
@@ -261,6 +262,11 @@ func _init() {
 		"Optional, to put the controller to process desired resources.")
 	defaultRouteDomain = globalFlags.Int("default-route-domain", 0,
 		"Optional, CIS uses this value as default Route Domain in BIG-IP ")
+	routeSpecConfigmap = globalFlags.String("route-spec-configmap", "",
+		"Required, specify a configmap that holds additional spec for routes"+
+			" if controller-mode is 'openshift'")
+	extendedSpecConfigmap = globalFlags.String("extended-spec-configmap", "",
+		"Required, specify a configmap that holds additional spec for controller. It's a required parameter if controller-mode is 'openshift'")
 
 	globalFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  Global:\n%s\n", globalFlags.FlagUsagesWrapped(width))
@@ -407,11 +413,6 @@ func _init() {
 	serverSSL = osRouteFlags.String("default-server-ssl", "",
 		"Optional, specify a user-created server ssl profile to be used as"+
 			" default for SNI for Route virtual servers")
-
-	routeSpecConfigmap = osRouteFlags.String("route-spec-configmap", "",
-		"Required, specify a configmap that holds additional spec for routes"+
-			" if controller-mode is 'openshift'")
-
 	osRouteFlags.Usage = func() {
 		fmt.Fprintf(os.Stderr, "  Openshift Routes:\n%s\n", osRouteFlags.FlagUsagesWrapped(width))
 	}
@@ -529,7 +530,18 @@ func verifyArgs() error {
 	} else {
 		return fmt.Errorf("'%v' is not a valid Pool Member Type", *poolMemberType)
 	}
-
+	if len(*extendedSpecConfigmap) > 0 {
+		if len(strings.Split(*extendedSpecConfigmap, "/")) != 2 {
+			return fmt.Errorf("invalid value provided for --extended-spec-configmap" +
+				"Usage: --extended-spec-configmap=<namespace>/<configmap-name>")
+		}
+	}
+	if len(*routeSpecConfigmap) > 0 {
+		if len(strings.Split(*routeSpecConfigmap, "/")) != 2 {
+			return fmt.Errorf("invalid value provided for --route-spec-configmap" +
+				"Usage: --route-spec-configmap=<namespace>/<configmap-name>")
+		}
+	}
 	if *staticRoutingMode == true {
 		if isNodePort || *poolMemberType == "nodeportlocal" {
 			return fmt.Errorf("Cannot run NodePort mode or nodeportlocal mode while supplying static-routing-mode true " +
@@ -581,16 +593,15 @@ func verifyArgs() error {
 				"Usage: --override-as3-declaration=<namespace>/<configmap-name>")
 		}
 	}
-
 	switch *controllerMode {
 	case "",
 		string(controller.CustomResourceMode),
 		string(controller.KubernetesMode):
 		break
 	case string(controller.OpenShiftMode):
-		if len(strings.Split(*routeSpecConfigmap, "/")) != 2 {
-			return fmt.Errorf("invalid value provided for --route-spec-configmap" +
-				"Usage: --route-spec-configmap=<namespace>/<configmap-name>")
+		if len(*extendedSpecConfigmap) == 0 && len(*routeSpecConfigmap) == 0 {
+			return fmt.Errorf("--route-spec-configmap or --extended-spec-configmap parameter is required in openshift mode\n" +
+				"Usage: --route-spec-configmap=<namespace>/<configmap-name> or --extended-spec-configmap=<namespace>/<configmap-name>")
 		}
 		if len(*routeLabel) > 0 {
 			*routeLabel = fmt.Sprintf("f5type in (%s)", *routeLabel)
@@ -817,28 +828,35 @@ func initController(
 
 	agent := controller.NewAgent(agentParams)
 
+	var globalSpecConfigMap *string
+	if *extendedSpecConfigmap != "" {
+		globalSpecConfigMap = extendedSpecConfigmap
+	} else {
+		globalSpecConfigMap = routeSpecConfigmap
+	}
+
 	ctlr := controller.NewController(
 		controller.Params{
-			Config:             config,
-			Namespaces:         *namespaces,
-			NamespaceLabel:     *namespaceLabel,
-			Partition:          (*bigIPPartitions)[0],
-			Agent:              agent,
-			PoolMemberType:     *poolMemberType,
-			VXLANName:          vxlanName,
-			VXLANMode:          vxlanMode,
-			UseNodeInternal:    *useNodeInternal,
-			NodePollInterval:   *nodePollInterval,
-			NodeLabelSelector:  *nodeLabelSelector,
-			IPAM:               *ipam,
-			ShareNodes:         *shareNodes,
-			DefaultRouteDomain: *defaultRouteDomain,
-			Mode:               controller.ControllerMode(*controllerMode),
-			RouteSpecConfigmap: *routeSpecConfigmap,
-			RouteLabel:         *routeLabel,
-			StaticRoutingMode:  *staticRoutingMode,
-			OrchestrationCNI:   *orchestrationCNI,
-			CISType:            *cisType,
+			Config:                      config,
+			Namespaces:                  *namespaces,
+			NamespaceLabel:              *namespaceLabel,
+			Partition:                   (*bigIPPartitions)[0],
+			Agent:                       agent,
+			PoolMemberType:              *poolMemberType,
+			VXLANName:                   vxlanName,
+			VXLANMode:                   vxlanMode,
+			UseNodeInternal:             *useNodeInternal,
+			NodePollInterval:            *nodePollInterval,
+			NodeLabelSelector:           *nodeLabelSelector,
+			IPAM:                        *ipam,
+			ShareNodes:                  *shareNodes,
+			DefaultRouteDomain:          *defaultRouteDomain,
+			Mode:                        controller.ControllerMode(*controllerMode),
+			GlobalExtendedSpecConfigmap: *globalSpecConfigMap,
+			RouteLabel:                  *routeLabel,
+			StaticRoutingMode:           *staticRoutingMode,
+			OrchestrationCNI:            *orchestrationCNI,
+			CISType:                     *cisType,
 		},
 	)
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -158,7 +158,6 @@ func NewController(params Params) *Controller {
 	ctlr.customResourceSelector, _ = createLabelSelector(DefaultCustomResourceLabel)
 	switch ctlr.mode {
 	case OpenShiftMode, KubernetesMode:
-		ctlr.routeSpecCMKey = params.RouteSpecConfigmap
 		ctlr.routeLabel = params.RouteLabel
 		var processedHostPath ProcessedHostPath
 		processedHostPath.processedHostPathMap = make(map[string]metaV1.Time)
@@ -166,6 +165,8 @@ func NewController(params Params) *Controller {
 	default:
 		ctlr.mode = CustomResourceMode
 	}
+	// set extended spec configmap for all
+	ctlr.globalExtendedCMKey = params.GlobalExtendedSpecConfigmap
 
 	//If pool-member-type type is nodeport enable share nodes ( for multi-partition)
 	if ctlr.PoolMemberType == "nodeport" {

--- a/pkg/controller/controller_suit_test.go
+++ b/pkg/controller/controller_suit_test.go
@@ -331,7 +331,7 @@ func (m *mockController) deletePod(pod v1.Pod) {
 }
 
 func (m *mockController) addConfigMap(cm *v1.ConfigMap) {
-	cusInf, _ := m.getNamespacedNativeInformer(cm.ObjectMeta.Namespace)
+	cusInf, _ := m.getNamespacedCommonInformer(cm.ObjectMeta.Namespace)
 	cusInf.cmInformer.GetStore().Add(cm)
 
 	if m.resourceQueue != nil {
@@ -340,7 +340,7 @@ func (m *mockController) addConfigMap(cm *v1.ConfigMap) {
 }
 
 func (m *mockController) deleteConfigMap(cm *v1.ConfigMap) {
-	cusInf, _ := m.getNamespacedNativeInformer(cm.ObjectMeta.Namespace)
+	cusInf, _ := m.getNamespacedCommonInformer(cm.ObjectMeta.Namespace)
 	cusInf.cmInformer.GetStore().Delete(cm)
 
 	if m.resourceQueue != nil {

--- a/pkg/controller/informers_test.go
+++ b/pkg/controller/informers_test.go
@@ -721,7 +721,7 @@ var _ = Describe("Informers Tests", func() {
 
 		It("Global ConfigMap", func() {
 			cmName := "samplecfgmap"
-			mockCtlr.routeSpecCMKey = namespace + "/" + cmName
+			mockCtlr.globalExtendedCMKey = namespace + "/" + cmName
 			cm := test.NewConfigMap(
 				cmName,
 				"v1",

--- a/pkg/controller/nativeResourceWorker.go
+++ b/pkg/controller/nativeResourceWorker.go
@@ -817,21 +817,23 @@ func (ctlr *Controller) GetServiceRouteWithoutHealthAnnotation(service *v1.Servi
 	return nil
 }
 
-func (ctlr *Controller) processGlobalExtendedRouteConfig() {
-	splits := strings.Split(ctlr.routeSpecCMKey, "/")
+func (ctlr *Controller) processGlobalExtendedConfigMap() {
+	splits := strings.Split(ctlr.globalExtendedCMKey, "/")
 	ns, cmName := splits[0], splits[1]
 	cm, err := ctlr.kubeClient.CoreV1().ConfigMaps(ns).Get(context.TODO(), cmName, metav1.GetOptions{})
 	if err != nil {
-		log.Errorf("Unable to Get Extended Route Spec Config Map: %v, %v", ctlr.routeSpecCMKey, err)
+		log.Errorf("Unable to Get Extended Config Map: %v, %v", ctlr.globalExtendedCMKey, err)
 	}
-	err = ctlr.setNamespaceLabelMode(cm)
-	if err != nil {
-		log.Errorf("invalid configuration: %v", ctlr.routeSpecCMKey, err)
-		os.Exit(1)
+	if ctlr.mode == OpenShiftMode {
+		err = ctlr.setNamespaceLabelMode(cm)
+		if err != nil {
+			log.Errorf("invalid configuration: %v", ctlr.globalExtendedCMKey, err)
+			os.Exit(1)
+		}
 	}
 	err, _ = ctlr.processConfigMap(cm, false)
 	if err != nil {
-		log.Errorf("Unable to Process Extended Route Spec Config Map: %v, %v", ctlr.routeSpecCMKey, err)
+		log.Errorf("Unable to Process Extended Config Map: %v, %v", ctlr.globalExtendedCMKey, err)
 	}
 }
 
@@ -899,255 +901,214 @@ func (ctlr *Controller) setNamespaceLabelMode(cm *v1.ConfigMap) error {
 	return nil
 }
 
-func (ctlr *Controller) processConfigMap(cm *v1.ConfigMap, isDelete bool) (error, bool) {
-	startTime := time.Now()
-	defer func() {
-		endTime := time.Now()
-		key := cm.Namespace + string('/') + cm.Name
-		if ctlr.routeSpecCMKey == key {
-			log.Debugf("Finished syncing extended Global spec configmap: %v/%v (%v)",
-				cm.Namespace, cm.Name, endTime.Sub(startTime))
-		} else {
-			log.Debugf("Finished syncing extended local spec configmap: %v/%v (%v)",
-				cm.Namespace, cm.Name, endTime.Sub(startTime))
-		}
-
-	}()
-
-	ersData := cm.Data
-	es := extendedSpec{}
-	//log.Debugf("GCM: %v", cm.Data)
-	err := yaml.UnmarshalStrict([]byte(ersData["extendedSpec"]), &es)
-	if err != nil {
-		return fmt.Errorf("invalid extended route spec in configmap: %v/%v error: %v", cm.Namespace, cm.Name, err), false
-	}
+// process the routeConfigFromGlobalConfigMap
+func (ctlr *Controller) processRouteConfigFromGlobalCM(es extendedSpec, isDelete bool) (error, bool) {
 
 	newExtdSpecMap := make(extendedSpecMap, len(ctlr.resources.extdSpecMap))
-	if ctlr.isGlobalExtendedRouteSpec(cm) {
-		// Get Multicluster kube-config
-		err := ctlr.readMultiClusterConfigFromGlobalCM(es.HAClusterConfig, es.MultiClusterConfigs)
-		ctlr.checkSecondaryCISConfig()
-		ctlr.stopDeletedGlobalCMMultiClusterInformers()
-		if err != nil {
-			return err, false
+	// Get the base route config from the Global ConfigMap
+	ctlr.readBaseRouteConfigFromGlobalCM(es.BaseRouteConfig)
+	var partition string
+	if len(es.BaseRouteConfig.DefaultRouteGroupConfig.BigIpPartition) > 0 {
+		partition = es.BaseRouteConfig.DefaultRouteGroupConfig.BigIpPartition
+	} else {
+		partition = ctlr.Partition
+	}
+
+	if es.BaseRouteConfig.DefaultRouteGroupConfig != (DefaultRouteGroupConfig{}) {
+		newExtdSpecMap[defaultRouteGroupName] = &extendedParsedSpec{
+			override:   false,
+			local:      nil,
+			global:     nil,
+			defaultrg:  &es.BaseRouteConfig.DefaultRouteGroupConfig.DefaultRouteGroupSpec,
+			namespaces: ctlr.getNamespacesForRouteGroup(defaultRouteGroupName),
+			partition:  partition,
 		}
-		// Get the base route config from the Global ConfigMap
-		ctlr.readBaseRouteConfigFromGlobalCM(es.BaseRouteConfig)
+	}
+	for rg := range es.ExtendedRouteGroupConfigs {
+		// ergc needs to be created at every iteration, as we are using address inside this container
+
+		// if this were used as an iteration variable, on every loop we just use the same container instead of creating one
+		// using the same container overrides the previous iteration contents, which is not desired
+		ergc := es.ExtendedRouteGroupConfigs[rg]
+		var allowOverride bool
+		var err error
+		if ctlr.namespaceLabelMode || len(ergc.AllowOverride) == 0 {
+			// specifically setting allow override as false in case of namespaceLabel Mode
+			// Defaulted to false in case AllowOverride is not set.( in both namespaceLabel and namespace Mode)
+			allowOverride = false
+		} else if allowOverride, err = strconv.ParseBool(ergc.AllowOverride); err != nil {
+			return fmt.Errorf("invalid allowOverride value in configmap: %v error: %v", ctlr.globalExtendedCMKey, err), false
+		}
+
+		var routeGroup string
+		if len(ergc.Namespace) > 0 {
+			routeGroup = ergc.Namespace
+		}
+		if len(ergc.NamespaceLabel) > 0 {
+			routeGroup = ergc.NamespaceLabel
+		}
 		var partition string
-		if len(es.BaseRouteConfig.DefaultRouteGroupConfig.BigIpPartition) > 0 {
-			partition = es.BaseRouteConfig.DefaultRouteGroupConfig.BigIpPartition
+		if len(ergc.BigIpPartition) > 0 {
+			partition = ergc.BigIpPartition
 		} else {
 			partition = ctlr.Partition
 		}
-
-		if es.BaseRouteConfig.DefaultRouteGroupConfig != (DefaultRouteGroupConfig{}) {
-			newExtdSpecMap[defaultRouteGroupName] = &extendedParsedSpec{
-				override:   false,
-				local:      nil,
-				global:     nil,
-				defaultrg:  &es.BaseRouteConfig.DefaultRouteGroupConfig.DefaultRouteGroupSpec,
-				namespaces: ctlr.getNamespacesForRouteGroup(defaultRouteGroupName),
-				partition:  partition,
-			}
+		newExtdSpecMap[routeGroup] = &extendedParsedSpec{
+			override:   allowOverride,
+			local:      nil,
+			global:     &ergc.ExtendedRouteGroupSpec,
+			namespaces: ctlr.getNamespacesForRouteGroup(routeGroup),
+			partition:  partition,
 		}
-		for rg := range es.ExtendedRouteGroupConfigs {
-			// ergc needs to be created at every iteration, as we are using address inside this container
-
-			// if this were used as an iteration variable, on every loop we just use the same container instead of creating one
-			// using the same container overrides the previous iteration contents, which is not desired
-			ergc := es.ExtendedRouteGroupConfigs[rg]
-			var allowOverride bool
-
-			if ctlr.namespaceLabelMode || len(ergc.AllowOverride) == 0 {
-				// specifically setting allow override as false in case of namespaceLabel Mode
-				// Defaulted to false in case AllowOverride is not set.( in both namespaceLabel and namespace Mode)
-				allowOverride = false
-			} else if allowOverride, err = strconv.ParseBool(ergc.AllowOverride); err != nil {
-				return fmt.Errorf("invalid allowOverride value in configmap: %v/%v error: %v", cm.Namespace, cm.Name, err), false
-			}
-
-			var routeGroup string
-			if len(ergc.Namespace) > 0 {
-				routeGroup = ergc.Namespace
-			}
-			if len(ergc.NamespaceLabel) > 0 {
-				routeGroup = ergc.NamespaceLabel
-			}
-			var partition string
-			if len(ergc.BigIpPartition) > 0 {
-				partition = ergc.BigIpPartition
-			} else {
-				partition = ctlr.Partition
-			}
-			newExtdSpecMap[routeGroup] = &extendedParsedSpec{
-				override:   allowOverride,
-				local:      nil,
-				global:     &ergc.ExtendedRouteGroupSpec,
-				namespaces: ctlr.getNamespacesForRouteGroup(routeGroup),
-				partition:  partition,
-			}
-			if len(newExtdSpecMap[routeGroup].namespaces) > 0 {
-				ctlr.TeemData.Lock()
-				ctlr.TeemData.ResourceType.RouteGroups[routeGroup] = 1
-				ctlr.TeemData.Unlock()
-			}
+		if len(newExtdSpecMap[routeGroup].namespaces) > 0 {
+			ctlr.TeemData.Lock()
+			ctlr.TeemData.ResourceType.RouteGroups[routeGroup] = 1
+			ctlr.TeemData.Unlock()
 		}
+	}
 
-		// Global configmap once gets processed even before processing other native resources
-		if ctlr.initState {
-			ctlr.resources.extdSpecMap = newExtdSpecMap
-			for rg, ergps := range newExtdSpecMap {
-				if !ctlr.namespaceLabelMode && ergps.override {
-					// check for alternative local configmaps (pick latest)
-					// process if one is available
-					localCM := ctlr.getLatestLocalConfigMap(rg)
-					if localCM != nil {
-						err, _ = ctlr.processConfigMap(localCM, false)
-						if err != nil {
-							log.Errorf("Could not process local configmap for routeGroup : %v error: %v", rg, err)
-						}
+	// Global configmap once gets processed even before processing other native resources
+	if ctlr.initState {
+		ctlr.resources.extdSpecMap = newExtdSpecMap
+		for rg, ergps := range newExtdSpecMap {
+			if !ctlr.namespaceLabelMode && ergps.override {
+				// check for alternative local configmaps (pick latest)
+				// process if one is available
+				localCM := ctlr.getLatestLocalConfigMap(rg)
+				if localCM != nil {
+					err, _ := ctlr.processConfigMap(localCM, false)
+					if err != nil {
+						log.Errorf("Could not process local configmap for routeGroup : %v error: %v", rg, err)
 					}
-
 				}
+
+			}
+		}
+		return nil, true
+	}
+	deletedSpecs, modifiedSpecs, updatedSpecs, createdSpecs := getOperationalExtendedConfigMapSpecs(
+		ctlr.resources.extdSpecMap, newExtdSpecMap, isDelete,
+	)
+	for _, routeGroupKey := range deletedSpecs {
+		_ = ctlr.processRoutes(routeGroupKey, true)
+		if ctlr.resources.extdSpecMap[routeGroupKey].local == nil {
+			delete(ctlr.resources.extdSpecMap, routeGroupKey)
+			if ctlr.namespaceLabelMode {
+				// deleting and stopping the namespaceLabel informers if a routeGroupKey is modified or deleted
+				nsLabel := fmt.Sprintf("%v,%v", ctlr.namespaceLabel, routeGroupKey)
+				if nsInf, ok := ctlr.nsInformers[nsLabel]; ok {
+					log.Debugf("Removed namespace label informer: %v", nsLabel)
+					nsInf.stop()
+					delete(ctlr.nsInformers, nsLabel)
+				}
+			}
+		} else {
+			ctlr.resources.extdSpecMap[routeGroupKey].global = nil
+			ctlr.resources.extdSpecMap[routeGroupKey].override = false
+			ctlr.resources.extdSpecMap[routeGroupKey].partition = ""
+			ctlr.resources.extdSpecMap[routeGroupKey].namespaces = []string{}
+
+		}
+
+	}
+
+	for _, routeGroupKey := range modifiedSpecs {
+		_ = ctlr.processRoutes(routeGroupKey, true)
+		// deleting the bigip partition when partition is changes
+		if ctlr.resources.extdSpecMap[routeGroupKey].partition != newExtdSpecMap[routeGroupKey].partition {
+			if _, ok := ctlr.resources.ltmConfig[ctlr.resources.extdSpecMap[routeGroupKey].partition]; ok {
+				ctlr.resources.updatePartitionPriority(ctlr.resources.extdSpecMap[routeGroupKey].partition, 1)
+			}
+		}
+		ctlr.resources.extdSpecMap[routeGroupKey].override = newExtdSpecMap[routeGroupKey].override
+		ctlr.resources.extdSpecMap[routeGroupKey].global = newExtdSpecMap[routeGroupKey].global
+		ctlr.resources.extdSpecMap[routeGroupKey].partition = newExtdSpecMap[routeGroupKey].partition
+		ctlr.resources.extdSpecMap[routeGroupKey].defaultrg = newExtdSpecMap[routeGroupKey].defaultrg
+		ctlr.resources.extdSpecMap[routeGroupKey].namespaces = newExtdSpecMap[routeGroupKey].namespaces
+		err := ctlr.processRoutes(routeGroupKey, false)
+		if err != nil {
+			log.Errorf("Failed to process RouteGroup: %v with modified extended spec", routeGroupKey)
+		}
+	}
+
+	for _, routeGroupKey := range updatedSpecs {
+		ctlr.resources.extdSpecMap[routeGroupKey].override = newExtdSpecMap[routeGroupKey].override
+		ctlr.resources.extdSpecMap[routeGroupKey].global = newExtdSpecMap[routeGroupKey].global
+		ctlr.resources.extdSpecMap[routeGroupKey].partition = newExtdSpecMap[routeGroupKey].partition
+		ctlr.resources.extdSpecMap[routeGroupKey].namespaces = newExtdSpecMap[routeGroupKey].namespaces
+		ctlr.resources.extdSpecMap[routeGroupKey].defaultrg = newExtdSpecMap[routeGroupKey].defaultrg
+		err := ctlr.processRoutes(routeGroupKey, false)
+		if err != nil {
+			log.Errorf("Failed to process RouteGroup: %v with updated extended spec", routeGroupKey)
+		}
+	}
+
+	for _, routeGroupKey := range createdSpecs {
+		ctlr.resources.extdSpecMap[routeGroupKey] = &extendedParsedSpec{}
+		ctlr.resources.extdSpecMap[routeGroupKey].override = newExtdSpecMap[routeGroupKey].override
+		ctlr.resources.extdSpecMap[routeGroupKey].global = newExtdSpecMap[routeGroupKey].global
+		ctlr.resources.extdSpecMap[routeGroupKey].partition = newExtdSpecMap[routeGroupKey].partition
+		ctlr.resources.extdSpecMap[routeGroupKey].namespaces = newExtdSpecMap[routeGroupKey].namespaces
+		ctlr.resources.extdSpecMap[routeGroupKey].defaultrg = newExtdSpecMap[routeGroupKey].defaultrg
+		err := ctlr.processRoutes(routeGroupKey, false)
+		if err != nil {
+			log.Errorf("Failed to process RouteGroup: %v on addition of extended spec", routeGroupKey)
+		}
+	}
+	return nil, true
+}
+
+func (ctlr *Controller) processRouteConfigFromLocalCM(es extendedSpec, isDelete bool, namespace string) (error, bool) {
+	//local configmap processing.
+	ergc := es.ExtendedRouteGroupConfigs[0]
+	if ergc.Namespace != namespace {
+		return fmt.Errorf("Invalid Extended Route Spec Block in configmap: Mismatching namespace found at index 0 in %v", ctlr.globalExtendedCMKey), true
+	}
+	routeGroup, ok := ctlr.resources.invertedNamespaceLabelMap[ergc.Namespace]
+	if !ok {
+		return fmt.Errorf("RouteGroup not found"), true
+	}
+	if spec, ok := ctlr.resources.extdSpecMap[ergc.Namespace]; ok {
+		if isDelete {
+			if !spec.override {
+				spec.local = nil
+				return nil, true
+			}
+
+			// check for alternative local configmaps (pick latest)
+			// process if one is available
+			localCM := ctlr.getLatestLocalConfigMap(ergc.Namespace)
+			if localCM != nil {
+				err, _ := ctlr.processConfigMap(localCM, false)
+				if err == nil {
+					return nil, true
+				}
+			}
+
+			_ = ctlr.processRoutes(routeGroup, true)
+			spec.local = nil
+			// process routes again, this time routes get processed along with global config
+			err := ctlr.processRoutes(routeGroup, false)
+			if err != nil {
+				log.Errorf("Failed to process RouteGroup: %v on with global extended spec after deletion of local extended spec", ergc.Namespace)
 			}
 			return nil, true
 		}
-		deletedSpecs, modifiedSpecs, updatedSpecs, createdSpecs := getOperationalExtendedConfigMapSpecs(
-			ctlr.resources.extdSpecMap, newExtdSpecMap, isDelete,
-		)
-		for _, routeGroupKey := range deletedSpecs {
-			_ = ctlr.processRoutes(routeGroupKey, true)
-			if ctlr.resources.extdSpecMap[routeGroupKey].local == nil {
-				delete(ctlr.resources.extdSpecMap, routeGroupKey)
-				if ctlr.namespaceLabelMode {
-					// deleting and stopping the namespaceLabel informers if a routeGroupKey is modified or deleted
-					nsLabel := fmt.Sprintf("%v,%v", ctlr.namespaceLabel, routeGroupKey)
-					if nsInf, ok := ctlr.nsInformers[nsLabel]; ok {
-						log.Debugf("Removed namespace label informer: %v", nsLabel)
-						nsInf.stop()
-						delete(ctlr.nsInformers, nsLabel)
-					}
-				}
-			} else {
-				ctlr.resources.extdSpecMap[routeGroupKey].global = nil
-				ctlr.resources.extdSpecMap[routeGroupKey].override = false
-				ctlr.resources.extdSpecMap[routeGroupKey].partition = ""
-				ctlr.resources.extdSpecMap[routeGroupKey].namespaces = []string{}
 
-			}
-
+		if !spec.override || spec.global == nil {
+			spec.local = &ergc.ExtendedRouteGroupSpec
+			return nil, true
 		}
-
-		for _, routeGroupKey := range modifiedSpecs {
-			_ = ctlr.processRoutes(routeGroupKey, true)
-			// deleting the bigip partition when partition is changes
-			if ctlr.resources.extdSpecMap[routeGroupKey].partition != newExtdSpecMap[routeGroupKey].partition {
-				if _, ok := ctlr.resources.ltmConfig[ctlr.resources.extdSpecMap[routeGroupKey].partition]; ok {
-					ctlr.resources.updatePartitionPriority(ctlr.resources.extdSpecMap[routeGroupKey].partition, 1)
-				}
-			}
-			ctlr.resources.extdSpecMap[routeGroupKey].override = newExtdSpecMap[routeGroupKey].override
-			ctlr.resources.extdSpecMap[routeGroupKey].global = newExtdSpecMap[routeGroupKey].global
-			ctlr.resources.extdSpecMap[routeGroupKey].partition = newExtdSpecMap[routeGroupKey].partition
-			ctlr.resources.extdSpecMap[routeGroupKey].defaultrg = newExtdSpecMap[routeGroupKey].defaultrg
-			ctlr.resources.extdSpecMap[routeGroupKey].namespaces = newExtdSpecMap[routeGroupKey].namespaces
-			err := ctlr.processRoutes(routeGroupKey, false)
-			if err != nil {
-				log.Errorf("Failed to process RouteGroup: %v with modified extended spec", routeGroupKey)
-			}
-		}
-
-		for _, routeGroupKey := range updatedSpecs {
-			ctlr.resources.extdSpecMap[routeGroupKey].override = newExtdSpecMap[routeGroupKey].override
-			ctlr.resources.extdSpecMap[routeGroupKey].global = newExtdSpecMap[routeGroupKey].global
-			ctlr.resources.extdSpecMap[routeGroupKey].partition = newExtdSpecMap[routeGroupKey].partition
-			ctlr.resources.extdSpecMap[routeGroupKey].namespaces = newExtdSpecMap[routeGroupKey].namespaces
-			ctlr.resources.extdSpecMap[routeGroupKey].defaultrg = newExtdSpecMap[routeGroupKey].defaultrg
-			err := ctlr.processRoutes(routeGroupKey, false)
-			if err != nil {
-				log.Errorf("Failed to process RouteGroup: %v with updated extended spec", routeGroupKey)
-			}
-		}
-
-		for _, routeGroupKey := range createdSpecs {
-			ctlr.resources.extdSpecMap[routeGroupKey] = &extendedParsedSpec{}
-			ctlr.resources.extdSpecMap[routeGroupKey].override = newExtdSpecMap[routeGroupKey].override
-			ctlr.resources.extdSpecMap[routeGroupKey].global = newExtdSpecMap[routeGroupKey].global
-			ctlr.resources.extdSpecMap[routeGroupKey].partition = newExtdSpecMap[routeGroupKey].partition
-			ctlr.resources.extdSpecMap[routeGroupKey].namespaces = newExtdSpecMap[routeGroupKey].namespaces
-			ctlr.resources.extdSpecMap[routeGroupKey].defaultrg = newExtdSpecMap[routeGroupKey].defaultrg
-			err := ctlr.processRoutes(routeGroupKey, false)
-			if err != nil {
-				log.Errorf("Failed to process RouteGroup: %v on addition of extended spec", routeGroupKey)
-			}
-		}
-
-	} else if len(es.ExtendedRouteGroupConfigs) > 0 && !ctlr.resourceContext.namespaceLabelMode {
-		//local configmap processing.
-		ergc := es.ExtendedRouteGroupConfigs[0]
-		if ergc.Namespace != cm.Namespace {
-			return fmt.Errorf("Invalid Extended Route Spec Block in configmap: Mismatching namespace found at index 0 in %v/%v", cm.Namespace, cm.Name), true
-		}
-		routeGroup, ok := ctlr.resources.invertedNamespaceLabelMap[ergc.Namespace]
-		if !ok {
-			return fmt.Errorf("RouteGroup not found"), true
-		}
-		if spec, ok := ctlr.resources.extdSpecMap[ergc.Namespace]; ok {
-			if isDelete {
-				if !spec.override {
-					spec.local = nil
+		// creation event
+		if spec.local == nil {
+			if !reflect.DeepEqual(*(spec.global), ergc.ExtendedRouteGroupSpec) {
+				if ctlr.initState {
+					spec.local = &ergc.ExtendedRouteGroupSpec
 					return nil, true
 				}
-
-				// check for alternative local configmaps (pick latest)
-				// process if one is available
-				localCM := ctlr.getLatestLocalConfigMap(ergc.Namespace)
-				if localCM != nil {
-					err, _ = ctlr.processConfigMap(localCM, false)
-					if err == nil {
-						return nil, true
-					}
-				}
-
-				_ = ctlr.processRoutes(routeGroup, true)
-				spec.local = nil
-				// process routes again, this time routes get processed along with global config
-				err := ctlr.processRoutes(routeGroup, false)
-				if err != nil {
-					log.Errorf("Failed to process RouteGroup: %v on with global extended spec after deletion of local extended spec", ergc.Namespace)
-				}
-				return nil, true
-			}
-
-			if !spec.override || spec.global == nil {
-				spec.local = &ergc.ExtendedRouteGroupSpec
-				return nil, true
-			}
-			// creation event
-			if spec.local == nil {
-				if !reflect.DeepEqual(*(spec.global), ergc.ExtendedRouteGroupSpec) {
-					if ctlr.initState {
-						spec.local = &ergc.ExtendedRouteGroupSpec
-						return nil, true
-					}
-					if spec.global.VServerName != ergc.ExtendedRouteGroupSpec.VServerName {
-						// Delete existing virtual that was framed with globla config
-						// later build new virtual with local config
-						_ = ctlr.processRoutes(routeGroup, true)
-					}
-					spec.local = &ergc.ExtendedRouteGroupSpec
-					err := ctlr.processRoutes(routeGroup, false)
-					if err != nil {
-						log.Errorf("Failed to process RouteGroup: %v on addition of extended spec", ergc.Namespace)
-					}
-				}
-				return nil, true
-			}
-
-			// update event
-			if !reflect.DeepEqual(*(spec.local), ergc.ExtendedRouteGroupSpec) {
-				// if update event, update to VServerName should trigger delete and recreation of object
-				if spec.local.VServerName != ergc.ExtendedRouteGroupSpec.VServerName {
+				if spec.global.VServerName != ergc.ExtendedRouteGroupSpec.VServerName {
+					// Delete existing virtual that was framed with globla config
+					// later build new virtual with local config
 					_ = ctlr.processRoutes(routeGroup, true)
 				}
 				spec.local = &ergc.ExtendedRouteGroupSpec
@@ -1155,18 +1116,32 @@ func (ctlr *Controller) processConfigMap(cm *v1.ConfigMap, isDelete bool) (error
 				if err != nil {
 					log.Errorf("Failed to process RouteGroup: %v on addition of extended spec", ergc.Namespace)
 				}
-				return nil, true
 			}
-
-		} else {
-			// Need not process routes as there is no confirmation of override yet
-			ctlr.resources.extdSpecMap[ergc.Namespace] = &extendedParsedSpec{
-				override: false,
-				local:    &ergc.ExtendedRouteGroupSpec,
-				global:   nil,
-			}
-			return nil, false
+			return nil, true
 		}
+
+		// update event
+		if !reflect.DeepEqual(*(spec.local), ergc.ExtendedRouteGroupSpec) {
+			// if update event, update to VServerName should trigger delete and recreation of object
+			if spec.local.VServerName != ergc.ExtendedRouteGroupSpec.VServerName {
+				_ = ctlr.processRoutes(routeGroup, true)
+			}
+			spec.local = &ergc.ExtendedRouteGroupSpec
+			err := ctlr.processRoutes(routeGroup, false)
+			if err != nil {
+				log.Errorf("Failed to process RouteGroup: %v on addition of extended spec", ergc.Namespace)
+			}
+			return nil, true
+		}
+
+	} else {
+		// Need not process routes as there is no confirmation of override yet
+		ctlr.resources.extdSpecMap[ergc.Namespace] = &extendedParsedSpec{
+			override: false,
+			local:    &ergc.ExtendedRouteGroupSpec,
+			global:   nil,
+		}
+		return nil, false
 	}
 	return nil, true
 }
@@ -1206,10 +1181,10 @@ func (ctlr *Controller) readBaseRouteConfigFromGlobalCM(baseRouteConfig BaseRout
 	}
 }
 
-func (ctlr *Controller) isGlobalExtendedRouteSpec(cm *v1.ConfigMap) bool {
+func (ctlr *Controller) isGlobalExtendedCM(cm *v1.ConfigMap) bool {
 	cmKey := cm.Namespace + "/" + cm.Name
 
-	if cmKey == ctlr.routeSpecCMKey {
+	if cmKey == ctlr.globalExtendedCMKey {
 		return true
 	}
 
@@ -1217,7 +1192,7 @@ func (ctlr *Controller) isGlobalExtendedRouteSpec(cm *v1.ConfigMap) bool {
 }
 
 func (ctlr *Controller) getLatestLocalConfigMap(ns string) *v1.ConfigMap {
-	inf, ok := ctlr.getNamespacedNativeInformer(ns)
+	inf, ok := ctlr.getNamespacedCommonInformer(ns)
 
 	if !ok {
 		return nil

--- a/pkg/controller/nativeResourceWorker_test.go
+++ b/pkg/controller/nativeResourceWorker_test.go
@@ -27,6 +27,7 @@ var _ = Describe("Routes", func() {
 		mockCtlr.multiClusterConfigs = clustermanager.NewMultiClusterConfig()
 		mockCtlr.resources = NewResourceStore()
 		mockCtlr.mode = OpenShiftMode
+		mockCtlr.globalExtendedCMKey = "kube-system/global-cm"
 		mockCtlr.routeClientV1 = fakeRouteClient.NewSimpleClientset().RouteV1()
 		mockCtlr.namespaces = make(map[string]bool)
 		mockCtlr.namespaces["default"] = true
@@ -204,7 +205,7 @@ var _ = Describe("Routes", func() {
 			var data map[string]string
 			cmName := "escm"
 			cmNamespace := "system"
-			mockCtlr.routeSpecCMKey = cmNamespace + "/" + cmName
+			mockCtlr.globalExtendedCMKey = cmNamespace + "/" + cmName
 
 			data = make(map[string]string)
 			cm = test.NewConfigMap(
@@ -396,7 +397,7 @@ var _ = Describe("Routes", func() {
 			var data map[string]string
 			cmName := "escm"
 			cmNamespace := "kube-system"
-			mockCtlr.routeSpecCMKey = cmNamespace + "/" + cmName
+			mockCtlr.globalExtendedCMKey = cmNamespace + "/" + cmName
 
 			data = make(map[string]string)
 			mockCtlr.Partition = "default"
@@ -1248,7 +1249,7 @@ extendedRouteSpec:
 		BeforeEach(func() {
 			cmName := "escm"
 			cmNamespace := "system"
-			mockCtlr.routeSpecCMKey = cmNamespace + "/" + cmName
+			mockCtlr.globalExtendedCMKey = cmNamespace + "/" + cmName
 
 			data = make(map[string]string)
 			cm = test.NewConfigMap(
@@ -1455,14 +1456,14 @@ extendedRouteSpec:
       vserverName: latestserver
 `
 
-			_ = mockCtlr.nrInformers[namespace].cmInformer.GetIndexer().Add(localCm1)
-			_ = mockCtlr.nrInformers[namespace].cmInformer.GetIndexer().Add(localCm2)
-			_ = mockCtlr.nrInformers[namespace].cmInformer.GetIndexer().Add(localCm3)
+			_ = mockCtlr.comInformers[namespace].cmInformer.GetIndexer().Add(localCm1)
+			_ = mockCtlr.comInformers[namespace].cmInformer.GetIndexer().Add(localCm2)
+			_ = mockCtlr.comInformers[namespace].cmInformer.GetIndexer().Add(localCm3)
 			err, ok = mockCtlr.processConfigMap(localCm3, false)
 			Expect(err).To(BeNil())
 			Expect(ok).To(BeTrue())
 
-			_ = mockCtlr.nrInformers[namespace].cmInformer.GetIndexer().Delete(localCm3)
+			_ = mockCtlr.comInformers[namespace].cmInformer.GetIndexer().Delete(localCm3)
 			err, ok = mockCtlr.processConfigMap(localCm3, true)
 			Expect(err).To(BeNil())
 			Expect(ok).To(BeTrue())
@@ -1696,7 +1697,7 @@ var _ = Describe("With NamespaceLabel parameter in deployment", func() {
 		BeforeEach(func() {
 			cmName := "escm"
 			cmNamespace := "system"
-			mockCtlr.routeSpecCMKey = cmNamespace + "/" + cmName
+			mockCtlr.globalExtendedCMKey = cmNamespace + "/" + cmName
 
 			data = make(map[string]string)
 			cm = test.NewConfigMap(
@@ -1755,7 +1756,7 @@ var _ = Describe("Without NamespaceLabel parameter in deployment", func() {
 		BeforeEach(func() {
 			cmName := "escm"
 			cmNamespace := "system"
-			mockCtlr.routeSpecCMKey = cmNamespace + "/" + cmName
+			mockCtlr.globalExtendedCMKey = cmNamespace + "/" + cmName
 
 			data = make(map[string]string)
 			cm = test.NewConfigMap(

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -101,7 +101,7 @@ type (
 		nodeInformer              *NodeInformer
 		multiClusterPoolInformers map[string]map[string]*MultiClusterPoolInformer
 		multiClusterNodeInformers map[string]*NodeInformer
-		routeSpecCMKey            string
+		globalExtendedCMKey       string
 		routeLabel                string
 		namespaceLabelMode        bool
 		processedHostPath         *ProcessedHostPath
@@ -109,26 +109,26 @@ type (
 
 	// Params defines parameters
 	Params struct {
-		Config             *rest.Config
-		Namespaces         []string
-		NamespaceLabel     string
-		Partition          string
-		Agent              *Agent
-		PoolMemberType     string
-		VXLANName          string
-		VXLANMode          string
-		UseNodeInternal    bool
-		NodePollInterval   int
-		NodeLabelSelector  string
-		ShareNodes         bool
-		IPAM               bool
-		DefaultRouteDomain int
-		Mode               ControllerMode
-		RouteSpecConfigmap string
-		RouteLabel         string
-		StaticRoutingMode  bool
-		OrchestrationCNI   string
-		CISType            string
+		Config                      *rest.Config
+		Namespaces                  []string
+		NamespaceLabel              string
+		Partition                   string
+		Agent                       *Agent
+		PoolMemberType              string
+		VXLANName                   string
+		VXLANMode                   string
+		UseNodeInternal             bool
+		NodePollInterval            int
+		NodeLabelSelector           string
+		ShareNodes                  bool
+		IPAM                        bool
+		DefaultRouteDomain          int
+		Mode                        ControllerMode
+		GlobalExtendedSpecConfigmap string
+		RouteLabel                  string
+		StaticRoutingMode           bool
+		OrchestrationCNI            string
+		CISType                     string
 	}
 
 	// CRInformer defines the structure of Custom Resource Informer
@@ -150,6 +150,7 @@ type (
 		plcInformer     cache.SharedIndexInformer
 		podInformer     cache.SharedIndexInformer
 		secretsInformer cache.SharedIndexInformer
+		cmInformer      cache.SharedIndexInformer
 	}
 
 	// NRInformer is informer context for Native Resources of Kubernetes/Openshift
@@ -157,7 +158,6 @@ type (
 		namespace     string
 		stopCh        chan struct{}
 		routeInformer cache.SharedIndexInformer
-		cmInformer    cache.SharedIndexInformer
 	}
 
 	NodeInformer struct {

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -22,6 +22,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
+	"gopkg.in/yaml.v2"
 	listerscorev1 "k8s.io/client-go/listers/core/v1"
 	"reflect"
 	"sort"
@@ -55,14 +56,15 @@ func (ctlr *Controller) nextGenResourceWorker() {
 	log.Debugf("Starting Custom Resource Worker")
 	ctlr.setInitialResourceCount()
 	ctlr.migrateIPAM()
-	if ctlr.mode == OpenShiftMode {
-		ctlr.processGlobalExtendedRouteConfig()
+	// process the extended configmap if present
+	if ctlr.globalExtendedCMKey != "" {
+		ctlr.processGlobalExtendedConfigMap()
+	}
 
-		// when CIS is running in the secondary mode then enable health probe on the primary cluster
-		if ctlr.cisType == SecondaryCIS {
-			ctlr.firstPollPrimaryClusterHealthStatus()
-			go ctlr.probePrimaryClusterHealthStatus()
-		}
+	// when CIS is running in the secondary mode then enable health probe on the primary cluster
+	if ctlr.cisType == SecondaryCIS {
+		ctlr.firstPollPrimaryClusterHealthStatus()
+		go ctlr.probePrimaryClusterHealthStatus()
 	}
 	for ctlr.processResources() {
 	}
@@ -610,7 +612,7 @@ func (ctlr *Controller) processResources() bool {
 				log.Debugf("Added Namespace: '%v' to CIS scope", nsName)
 			}
 			if ctlr.namespaceLabelMode {
-				ctlr.processGlobalExtendedRouteConfig()
+				ctlr.processGlobalExtendedConfigMap()
 			} else {
 				if routeGroup, ok := ctlr.resources.invertedNamespaceLabelMap[nsName]; ok {
 					_ = ctlr.processRoutes(routeGroup, triggerDelete)
@@ -3794,6 +3796,47 @@ func (ctlr *Controller) processPod(pod *v1.Pod, ispodDeleted bool) error {
 		delete(ctlr.resources.nplStore, podKey)
 	}
 	return nil
+}
+
+func (ctlr *Controller) processConfigMap(cm *v1.ConfigMap, isDelete bool) (error, bool) {
+	startTime := time.Now()
+	defer func() {
+		endTime := time.Now()
+		key := cm.Namespace + string('/') + cm.Name
+		if ctlr.globalExtendedCMKey == key {
+			log.Debugf("Finished syncing extended global spec configmap: %v/%v (%v)",
+				cm.Namespace, cm.Name, endTime.Sub(startTime))
+		} else {
+			log.Debugf("Finished syncing extended local spec configmap: %v/%v (%v)",
+				cm.Namespace, cm.Name, endTime.Sub(startTime))
+		}
+
+	}()
+	ersData := cm.Data
+	es := extendedSpec{}
+	//log.Debugf("GCM: %v", cm.Data)
+	err := yaml.UnmarshalStrict([]byte(ersData["extendedSpec"]), &es)
+	if err != nil {
+		return fmt.Errorf("invalid extended route spec in configmap: %v/%v error: %v", cm.Namespace, cm.Name, err), false
+	}
+	if ctlr.isGlobalExtendedCM(cm) {
+		// Get Multicluster kube-config
+		err := ctlr.readMultiClusterConfigFromGlobalCM(es.HAClusterConfig, es.MultiClusterConfigs)
+		ctlr.checkSecondaryCISConfig()
+		ctlr.stopDeletedGlobalCMMultiClusterInformers()
+		if err != nil {
+			return err, false
+		}
+	}
+	// Process the routeSpec defined in extended configMap
+	if ctlr.mode == OpenShiftMode {
+		if ctlr.isGlobalExtendedCM(cm) {
+			return ctlr.processRouteConfigFromGlobalCM(es, isDelete)
+		} else if len(es.ExtendedRouteGroupConfigs) > 0 && !ctlr.resourceContext.namespaceLabelMode {
+			return ctlr.processRouteConfigFromLocalCM(es, isDelete, cm.Namespace)
+		}
+	}
+	return nil, true
 }
 
 // getPolicyFromLBService gets the policy attached to the service and returns it


### PR DESCRIPTION
**Description**:  Code Refactoring for extended configmap support in crd mode

**Changes Proposed in PR**: This PR adds support for new CIS deployment parameter for passing the extended configMap (--extended-spec-configmap). This PR also includes multi-cluster route annotation validation.

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated the documentation
- [x] Smoke testing completed
