### PR TITLE
#2967 fix pod security violation warning on openshift installation

### DIFF
--- a/docs/config_examples/Install/openshift/HA/f5-k8s-bigip-ctlr-openshift-ose-bigip-01.yaml
+++ b/docs/config_examples/Install/openshift/HA/f5-k8s-bigip-ctlr-openshift-ose-bigip-01.yaml
@@ -1,39 +1,54 @@
-  apiVersion: extensions/v1beta1
-  kind: Deployment
-  metadata:
-    name: f5-ose-bigip-01-ctrl
-    namespace: kube-system
-  spec:
-    replicas: 1
-    template:
-      metadata:
-        name: k8s-bigip-ctlr
-        labels:
-          app: k8s-bigip-ctlr
-      spec:
-        # Name of the Service Account bound to a Cluster Role with the required
-        # permissions
-        serviceAccountName: bigip-ctlr
-        containers:
-          - name: k8s-bigip-ctlr
-            image: amit49g/k8s-bigip-ctlr:tsys-1.13-cf-1
-            env:
-              - name: BIGIP_USERNAME
-                valueFrom:
-                  secretKeyRef:
-                    # Replace with the name of the Secret containing your login
-                    # credentials
-                    name: bigip-login
-                    key: username
-              - name: BIGIP_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    # Replace with the name of the Secret containing your login
-                    # credentials
-                    name: bigip-login
-                    key: password
-            command: ["/app/bin/k8s-bigip-ctlr"]
-            args: [
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: f5-ose-bigip-01-ctrl
+  namespace: kube-system
+spec:
+  # DO NOT INCREASE REPLICA COUNT
+  replicas: 1
+  selector:
+    matchLabels:
+      app: k8s-bigip-ctlr
+  template:
+    metadata:
+      labels:
+        app: k8s-bigip-ctlr
+    spec:
+      # Name of the Service Account bound to a Cluster Role with the required
+      # permissions
+      containers:
+        - name: cntr-ingress-svcs
+          image: registry.connect.redhat.com/f5networks/cntr-ingress-svcs:latest
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 3000
+            fsGroup: 2000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BIGIP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  # Replace with the name of the Secret containing your login
+                  # credentials
+                  name: bigip-login
+                  key: username
+            - name: BIGIP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  # Replace with the name of the Secret containing your login
+                  # credentials
+                  name: bigip-login
+                  key: password
+          command: ["/app/bin/k8s-bigip-ctlr"]
+          args: [
+              # See the k8s-bigip-ctlr documentation for information about
+              # all config options
+              # https://clouddocs.f5.com/containers/latest/
               "--bigip-username=$(BIGIP_USERNAME)",
               "--bigip-password=$(BIGIP_PASSWORD)",
               # Replace with the IP address or hostname of your BIG-IP device
@@ -56,6 +71,7 @@
               "--insecure=true",
               "--agent=as3"
               ]
-        imagePullSecrets:
+      serviceAccountName: bigip-ctlr
+      imagePullSecrets:
           - name: f5-docker-images
           - name: bigip-login

--- a/docs/config_examples/Install/openshift/HA/f5-k8s-bigip-ctlr-openshift-ose-bigip-02.yaml
+++ b/docs/config_examples/Install/openshift/HA/f5-k8s-bigip-ctlr-openshift-ose-bigip-02.yaml
@@ -1,39 +1,54 @@
-  apiVersion: extensions/v1beta1
-  kind: Deployment
-  metadata:
-    name: f5-ose-bigip-02-ctrl
-    namespace: kube-system
-  spec:
-    replicas: 1
-    template:
-      metadata:
-        name: k8s-bigip-ctlr
-        labels:
-          app: k8s-bigip-ctlr
-      spec:
-        # Name of the Service Account bound to a Cluster Role with the required
-        # permissions
-        serviceAccountName: bigip-ctlr
-        containers:
-          - name: k8s-bigip-ctlr
-            image: amit49g/k8s-bigip-ctlr:tsys-1.13-cf-1
-            env:
-              - name: BIGIP_USERNAME
-                valueFrom:
-                  secretKeyRef:
-                    # Replace with the name of the Secret containing your login
-                    # credentials
-                    name: bigip-login
-                    key: username
-              - name: BIGIP_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    # Replace with the name of the Secret containing your login
-                    # credentials
-                    name: bigip-login
-                    key: password
-            command: ["/app/bin/k8s-bigip-ctlr"]
-            args: [
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: f5-ose-bigip-02-ctrl
+  namespace: kube-system
+spec:
+  # DO NOT INCREASE REPLICA COUNT
+  replicas: 1
+  selector:
+    matchLabels:
+      app: k8s-bigip-ctlr
+  template:
+    metadata:
+      labels:
+        app: k8s-bigip-ctlr
+    spec:
+      # Name of the Service Account bound to a Cluster Role with the required
+      # permissions
+      containers:
+        - name: cntr-ingress-svcs
+          image: registry.connect.redhat.com/f5networks/cntr-ingress-svcs:latest
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 3000
+            fsGroup: 2000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BIGIP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  # Replace with the name of the Secret containing your login
+                  # credentials
+                  name: bigip-login
+                  key: username
+            - name: BIGIP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  # Replace with the name of the Secret containing your login
+                  # credentials
+                  name: bigip-login
+                  key: password
+          command: ["/app/bin/k8s-bigip-ctlr"]
+          args: [
+              # See the k8s-bigip-ctlr documentation for information about
+              # all config options
+              # https://clouddocs.f5.com/containers/latest/
               "--bigip-username=$(BIGIP_USERNAME)",
               "--bigip-password=$(BIGIP_PASSWORD)",
               # Replace with the IP address or hostname of your BIG-IP device
@@ -56,6 +71,7 @@
               "--insecure=true",
               "--agent=as3"
               ]
-        imagePullSecrets:
+      serviceAccountName: bigip-ctlr
+      imagePullSecrets:
           - name: f5-docker-images
           - name: bigip-login

--- a/docs/config_examples/Install/openshift/StandAlone/f5-k8s-bigip-ctlr-openshift.yaml
+++ b/docs/config_examples/Install/openshift/StandAlone/f5-k8s-bigip-ctlr-openshift.yaml
@@ -1,42 +1,54 @@
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: f5-server
-    namespace: kube-system
-  spec:
-    replicas: 1
-    selector:
-      matchLabels:
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: f5-server
+  namespace: kube-system
+spec:
+  # DO NOT INCREASE REPLICA COUNT
+  replicas: 1
+  selector:
+    matchLabels:
+      app: k8s-bigip-ctlr
+  template:
+    metadata:
+      labels:
         app: k8s-bigip-ctlr
-    template:
-      metadata:
-        name: k8s-bigip-ctlr
-        labels:
-          app: k8s-bigip-ctlr
-      spec:
-        # Name of the Service Account bound to a Cluster Role with the required
-        # permissions
-        serviceAccountName: bigip-ctlr
-        containers:
-          - name: cntr-ingress-svcs
-            image: registry.connect.redhat.com/f5networks/cntr-ingress-svcs:latest
-            env:
-              - name: BIGIP_USERNAME
-                valueFrom:
-                  secretKeyRef:
-                    # Replace with the name of the Secret containing your login
-                    # credentials
-                    name: bigip-login
-                    key: username
-              - name: BIGIP_PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    # Replace with the name of the Secret containing your login
-                    # credentials
-                    name: bigip-login
-                    key: password
-            command: ["/app/bin/k8s-bigip-ctlr"]
-            args: [
+    spec:
+      # Name of the Service Account bound to a Cluster Role with the required
+      # permissions
+      containers:
+        - name: cntr-ingress-svcs
+          image: registry.connect.redhat.com/f5networks/cntr-ingress-svcs:latest
+          securityContext:
+            runAsUser: 1000
+            runAsGroup: 3000
+            fsGroup: 2000
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          env:
+            - name: BIGIP_USERNAME
+              valueFrom:
+                secretKeyRef:
+                  # Replace with the name of the Secret containing your login
+                  # credentials
+                  name: bigip-login
+                  key: username
+            - name: BIGIP_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  # Replace with the name of the Secret containing your login
+                  # credentials
+                  name: bigip-login
+                  key: password
+          command: ["/app/bin/k8s-bigip-ctlr"]
+          args: [
+              # See the k8s-bigip-ctlr documentation for information about
+              # all config options
+              # https://clouddocs.f5.com/containers/latest/
               "--bigip-username=$(BIGIP_USERNAME)",
               "--bigip-password=$(BIGIP_PASSWORD)",
               # Replace with the IP address or hostname of your BIG-IP device
@@ -63,6 +75,7 @@
               # Self-signed cert
               "--insecure=true"
               ]
-        imagePullSecrets:
+      serviceAccountName: bigip-ctlr
+      imagePullSecrets:
           - name: f5-docker-images
           - name: bigip-login


### PR DESCRIPTION
**Description**:  When following either https://clouddocs.f5.com/containers/latest/userguide/openshift/openshift-4-12-standalone.html
or https://clouddocs.f5.com/containers/latest/userguide/openshift/openshift-4-12-cluster.html

CIS creation brings the following warning

```
$ oc create -f f5-bigip1-ctlr-deployment.yaml 
Warning: would violate PodSecurity "restricted:latest": allowPrivilegeEscalation != false (container "cntr-ingress-svcs" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (container "cntr-ingress-svcs" must set securityContext.capabilities.drop=["ALL"]), runAsNonRoot != true (pod or container "cntr-ingress-svcs" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container "cntr-ingress-svcs" must set securityContext.seccompProfile.type to "RuntimeDefault" or "Localhost")
deployment.apps/k8s-bigip-ctlr-deployment created
```

**Changes Proposed in PR**: Added the pod security attributes in the deployment files

**Fixes**: resolves #2967

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema