### PR TITLE
Rename multiClusterConfigs to externalClustersConfig Section

### DIFF
--- a/docs/config_examples/multicluster/README.md
+++ b/docs/config_examples/multicluster/README.md
@@ -44,7 +44,7 @@ In a Standalone deployment of CIS, CIS is only deployed in one cluster, then cre
 Below is the sample Multi-Cluster Config in an Extended Global ConfigMap.
 ```
   extendedSpec: |
-    multiClusterConfigs:    -------------------------------------|----------------------------|                            |
+    externalClustersConfig:    -------------------------------------|----------------------------|                            |
     - clusterName: cluster3                                      |                            |
       secret: default/kubeconfig3                                |---> Cluster configs for    |
     - clusterName: cluster4                                      |     all other clusters     |
@@ -119,7 +119,7 @@ Below is the sample Multi-Cluster Configs with HA in Extended Global ConfigMap.
       secondaryCluster:                                          |                            |
         clusterName: cluster2                                    |                            |
         secret: default/kubeconfig2                              |                            |
-    multiClusterConfigs:    -------------------------------------|                            |
+    externalClustersConfig:    -------------------------------------|                            |
     - clusterName: cluster3                                      |                            |
       secret: default/kubeconfig3                                |---> Cluster configs for    |
     - clusterName: cluster4                                      |     all other clusters     |
@@ -155,7 +155,7 @@ Below is the sample Multi-Cluster Configs with HA and Ratio in Extended Global C
         clusterName: cluster2                                    |                            |
         secret: default/kubeconfig2                              |                            |
         ratio: 2                                                 |                            |
-    multiClusterConfigs:    -------------------------------------|                            |
+    externalClustersConfig:    -------------------------------------|                            |
     - clusterName: cluster3                                      |                            |
       secret: default/kubeconfig3                                |---> Cluster configs for    |
       ratio: 2                                                   |     all other clusters     |
@@ -218,14 +218,14 @@ Following is the sample deployment for primary CIS deployment:
 
 ### extended ConfigMap Parameters
 
-#### multiClusterConfigs Parameters
+#### externalClustersConfig Parameters
 
 | Parameter   | Type   | Required  | Description                                                               | Default | Examples                |
 |-------------|--------|-----------|---------------------------------------------------------------------------|---------|-------------------------|
 | clusterName | String | Mandatory | Name of the cluster                                                       | -       | cluster1                |
 | secret      | String | Mandatory | Name of the secret created for kubeconfig (format: namespace/secret-name) | -       | test/secret-kubeconfig1 |
 
-**Note:** Avoid specifying HA cluster(Primary/Secondary cluster) configs in multiClusterConfigs.
+**Note:** Avoid specifying HA cluster(Primary/Secondary cluster) configs in externalClustersConfig.
 
 #### High Availability Mode (Optional parameter)
 | Parameter              | Type    | Required  | Description                                                         | Default        | Examples       |

--- a/docs/config_examples/multicluster/extendedConfigmap/global-config-with-primary-cluster-health-probe.yaml
+++ b/docs/config_examples/multicluster/extendedConfigmap/global-config-with-primary-cluster-health-probe.yaml
@@ -23,7 +23,7 @@ data:
       secondaryCluster:
         clusterName: cluster2
         secret: default/kubeconfig2
-    multiClusterConfigs:
+    externalClustersConfig:
     - clusterName: cluster3
       secret: default/kubeconfig3
     - clusterName: cluster4

--- a/docs/config_examples/multicluster/extendedConfigmap/global-spec-config-for-multicluster-with-active-active.yaml
+++ b/docs/config_examples/multicluster/extendedConfigmap/global-spec-config-for-multicluster-with-active-active.yaml
@@ -18,7 +18,7 @@ data:
       secondaryCluster:
         clusterName: cluster2
         secret: default/kubeconfig2
-    multiClusterConfigs:
+    externalClustersConfig:
     - clusterName: cluster3
       secret: default/kubeconfig3
     - clusterName: cluster4

--- a/docs/config_examples/multicluster/extendedConfigmap/global-spec-config-for-multicluster.yaml
+++ b/docs/config_examples/multicluster/extendedConfigmap/global-spec-config-for-multicluster.yaml
@@ -18,7 +18,7 @@ data:
       secondaryCluster:
         clusterName: cluster2
         secret: default/kubeconfig2
-    multiClusterConfigs:
+    externalClustersConfig:
     - clusterName: cluster3
       secret: default/kubeconfig3
     - clusterName: cluster4

--- a/pkg/clustermanager/types.go
+++ b/pkg/clustermanager/types.go
@@ -7,9 +7,9 @@ import (
 type (
 	// MultiClusterConfig defines a structure for holding cluster configuration
 	MultiClusterConfig struct {
-		ClusterConfigs   map[string]ClusterConfig
-		HAPairCusterName string
-		LocalClusterName string
+		ClusterConfigs    map[string]ClusterConfig
+		HAPairClusterName string
+		LocalClusterName  string
 	}
 
 	ClusterConfig struct {

--- a/pkg/controller/multiClusterHealthProbeManager.go
+++ b/pkg/controller/multiClusterHealthProbeManager.go
@@ -19,7 +19,7 @@ func (postMgr *PostManager) checkPrimaryClusterHealthStatus() bool {
 		case "tcp":
 			status = postMgr.getPrimaryClusterHealthStatusFromTCPEndPoint()
 		case "", "default":
-			log.Debugf("unsupported primary cluster health probe endPoint  : %v", postMgr.PrimaryClusterHealthProbeParams.EndPoint)
+			log.Debugf("unsupported primaryEndPoint specified under highAvailabilityCIS section: %v", postMgr.PrimaryClusterHealthProbeParams.EndPoint)
 			return false
 		}
 
@@ -42,7 +42,7 @@ func (postMgr *PostManager) setPrimaryClusterHealthCheckEndPointType() {
 		} else if strings.HasPrefix(postMgr.PrimaryClusterHealthProbeParams.EndPoint, "http://") {
 			postMgr.PrimaryClusterHealthProbeParams.EndPointType = "http"
 		} else {
-			log.Debugf("unsupported primary cluster endPoint protocol type configured. EndPoint: %v \n "+
+			log.Debugf("unsupported primaryEndPoint protocol type configured under highAvailabilityCIS section. EndPoint: %v \n "+
 				"supported protocols:[http, tcp] ", postMgr.PrimaryClusterHealthProbeParams.EndPoint)
 			os.Exit(1)
 		}
@@ -56,7 +56,7 @@ func (postMgr *PostManager) getPrimaryClusterHealthStatusFromHTTPEndPoint() bool
 		return false
 	}
 	if !strings.HasPrefix(postMgr.PrimaryClusterHealthProbeParams.EndPoint, "http://") {
-		log.Debugf("Error: invalid health probe http endpoint: %v", postMgr.PrimaryClusterHealthProbeParams.EndPoint)
+		log.Debugf("Error: invalid primaryEndPoint detected under highAvailabilityCIS section: %v", postMgr.PrimaryClusterHealthProbeParams.EndPoint)
 		return false
 	}
 
@@ -71,7 +71,7 @@ func (postMgr *PostManager) getPrimaryClusterHealthStatusFromHTTPEndPoint() bool
 		postMgr.httpClient.Timeout = timeOut
 	}()
 	if postMgr.PrimaryClusterHealthProbeParams.statusChanged {
-		log.Debugf("posting GET Check Primary Cluster Health request on %v", postMgr.PrimaryClusterHealthProbeParams.EndPoint)
+		log.Debugf("posting GET Check primaryEndPoint Health request on %v", postMgr.PrimaryClusterHealthProbeParams.EndPoint)
 	}
 	postMgr.httpClient.Timeout = 10 * time.Second
 
@@ -83,7 +83,7 @@ func (postMgr *PostManager) getPrimaryClusterHealthStatusFromHTTPEndPoint() bool
 	case http.StatusOK:
 		return true
 	case http.StatusNotFound, http.StatusInternalServerError:
-		log.Debugf("error fetching primary cluster health status. endPoint:%v, statusCode: %v, error:%v",
+		log.Debugf("error fetching primaryEndPoint health status. endPoint:%v, statusCode: %v, error:%v",
 			postMgr.PrimaryClusterHealthProbeParams.EndPoint, httpResp.StatusCode, httpResp.Request.Response)
 	}
 	return false
@@ -95,13 +95,13 @@ func (postMgr *PostManager) getPrimaryClusterHealthStatusFromTCPEndPoint() bool 
 		return false
 	}
 	if !strings.HasPrefix(postMgr.PrimaryClusterHealthProbeParams.EndPoint, "tcp://") {
-		log.Debugf("invalid health probe tcp endpoint: %v", postMgr.PrimaryClusterHealthProbeParams.EndPoint)
+		log.Debugf("invalid primaryEndPoint health probe tcp endpoint: %v", postMgr.PrimaryClusterHealthProbeParams.EndPoint)
 		return false
 	}
 
 	_, err := net.Dial("tcp", strings.TrimLeft(postMgr.PrimaryClusterHealthProbeParams.EndPoint, "tcp://"))
 	if err != nil {
-		log.Debugf("error connecting to primary cluster tcp health probe endPoint: %v, error: %v", postMgr.PrimaryClusterHealthProbeParams.EndPoint, err)
+		log.Debugf("error connecting to primaryEndPoint tcp health probe: %v, error: %v", postMgr.PrimaryClusterHealthProbeParams.EndPoint, err)
 		return false
 	}
 	return true
@@ -152,13 +152,13 @@ func (ctlr *Controller) probePrimaryClusterHealthStatus() {
 			doneCh, errCh, err := ctlr.Agent.ConfigWriter.SendSection("primary-cluster-status", ctlr.Agent.PrimaryClusterHealthProbeParams.statusRunning)
 
 			if nil != err {
-				log.Warningf("Failed to write primary cluster status section: %v", err)
+				log.Warningf("Failed to write primary-cluster-status section: %v", err)
 			} else {
 				select {
 				case <-doneCh:
-					log.Debugf("Wrote primary cluster status as %v", ctlr.Agent.PrimaryClusterHealthProbeParams.statusRunning)
+					log.Debugf("Wrote primary-cluster-status as %v", ctlr.Agent.PrimaryClusterHealthProbeParams.statusRunning)
 				case e := <-errCh:
-					log.Warningf("Failed to write primary cluster status config section: %v", e)
+					log.Warningf("Failed to write primary-cluster-status config section: %v", e)
 				case <-time.After(time.Second):
 					log.Warningf("Did not receive write response in 1s")
 				}

--- a/pkg/controller/multiClusterInformers.go
+++ b/pkg/controller/multiClusterInformers.go
@@ -284,7 +284,7 @@ func (ctlr *Controller) setupMultiClusterNodeInformers(clusterName string) error
 // if endPoint is configured then CIS will exit
 func (ctlr *Controller) checkSecondaryCISConfig() {
 	if ctlr.cisType == SecondaryCIS && ctlr.Agent.PrimaryClusterHealthProbeParams.EndPoint == "" {
-		log.Debugf("error: cis running in secondary mode and missing primary cluster health check endPoint. ")
+		log.Debugf("error: cis running in secondary mode and missing primaryEndPoint under highAvailabilityCIS section. ")
 		os.Exit(1)
 	}
 }
@@ -293,7 +293,7 @@ func (ctlr *Controller) getNamespaceMultiClusterPoolInformer(
 	namespace string, clusterName string,
 ) (*MultiClusterPoolInformer, bool) {
 	// CIS may be watching all namespaces in case of HA clusters only
-	if clusterName == ctlr.multiClusterConfigs.HAPairCusterName && ctlr.watchingAllNamespaces() {
+	if clusterName == ctlr.multiClusterConfigs.HAPairClusterName && ctlr.watchingAllNamespaces() {
 		namespace = ""
 	}
 	nsPoolInf, ok := ctlr.multiClusterPoolInformers[clusterName]

--- a/pkg/controller/multiClusterWorker.go
+++ b/pkg/controller/multiClusterWorker.go
@@ -9,7 +9,7 @@ func (ctlr *Controller) processResourceExternalClusterServices(rscKey resourceRe
 
 	// if no external cluster is configured skip processing
 	if len(ctlr.multiClusterConfigs.ClusterConfigs) == 0 {
-		log.Debugf("no external cluster configuration found.")
+		log.Debugf("There is no externalClustersConfig section or there are no clusters defined in it.")
 		return
 	}
 

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -67,7 +67,7 @@ func (rs *ResourceStore) Init() {
 	rs.svcResourceCache = make(map[MultiClusterServiceKey]map[string]svcResourceCacheMeta)
 	rs.ipamContext = make(map[string]ficV1.IPSpec)
 	rs.processedNativeResources = make(map[resourceRef]struct{})
-	rs.multiClusterConfigs = make(map[string]MultiClusterConfig)
+	rs.externalClustersConfig = make(map[string]ExternalClusterConfig)
 }
 
 const (
@@ -560,9 +560,9 @@ func (ctlr *Controller) prepareRSConfigFromVirtualServer(
 				// update the multicluster resource serviceMap with local cluster services
 				ctlr.updateMultiClusterResourceServiceMap(rsCfg, rsRef, pl.Service, pl.Path, pool, pl.ServicePort, "")
 				// update the multicluster resource serviceMap with HA pair cluster services
-				if ctlr.haModeType == Active && ctlr.multiClusterConfigs.HAPairCusterName != "" {
+				if ctlr.haModeType == Active && ctlr.multiClusterConfigs.HAPairClusterName != "" {
 					ctlr.updateMultiClusterResourceServiceMap(rsCfg, rsRef, pl.Service, pl.Path, pool, pl.ServicePort,
-						ctlr.multiClusterConfigs.HAPairCusterName)
+						ctlr.multiClusterConfigs.HAPairClusterName)
 				}
 			} else {
 				ctlr.updateMultiClusterResourceServiceMap(rsCfg, rsRef, pl.Service, pl.Path, pool, pl.ServicePort, "")
@@ -1945,9 +1945,9 @@ func (ctlr *Controller) prepareRSConfigFromTransportServer(
 		// update the multicluster resource serviceMap with local cluster services
 		ctlr.updateMultiClusterResourceServiceMap(rsCfg, rsRef, vs.Spec.Pool.Service, vs.Spec.Pool.Path, pool, vs.Spec.Pool.ServicePort, "")
 		// update the multicluster resource serviceMap with HA pair cluster services
-		if ctlr.haModeType == Active && ctlr.multiClusterConfigs.HAPairCusterName != "" {
+		if ctlr.haModeType == Active && ctlr.multiClusterConfigs.HAPairClusterName != "" {
 			ctlr.updateMultiClusterResourceServiceMap(rsCfg, rsRef, vs.Spec.Pool.Service, "", pool, vs.Spec.Pool.ServicePort,
-				ctlr.multiClusterConfigs.HAPairCusterName)
+				ctlr.multiClusterConfigs.HAPairClusterName)
 		}
 	} else {
 		ctlr.updateMultiClusterResourceServiceMap(rsCfg, rsRef, vs.Spec.Pool.Service, vs.Spec.Pool.Path, pool, vs.Spec.Pool.ServicePort, "")

--- a/pkg/controller/routing.go
+++ b/pkg/controller/routing.go
@@ -1267,7 +1267,7 @@ func (ctlr *Controller) GetRouteBackends(route *routeapi.Route, clusterSvcs []ci
 	// If this is an HA setup, consider services linked to the route from both the clusters which are part of this
 	// HA setup
 	factor := 1 // factor is used to ensure the secondary cluster services associated with the Route are also considered
-	if ctlr.multiClusterConfigs.HAPairCusterName != "" {
+	if ctlr.multiClusterConfigs.HAPairClusterName != "" {
 		factor = 2
 	}
 	// Default service weight is 100 as per openshift route documentation
@@ -1332,12 +1332,12 @@ func (ctlr *Controller) GetRouteBackends(route *routeapi.Route, clusterSvcs []ci
 		rbcs[beIdx].Weight = (float64(*(route.Spec.To.Weight)) / totalSvcWeights) *
 			(float64(*ctlr.clusterRatio[ctlr.multiClusterConfigs.LocalClusterName]) / totalClusterRatio)
 		// Route backend service in HA partner cluster
-		if ctlr.multiClusterConfigs.HAPairCusterName != "" {
+		if ctlr.multiClusterConfigs.HAPairClusterName != "" {
 			beIdx++
 			rbcs[beIdx].Name = route.Spec.To.Name
 			rbcs[beIdx].Weight = (float64(*(route.Spec.To.Weight)) / totalSvcWeights) *
-				(float64(*ctlr.clusterRatio[ctlr.multiClusterConfigs.HAPairCusterName]) / totalClusterRatio)
-			rbcs[beIdx].Cluster = ctlr.multiClusterConfigs.HAPairCusterName
+				(float64(*ctlr.clusterRatio[ctlr.multiClusterConfigs.HAPairClusterName]) / totalClusterRatio)
+			rbcs[beIdx].Cluster = ctlr.multiClusterConfigs.HAPairClusterName
 		}
 	} else {
 		// Older versions of openshift do not have a weight field
@@ -1345,11 +1345,11 @@ func (ctlr *Controller) GetRouteBackends(route *routeapi.Route, clusterSvcs []ci
 		// local cluster
 		rbcs[beIdx].Weight = 0.0
 		// HA partner cluster
-		if ctlr.multiClusterConfigs.HAPairCusterName != "" {
+		if ctlr.multiClusterConfigs.HAPairClusterName != "" {
 			beIdx++
 			rbcs[beIdx].Name = route.Spec.To.Name
 			rbcs[beIdx].Weight = 0.0
-			rbcs[beIdx].Cluster = ctlr.multiClusterConfigs.HAPairCusterName
+			rbcs[beIdx].Cluster = ctlr.multiClusterConfigs.HAPairClusterName
 		}
 	}
 	// Process Alternate backends
@@ -1360,12 +1360,12 @@ func (ctlr *Controller) GetRouteBackends(route *routeapi.Route, clusterSvcs []ci
 			rbcs[beIdx].Weight = (float64(*(svc.Weight)) / totalSvcWeights) *
 				(float64(*ctlr.clusterRatio[ctlr.multiClusterConfigs.LocalClusterName]) / totalClusterRatio)
 			// HA partner cluster
-			if ctlr.multiClusterConfigs.HAPairCusterName != "" {
+			if ctlr.multiClusterConfigs.HAPairClusterName != "" {
 				beIdx = beIdx + 1
 				rbcs[beIdx].Name = svc.Name
 				rbcs[beIdx].Weight = (float64(*(svc.Weight)) / totalSvcWeights) *
-					(float64(*ctlr.clusterRatio[ctlr.multiClusterConfigs.HAPairCusterName]) / totalClusterRatio)
-				rbcs[beIdx].Cluster = ctlr.multiClusterConfigs.HAPairCusterName
+					(float64(*ctlr.clusterRatio[ctlr.multiClusterConfigs.HAPairClusterName]) / totalClusterRatio)
+				rbcs[beIdx].Cluster = ctlr.multiClusterConfigs.HAPairClusterName
 			}
 		}
 	}

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -473,8 +473,8 @@ type (
 		// key of the map is IPSpec.Key
 		ipamContext              map[string]ficV1.IPSpec
 		processedNativeResources map[resourceRef]struct{}
-		// stores valid multiClusterConfigs from extendendCM
-		multiClusterConfigs map[string]MultiClusterConfig
+		// stores valid externalClustersConfig from extendendCM
+		externalClustersConfig map[string]ExternalClusterConfig
 	}
 
 	svcResourceCacheMeta struct {
@@ -1216,10 +1216,10 @@ type (
 	extendedSpec struct {
 		ExtendedRouteGroupConfigs []ExtendedRouteGroupConfig `yaml:"extendedRouteSpec"`
 		BaseRouteConfig           `yaml:"baseRouteSpec"`
-		MultiClusterConfigs       []MultiClusterConfig `yaml:"multiClusterConfigs"`
-		HAClusterConfig           HAClusterConfig      `yaml:"highAvailabilityCIS"`
-		HAMode                    HAModeType           `yaml:"mode"`
-		LocalClusterRatio         *int                 `yaml:"localClusterRatio"`
+		ExternalClustersConfig    []ExternalClusterConfig `yaml:"externalClustersConfig"`
+		HAClusterConfig           HAClusterConfig         `yaml:"highAvailabilityCIS"`
+		HAMode                    HAModeType              `yaml:"mode"`
+		LocalClusterRatio         *int                    `yaml:"localClusterRatio"`
 	}
 
 	ExtendedRouteGroupConfig struct {
@@ -1284,7 +1284,7 @@ const (
 )
 
 type (
-	MultiClusterConfig struct {
+	ExternalClusterConfig struct {
 		ClusterName string `yaml:"clusterName"`
 		Secret      string `yaml:"secret"`
 		Ratio       *int   `yaml:"ratio"`

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -331,7 +331,7 @@ func (ctlr *Controller) processResources() bool {
 		secret := rKey.rsc.(*v1.Secret)
 		mcc := ctlr.getClusterForSecret(secret)
 		// TODO: Process all the resources again that refer to any resource running in the affected cluster?
-		if mcc != (MultiClusterConfig{}) {
+		if mcc != (ExternalClusterConfig{}) {
 			err := ctlr.updateClusterConfigStore(secret, mcc, rscDelete)
 			if err != nil {
 				log.Warningf(err.Error())
@@ -2047,10 +2047,10 @@ func (ctlr *Controller) updatePoolMembersForResources(pool *Pool) {
 	}
 
 	// for HA cluster pair service
-	if ctlr.haModeType == Active && ctlr.multiClusterConfigs.HAPairCusterName != "" {
+	if ctlr.haModeType == Active && ctlr.multiClusterConfigs.HAPairClusterName != "" {
 		poolMembers = append(poolMembers,
 			ctlr.fetchPoolMembersForService(pool.ServiceName, pool.ServiceNamespace, pool.ServicePort,
-				pool.NodeMemberLabel, ctlr.multiClusterConfigs.HAPairCusterName)...)
+				pool.NodeMemberLabel, ctlr.multiClusterConfigs.HAPairClusterName)...)
 	}
 
 	if len(ctlr.clusterRatio) > 0 {
@@ -2069,7 +2069,7 @@ func (ctlr *Controller) updatePoolMembersForResources(pool *Pool) {
 		// Ensure cluster services of the HA pair cluster (if specified as multi cluster service in route annotations)
 		// isn't considered for updating the pool members as it may lead to duplicate pool members as it may have been
 		// already populated while updating the HA cluster pair service pool members above
-		if _, ok := ctlr.multiClusterPoolInformers[mcs.ClusterName]; ok && ctlr.multiClusterConfigs.HAPairCusterName != mcs.ClusterName {
+		if _, ok := ctlr.multiClusterPoolInformers[mcs.ClusterName]; ok && ctlr.multiClusterConfigs.HAPairClusterName != mcs.ClusterName {
 			poolMembers = append(poolMembers,
 				ctlr.fetchPoolMembersForService(mcs.SvcName, mcs.Namespace, mcs.ServicePort,
 					pool.NodeMemberLabel, mcs.ClusterName)...)
@@ -3882,7 +3882,7 @@ func (ctlr *Controller) processConfigMap(cm *v1.ConfigMap, isDelete bool) (error
 			}
 		}
 
-		if es.MultiClusterConfigs != nil {
+		if es.ExternalClustersConfig != nil {
 			ctlr.multiClusterMode = true
 		} else {
 			ctlr.multiClusterMode = false
@@ -3896,7 +3896,7 @@ func (ctlr *Controller) processConfigMap(cm *v1.ConfigMap, isDelete bool) (error
 		}
 
 		if ctlr.multiClusterMode || ctlr.Agent.HAMode {
-			err := ctlr.readMultiClusterConfigFromGlobalCM(es.HAClusterConfig, es.MultiClusterConfigs)
+			err := ctlr.readMultiClusterConfigFromGlobalCM(es.HAClusterConfig, es.ExternalClustersConfig)
 			ctlr.checkSecondaryCISConfig()
 			ctlr.stopDeletedGlobalCMMultiClusterInformers()
 			if err != nil {


### PR DESCRIPTION
**Description**:  Rename multiClusterConfigs to externalClustersConfig Section for better user understanding 

**Changes Proposed in PR**: 

- Renamed multiClusterConfigs to externalClustersConfig Section  for better user standing.
- Modifications to log messages where necessary.
- Improved few Multicluster log messages.

**Fixes**: resolves #2999

## General Checklist
- [ ] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation
- [ ] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema