### PR TITLE
Rename multiCluster parameters and update documentation

### DIFF
--- a/docs/config_examples/multicluster/extendedConfigmap/global-config-with-primary-cluster-health-probe.yaml
+++ b/docs/config_examples/multicluster/extendedConfigmap/global-config-with-primary-cluster-health-probe.yaml
@@ -1,7 +1,7 @@
-# primaryClusterEndPoint -> allowed values are http/tcp endpoint
+# primaryEndPoint -> allowed values are http/tcp endpoint
 # http endpoint format : http://10.145.72.114:8001
 # tcp endpoint format : tcp://10.145.72.114:8000
-# Note: when configuring primaryClusterEndPoint, endPoint should contain protocol i.e http://ip:port , tcp://ip:port
+# Note: when configuring primaryEndPoint, endPoint should contain protocol i.e http://ip:port , tcp://ip:port
 # probeInterval -> time interval between health check
 # retryInterval -> time interval between recheck when primary cluster is down.
 apiVersion: v1
@@ -13,8 +13,8 @@ metadata:
   namespace: kube-system
 data:
   extendedSpec: |
-    highAvailabilityClusterConfigs:
-      primaryClusterEndPoint: http://10.145.72.114:8001
+    highAvailabilityCIS:
+      primaryEndPoint: http://10.145.72.114:8001
       probeInterval: 30
       retryInterval: 3
       primaryCluster:

--- a/docs/config_examples/multicluster/extendedConfigmap/global-spec-config-for-multicluster-with-active-active.yaml
+++ b/docs/config_examples/multicluster/extendedConfigmap/global-spec-config-for-multicluster-with-active-active.yaml
@@ -7,10 +7,9 @@ metadata:
   namespace: kube-system
 data:
   extendedSpec: |
-    highAvailabilityClusterConfigs:
-      mode:
-        type: active
-      primaryClusterEndPoint: http://10.145.72.114:8001
+    mode: active-active
+    highAvailabilityCIS:
+      primaryEndPoint: http://10.145.72.114:8001
       probeInterval: 30
       retryInterval: 3
       primaryCluster:

--- a/docs/config_examples/multicluster/extendedConfigmap/global-spec-config-for-multicluster.yaml
+++ b/docs/config_examples/multicluster/extendedConfigmap/global-spec-config-for-multicluster.yaml
@@ -7,10 +7,9 @@ metadata:
   namespace: kube-system
 data:
   extendedSpec: |
-    highAvailabilityClusterConfigs:
-      mode:
-        type: active
-      primaryClusterEndPoint: http://10.145.72.114:8001
+    mode: active-active
+    highAvailabilityCIS:
+      primaryEndPoint: http://10.145.72.114:8001
       probeInterval: 30
       retryInterval: 3
       primaryCluster:

--- a/pkg/controller/nativeResourceWorker.go
+++ b/pkg/controller/nativeResourceWorker.go
@@ -1908,7 +1908,7 @@ func (ctlr *Controller) readMultiClusterConfigFromGlobalCM(haClusterConfig HAClu
 	primaryClusterName := ""
 	secondaryClusterName := ""
 	if ctlr.cisType != "" && haClusterConfig != (HAClusterConfig{}) {
-		// If HA mode not set use StandBy mode as defualt
+		// If HA mode not set use active-standby mode as defualt
 		if ctlr.haModeType == "" {
 			ctlr.haModeType = StandBy
 		}

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -1217,7 +1217,7 @@ type (
 		ExtendedRouteGroupConfigs []ExtendedRouteGroupConfig `yaml:"extendedRouteSpec"`
 		BaseRouteConfig           `yaml:"baseRouteSpec"`
 		MultiClusterConfigs       []MultiClusterConfig `yaml:"multiClusterConfigs"`
-		HAClusterConfig           HAClusterConfig      `yaml:"highAvailabilityClusterConfigs"`
+		HAClusterConfig           HAClusterConfig      `yaml:"highAvailabilityCIS"`
 		HAMode                    HAModeType           `yaml:"mode"`
 		LocalClusterRatio         *int                 `yaml:"localClusterRatio"`
 	}
@@ -1278,8 +1278,8 @@ const (
 type HAModeType string
 
 const (
-	Active  HAModeType = "active"
-	StandBy HAModeType = "standby"
+	Active  HAModeType = "active-active"
+	StandBy HAModeType = "active-standby"
 	Ratio   HAModeType = "ratio"
 )
 
@@ -1292,7 +1292,7 @@ type (
 
 	HAClusterConfig struct {
 		//HAMode                 HAMode         `yaml:"mode"`
-		PrimaryClusterEndPoint string         `yaml:"primaryClusterEndPoint"`
+		PrimaryClusterEndPoint string         `yaml:"primaryEndPoint"`
 		ProbeInterval          int            `yaml:"probeInterval"`
 		RetryInterval          int            `yaml:"retryInterval"`
 		PrimaryCluster         ClusterDetails `yaml:"primaryCluster"`
@@ -1300,7 +1300,7 @@ type (
 	}
 
 	HAMode struct {
-		// type can be active, standby, ratio
+		// type can be active-active, active-standby, ratio
 		Type HAModeType `yaml:"type"`
 	}
 

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -3794,12 +3794,13 @@ func (ctlr *Controller) processConfigMap(cm *v1.ConfigMap, isDelete bool) (error
 			}
 		}
 		// Read multiCluster mode
-		// Set the active/standby/ratio mode for the HA cluster
+		// Set the active-active/active-standby/ratio mode for the HA cluster
 		if es.HAMode != "" {
 			if es.HAMode == Active || es.HAMode == StandBy || es.HAMode == Ratio {
 				ctlr.haModeType = es.HAMode
 			} else {
-				log.Errorf("Invalid Type of high availability mode specified, supported values (active, standby, ratio)")
+				log.Errorf("Invalid Type of high availability mode specified, supported values (active-active, " +
+					"active-standby, ratio)")
 				os.Exit(1)
 			}
 		}


### PR DESCRIPTION
**Description**:  Rename multiCluster parameters and update documentation

**Changes Proposed in PR**:  Following changes are done in this PR:
1. HA mode names and documentation have been improved
2. HA config and endpoint parameters have been renamed
3. MultiCluster documentation has been improved

**Fixes**: resolves #2990

## General Checklist
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema