### PR TITLE
Fix CIS crash when GCM is missing

### DIFF
--- a/docs/config_examples/next-gen-routes/README.md
+++ b/docs/config_examples/next-gen-routes/README.md
@@ -135,7 +135,9 @@ Follow this for easy migration [Migration Guide](https://github.com/F5Networks/k
 * If any specific tenant requires modify access for routeconfig of their namespace, the admin can grant access by setting **allowOverride** to true in the extendedRouteSpec of the namespace.
 * Base route configuration can be defined in Global ConfigMap. This cannot be overridden from local ConfigMap. This is an alternative to CIS deployment arguments.</br>
 
-_**NOTE:** Global ConfigMap should be created in a namespace which CIS is monitoring._
+_**NOTE:**_
+* _Global ConfigMap should be created in a namespace which CIS is monitoring._
+* _It must be created before running CIS for NextGenRoutes._
 
 ### Local ConfigMap
 

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -198,7 +198,7 @@ func (ctlr *Controller) processResources() bool {
 	// During Init time, just process all the resources
 	if ctlr.initState && rKey.kind != Namespace {
 		if rKey.kind == VirtualServer || rKey.kind == TransportServer || rKey.kind == Service ||
-			rKey.kind == IngressLink || rKey.kind == Route || rKey.kind == ExternalDNS || rKey.kind == ConfigMap {
+			rKey.kind == IngressLink || rKey.kind == Route || rKey.kind == ExternalDNS {
 			if rKey.kind == Service {
 				if svc, ok := rKey.rsc.(*v1.Service); ok {
 					if svc.Spec.Type == v1.ServiceTypeLoadBalancer {
@@ -3779,6 +3779,15 @@ func (ctlr *Controller) processConfigMap(cm *v1.ConfigMap, isDelete bool) (error
 		if isDelete {
 			// Handle configmap deletion
 			es.HAClusterConfig = HAClusterConfig{}
+		}
+		// Check if HA configurations are specified properly
+		if ctlr.cisType != "" {
+			if es.HAClusterConfig == (HAClusterConfig{}) || es.HAClusterConfig.PrimaryCluster == (ClusterDetails{}) ||
+				es.HAClusterConfig.SecondaryCluster == (ClusterDetails{}) {
+				log.Errorf("Either CIS High availability cluster config not provided or --cis-type is provided in " +
+					"standalone CIS mode")
+				os.Exit(1)
+			}
 		}
 		// Read multiCluster mode
 		// Set the active/standby/ratio mode for the HA cluster


### PR DESCRIPTION
**Description**:  Fix CIS crash when GCM is missing 

**Changes Proposed in PR**:  This PR has the following improvements:
1. Fix CIS crash when Global ConfigMap is missing when CIS is running in secondary mode
2. CIS exits gracefully if Global ConfigMap is missing when it start running.

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Smoke testing completed
- [x]  Updated the documentation