### PR TITLE
Improve error handling and K8S resources fetching method

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -20,8 +20,7 @@ Bug Fixes
 ````````````
 * `Issue 2941 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2941>`_: Fix for services with same name in different namespaces in NodePortLocal mode
 * `Issue 2850 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2850>`_: Fix for AS3 config updated every 30 seconds by CIS with default ingress backend
-
-
+* `Issue 2909 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/2909>`_: Fix for empty pool members when K8S API server throws any error
 2.13.1
 -------------
 Bug Fixes

--- a/pkg/agent/as3/as3Manager_test.go
+++ b/pkg/agent/as3/as3Manager_test.go
@@ -35,9 +35,9 @@ func newMockAS3Manager(params *Params) *mockAS3Manager {
 	}
 }
 
-func mockGetEndPoints(string, string) []Member {
+func mockGetEndPoints(string, string) ([]Member, error) {
 	return []Member{{Address: "1.1.1.1", Port: 80, SvcPort: 80},
-		{Address: "2.2.2.2", Port: 80, SvcPort: 80}}
+		{Address: "2.2.2.2", Port: 80, SvcPort: 80}}, nil
 }
 
 func (m *mockAS3Manager) shutdown() error {
@@ -122,7 +122,7 @@ var _ = Describe("AS3Manager Tests", func() {
 				},
 			)
 			as3config := &AS3Config{}
-			as3config.configmaps, _ = mockMgr.prepareResourceAS3ConfigMaps()
+			as3config.configmaps, _, _ = mockMgr.prepareResourceAS3ConfigMaps()
 			result := mockMgr.getUnifiedDeclaration(as3config)
 			Expect(string(result)).To(MatchJSON(unified), "Failed to Create JSON with correct configuration")
 		})
@@ -158,7 +158,7 @@ var _ = Describe("AS3Manager Tests", func() {
 				},
 			)
 			as3config := &AS3Config{}
-			as3config.configmaps, _ = mockMgr.prepareResourceAS3ConfigMaps()
+			as3config.configmaps, _, _ = mockMgr.prepareResourceAS3ConfigMaps()
 
 			routeCfg := readConfigFile(configPath + "as3_route.json")
 			err := json.Unmarshal([]byte(routeCfg), &routeAdc)
@@ -250,7 +250,7 @@ var _ = Describe("AS3Manager Tests", func() {
 				},
 			)
 			as3config := &AS3Config{}
-			_, as3config.overrideConfigmapData = mockMgr.prepareResourceAS3ConfigMaps()
+			_, as3config.overrideConfigmapData, _ = mockMgr.prepareResourceAS3ConfigMaps()
 
 			routeCfg := readConfigFile(configPath + "as3_route.json")
 			err := json.Unmarshal([]byte(routeCfg), &routeAdc)
@@ -425,7 +425,7 @@ var _ = Describe("AS3Manager Tests", func() {
 				AgentCfgmaps: []*AgentCfgMap{},
 			}
 			mockMgr.ReqChan <- MessageRequest{ReqID: 1, MsgType: "test", ResourceRequest: resourceRequest}
-			result, output := mockMgr.postOnEventOrTimeout(timeoutSmall)
+			result, output, _ := mockMgr.postOnEventOrTimeout(timeoutSmall)
 			close(mockMgr.ReqChan)
 			Expect(result).To(BeTrue(), "Posting Failed")
 			Expect(output).To(Equal("statusOK"), "Posting Failed")
@@ -475,7 +475,7 @@ var _ = Describe("AS3Manager Tests", func() {
 				},
 			)
 			mockMgr.as3ActiveConfig.unifiedDeclaration = as3Declaration(readConfigFile(configPath + "as3config_multi_cm_unified.json"))
-			result, output := mockMgr.postAS3Declaration(resourceRequest)
+			result, output, _ := mockMgr.postAS3Declaration(resourceRequest)
 			Expect(result).To(BeTrue(), "Posting Failed")
 			Expect(output).To(Equal(responseStatusOk), "Posting Failed")
 			// Verify that tenant3 is deleted from active configMap

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -1258,7 +1258,7 @@ var _ = Describe("AppManager Tests", func() {
 						Session: "user-enabled",
 					},
 				}
-				mems := mockMgr.appMgr.getEndpoints("cis.f5.com/as3-tenant=test", "default")
+				mems, _ := mockMgr.appMgr.getEndpoints("cis.f5.com/as3-tenant=test", "default")
 				Expect(mems).To(Equal(expMembers))
 			})
 
@@ -4120,11 +4120,11 @@ var _ = Describe("AppManager Tests", func() {
 				// no service and different namespace
 				mockMgr.appMgr.poolMemberType = NodePortLocal
 				mockMgr.appMgr.AddNamespace(namespace, selector, 0)
-				podList := mockMgr.appMgr.GetPodsForService("diff-ns", svcName)
+				podList, _ := mockMgr.appMgr.GetPodsForService("diff-ns", svcName)
 				Expect(podList).To(BeNil())
 
 				// no service created, correct namespace
-				podList = mockMgr.appMgr.GetPodsForService(namespace, svcName)
+				podList, _ = mockMgr.appMgr.GetPodsForService(namespace, svcName)
 				Expect(podList).To(BeNil())
 
 				//Add service, No nodeportlocal annotation
@@ -4135,21 +4135,21 @@ var _ = Describe("AppManager Tests", func() {
 				}
 				svc1 := test.NewService(svcName, "1", namespace, v1.ServiceTypeClusterIP, svcPorts)
 				appInf.svcInformer.GetStore().Add(svc1)
-				podList = mockMgr.appMgr.GetPodsForService(namespace, svcName)
+				podList, _ = mockMgr.appMgr.GetPodsForService(namespace, svcName)
 				Expect(podList).To(BeNil())
 
 				// Add nodeportlocal annotation
 				svc1.Annotations = make(map[string]string)
 				svc1.Annotations[NPLSvcAnnotation] = "true"
 				appInf.svcInformer.GetStore().Update(svc1)
-				podList = mockMgr.appMgr.GetPodsForService(namespace, svcName)
+				podList, _ = mockMgr.appMgr.GetPodsForService(namespace, svcName)
 				Expect(podList).To(BeNil())
 
 				// Add Pod selector
 				svc1.Spec.Selector = make(map[string]string)
 				svc1.Spec.Selector["app"] = "app1"
 				appInf.svcInformer.GetStore().Update(svc1)
-				podList = mockMgr.appMgr.GetPodsForService(namespace, svcName)
+				podList, _ = mockMgr.appMgr.GetPodsForService(namespace, svcName)
 				Expect(podList).To(BeNil())
 			})
 			It("Test getEndpoints", func() {
@@ -4170,7 +4170,7 @@ var _ = Describe("AppManager Tests", func() {
 					mockMgr.appMgr.isNodePort = true
 				}()
 				mockMgr.appMgr.AddNamespace(namespace, selector, 0)
-				members := mockMgr.appMgr.getEndpoints("test", namespace)
+				members, _ := mockMgr.appMgr.getEndpoints("test", namespace)
 				Expect(members).To(BeNil())
 
 				// Add service
@@ -4185,16 +4185,16 @@ var _ = Describe("AppManager Tests", func() {
 				svc2.Labels["test"] = "true"
 				mockMgr.appMgr.kubeClient.CoreV1().Services(namespace).Create(context.TODO(), svc1, metav1.CreateOptions{})
 				mockMgr.appMgr.kubeClient.CoreV1().Services(namespace).Create(context.TODO(), svc2, metav1.CreateOptions{})
-				members = mockMgr.appMgr.getEndpoints("test", namespace)
+				members, _ = mockMgr.appMgr.getEndpoints("test", namespace)
 				Expect(members).To(BeNil())
 
 				// Set isNodePort to false, no endpoints
 				mockMgr.appMgr.isNodePort = false
-				members = mockMgr.appMgr.getEndpoints("test", namespace)
+				members, _ = mockMgr.appMgr.getEndpoints("test", namespace)
 				Expect(members).To(BeNil())
 
 				// Set isNodePort to false, no endpoints
-				members = mockMgr.appMgr.getEndpoints("test", namespace)
+				members, _ = mockMgr.appMgr.getEndpoints("test", namespace)
 				Expect(members).To(BeNil())
 
 				// Add endpoints
@@ -4202,7 +4202,7 @@ var _ = Describe("AppManager Tests", func() {
 				endpts1 := test.NewEndpoints(svcName1, "1", "node0", namespace,
 					readyIps, nil, convertSvcPortsToEndpointPorts(svcPorts))
 				appInf.endptInformer.GetStore().Add(endpts1)
-				members = mockMgr.appMgr.getEndpoints("test", namespace)
+				members, _ = mockMgr.appMgr.getEndpoints("test", namespace)
 				Expect(members).NotTo(BeNil())
 				Expect(len(members)).To(Equal(2))
 
@@ -4345,14 +4345,14 @@ var _ = Describe("AppManager Tests", func() {
 				}
 
 				// Nodeport service
-				ret, err1, msg := mockMgr.appMgr.updatePoolMembersForNPL(svc, sKey, rsCfg, 0)
+				ret, err1, msg, _ := mockMgr.appMgr.updatePoolMembersForNPL(svc, sKey, rsCfg, 0)
 				Expect(ret).To(BeFalse())
 				Expect(len(err1)).NotTo(Equal(0))
 				Expect(len(msg)).NotTo(Equal(0))
 
 				// ClusterIP service not created
 				svc.Spec.Type = v1.ServiceTypeClusterIP
-				ret, err1, msg = mockMgr.appMgr.updatePoolMembersForNPL(svc, sKey, rsCfg, 0)
+				ret, err1, msg, _ = mockMgr.appMgr.updatePoolMembersForNPL(svc, sKey, rsCfg, 0)
 				Expect(ret).To(BeTrue())
 				Expect(len(err1)).To(Equal(0))
 				Expect(len(msg)).To(Equal(0))
@@ -4365,7 +4365,7 @@ var _ = Describe("AppManager Tests", func() {
 				svc.Spec.Selector = make(map[string]string)
 				svc.Spec.Selector["app"] = "app1"
 				appInf.svcInformer.GetStore().Add(svc)
-				ret, err1, msg = mockMgr.appMgr.updatePoolMembersForNPL(svc, sKey, rsCfg, 0)
+				ret, err1, msg, _ = mockMgr.appMgr.updatePoolMembersForNPL(svc, sKey, rsCfg, 0)
 				Expect(ret).To(BeTrue())
 				Expect(len(err1)).To(Equal(0))
 				Expect(len(msg)).To(Equal(0))

--- a/pkg/appmanager/ingress_test.go
+++ b/pkg/appmanager/ingress_test.go
@@ -127,7 +127,8 @@ var _ = Describe("V1 Ingress Tests", func() {
 					"tls.key": []byte("testkey"),
 				},
 			}
-			_, err := mockMgr.appMgr.kubeClient.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+			//_, err := mockMgr.appMgr.kubeClient.CoreV1().Secrets(namespace).Create(context.TODO(), secret, metav1.CreateOptions{})
+			err := mockMgr.appMgr.appInformers[namespace].secretInformer.GetStore().Add(secret)
 			Expect(err).To(BeNil())
 
 			spec := netv1.IngressSpec{

--- a/pkg/resource/resourceConfig.go
+++ b/pkg/resource/resourceConfig.go
@@ -2754,7 +2754,7 @@ func CreatePolicy(rls Rules, policyName, partition string) *Policy {
 	return &plcy
 }
 
-func (cm *AgentCfgMap) Init(n string, ns string, d string, l map[string]string, getEP func(string, string) []Member) {
+func (cm *AgentCfgMap) Init(n string, ns string, d string, l map[string]string, getEP func(string, string) ([]Member, error)) {
 	cm.Name = n
 	cm.Namespace = ns
 	cm.Data = d

--- a/pkg/resource/resourceConfig_test.go
+++ b/pkg/resource/resourceConfig_test.go
@@ -2215,7 +2215,7 @@ var _ = Describe("Resource Config Tests", func() {
 		It("Test AgentCfgMap Init", func() {
 			cm := &AgentCfgMap{}
 			label := make(map[string]string)
-			getEP := func(string, string) []Member { return nil }
+			getEP := func(string, string) ([]Member, error) { return nil, nil }
 			cm.Init("test1", "default", "", label, getEP)
 			Expect(cm.Name).To(Equal("test1"))
 			Expect(cm.Namespace).To(Equal("default"))

--- a/pkg/resource/types.go
+++ b/pkg/resource/types.go
@@ -415,7 +415,7 @@ type (
 
 	AgentCfgMap struct {
 		Operation    string
-		GetEndpoints func(string, string) []Member
+		GetEndpoints func(string, string) ([]Member, error)
 		Data         string
 		Name         string
 		Namespace    string


### PR DESCRIPTION
**Description**: Improve error handling and K8S resources fetching method

**Changes Proposed in PR**:   To reduce the risks of improper processing of K8S resources when error is encountered while communicating with K8S API server, the following changes are introduced:
1. Improve Error handling: If error encountered while fetching pool members then handle it instead of setting empty pool members.
2. Use informers to fetch K8S resources:   Temporary issues with K8S API server doesn't impact CIS as resources are fetched from local cache maintained by informers.

**Fixes**: resolves #2909
## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed