### PR TITLE
Improvements in pod liveness probe based health monitor for NextGenRoutes

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -8,6 +8,8 @@ Added Functionality
 ```````````````````
 **What's new:**
     * Multi Cluster
+    * Next Generation Routes
+        * Improvements in pod liveness probe based health monitor and autoMonitor support for NextGenRoutes. See `Example <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/next-gen-routes/configmap>`_
     * CRD
     * Support for AS3 GTM agent with separate GTM server
 Bug Fixes

--- a/docs/config_examples/next-gen-routes/README.md
+++ b/docs/config_examples/next-gen-routes/README.md
@@ -94,6 +94,8 @@ If it's specified in both the places then allow source range in policy CR has mo
 ### Support for Health Monitors from pod liveness probe
 CIS uses the liveness probe of the pods to form the health monitors, whenever health annotations not provided in the route annotations. 
 
+This behaviour can be changed by setting autoMonitor in baseRouteSpec of the extended configmap.
+
 ## Migration Guide
 Follow this for easy migration [Migration Guide](https://github.com/F5Networks/k8s-bigip-ctlr/blob/master/docs/config_examples/next-gen-routes/migration-guide.md)
 
@@ -151,10 +153,21 @@ _**NOTE:**_
 
 Base route configuration can be defined in Global ConfigMap. This cannot be overridden from local ConfigMap. This is an alternative to CIS deployment arguments.
 
-| Parameter   | Required | Description                                                                                                               | Default | ConfigMap |
-|-------------|----------|---------------------------------------------------------------------------------------------------------------------------|---------| --------- |
-| tlsCipher   | Optional | Block to define TLS cipher parameters                                                                                     | N/A     | Global ConfigMap |
-| defaultTLS | Optional | Configures a cipher group in BIG-IP and references it here. Cipher group and ciphers are mutually exclusive; only use one. | /Common/f5-default     | Global ConfigMap |
+| Parameter   | Required | Description                                                                                                                     | Default            | ConfigMap |
+|-------------|----------|---------------------------------------------------------------------------------------------------------------------------------|--------------------| --------- |
+| tlsCipher   | Optional | Block to define TLS cipher parameters                                                                                           | N/A                | Global ConfigMap |
+| defaultTLS | Optional | Configures a cipher group in BIG-IP and references it here. Cipher group and ciphers are mutually exclusive; only use one.      | /Common/f5-default | Global ConfigMap |
+| autoMonitor   | Optional | Options for automatic health monitor in case no custom health monitor annotation is used (none/liveness-probe/service-endpoint) | liveness-probe     | Global ConfigMap |
+| autoMonitorTimeout | Optional | Timeout value(in seconds) to use for liveness probe based health monitor or default tcp health monitor                          | N/A                | Global ConfigMap |
+
+* autoMonitor: It provides options to configure CIS to either automatically create health monitor using pod liveness probe or create default tcp monitor or not create any health monitor in case custom health monitor annotation is not used in the Route.
+  * Supported values are "none", "liveness-probe" (default) and "service-endpoint".
+  * autoMonitor: none - CIS will not create health monitor for the pool.
+  * autoMonitor: liveness-probe - CIS will create health monitor for the pool based on the pod liveness probe configuration.
+  * autoMonitor: service-endpoint - CIS will create a default tcp health monitor for the pool.
+* autoMonitorTimeout: It provides option to configure timeout value for automatic monitor option selected.
+  * If not specified and pod contains liveness probe then timeout value of 3*interval+1 is used for automatic health monitor.
+  * If not specified and pod doesn't contain liveness probe then no automatic health monitor is created if autoMonitor is set to liveness-probe and default timeout value (16 seconds) is used if autoMonitor is set to service-endpoint.
 
 ```
  tlsCipher:

--- a/docs/config_examples/next-gen-routes/configmap/extendedRouteConfigwithBaseConfigWithAutoMonitor.yaml
+++ b/docs/config_examples/next-gen-routes/configmap/extendedRouteConfigwithBaseConfigWithAutoMonitor.yaml
@@ -1,0 +1,27 @@
+# autoMonitor is used to configure whether CIS should automatically create health monitor the pool or not.
+# It's specified in baseRouteSpec which applies to all RouteGroups and used only when custom health monitors annotations
+# are not specified.
+# supported values are "none", "liveness-probe" (default) and "service-endpoint"
+# autoMonitor: none - CIS will not create health monitor for the pool
+# autoMonitor: liveness-probe - CIS will create health monitor for the pool based on the pod liveness probe configuration
+# autoMonitor: service-endpoint - CIS will create a tcp health monitor for the pool
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: global-spec-config
+  namespace: kube-system
+  labels:
+    f5nr: "true"
+data:
+  extendedSpec: |
+    baseRouteSpec:
+     autoMonitor: service-endpoint
+     autoMonitorTimeout: 30
+    extendedRouteSpec:
+    - namespace: default
+      vserverAddr: 10.8.0.4
+      vserverName: nextgenroutes
+      allowOverride: true
+    - namespace: bar
+      vserverAddr: 10.8.0.5
+      allowOverride: false

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -1545,6 +1545,7 @@ func createMonitorDecl(cfg *ResourceConfig, sharedApp as3Application) {
 		monitor.TargetPort = v.TargetPort
 		targetAddressStr := ""
 		monitor.TargetAddress = &targetAddressStr
+		monitor.TimeUnitilUp = v.TimeUntilUp
 		//Monitor type
 		switch v.Type {
 		case "http":
@@ -1555,7 +1556,6 @@ func createMonitorDecl(cfg *ResourceConfig, sharedApp as3Application) {
 			if v.Recv != "" {
 				monitor.Receive = v.Recv
 			}
-			monitor.TimeUnitilUp = &val
 			monitor.Send = v.Send
 		case "https":
 			//Todo: For https monitor type
@@ -1565,6 +1565,7 @@ func createMonitorDecl(cfg *ResourceConfig, sharedApp as3Application) {
 				monitor.Receive = v.Recv
 			}
 			monitor.Send = v.Send
+			monitor.TimeUnitilUp = v.TimeUntilUp
 		case "tcp", "udp":
 			adaptiveFalse := false
 			monitor.Adaptive = &adaptiveFalse

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -445,15 +445,16 @@ type (
 
 	// Monitor is Pool health monitor
 	Monitor struct {
-		Name       string `json:"name"`
-		Partition  string `json:"-"`
-		Interval   int    `json:"interval,omitempty"`
-		Type       string `json:"type,omitempty"`
-		Send       string `json:"send,omitempty"`
-		Recv       string `json:"recv"`
-		Timeout    int    `json:"timeout,omitempty"`
-		TargetPort int32  `json:"targetPort,omitempty"`
-		Path       string `json:"path,omitempty"`
+		Name        string `json:"name"`
+		Partition   string `json:"-"`
+		Interval    int    `json:"interval,omitempty"`
+		Type        string `json:"type,omitempty"`
+		Send        string `json:"send,omitempty"`
+		Recv        string `json:"recv"`
+		Timeout     int    `json:"timeout,omitempty"`
+		TargetPort  int32  `json:"targetPort,omitempty"`
+		Path        string `json:"path,omitempty"`
+		TimeUntilUp *int   `json:"timeUntilUp,omitempty"`
 	}
 	MonitorName struct {
 		Name string `json:"name"`
@@ -1257,6 +1258,8 @@ type (
 		TLSCipher               TLSCipher               `yaml:"tlsCipher"`
 		DefaultTLS              DefaultSSLProfile       `yaml:"defaultTLS,omitempty"`
 		DefaultRouteGroupConfig DefaultRouteGroupConfig `yaml:"defaultRouteGroup,omitempty"`
+		AutoMonitor             AutoMonitorType         `yaml:"autoMonitor,omitempty"`
+		AutoMonitorTimeout      int                     `yaml:"autoMonitorTimeout,omitempty"`
 	}
 
 	TLSCipher struct {
@@ -1282,11 +1285,15 @@ const (
 )
 
 type HAModeType string
+type AutoMonitorType string
 
 const (
-	Active  HAModeType = "active-active"
-	StandBy HAModeType = "active-standby"
-	Ratio   HAModeType = "ratio"
+	Active          HAModeType      = "active-active"
+	StandBy         HAModeType      = "active-standby"
+	Ratio           HAModeType      = "ratio"
+	None            AutoMonitorType = "none"
+	LivenessProbe   AutoMonitorType = "liveness-probe"
+	ServiceEndpoint AutoMonitorType = "service-endpoint"
 )
 
 type (

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -567,7 +567,7 @@ func (ctlr *Controller) processResources() bool {
 		// Update the poolMembers for affected resources
 		ctlr.updatePoolMembersForService(svcKey)
 
-		if ctlr.mode == OpenShiftMode && rscDelete == false {
+		if ctlr.mode == OpenShiftMode && rscDelete == false && ctlr.resources.baseRouteConfig.AutoMonitor != None {
 			ctlr.UpdatePoolHealthMonitors(svcKey)
 		}
 

--- a/pkg/controller/worker_test.go
+++ b/pkg/controller/worker_test.go
@@ -3240,11 +3240,11 @@ extendedRouteSpec:
 				}
 				cnt := v1.Container{
 					LivenessProbe: &v1.Probe{
-
-						TimeoutSeconds:   10,
-						PeriodSeconds:    10,
-						SuccessThreshold: 1,
-						Handler:          Handler,
+						TimeoutSeconds:      10,
+						PeriodSeconds:       10,
+						SuccessThreshold:    1,
+						Handler:             Handler,
+						InitialDelaySeconds: 3,
 					},
 					Ports: []v1.ContainerPort{
 						v1.ContainerPort{


### PR DESCRIPTION
**Description**:  Improvements in pod liveliness probe based health monitor for NextGenRoutes

**Changes Proposed in PR**: 
 Improvements in pod liveness probe based health monitor for NextGenRoutes:
             * Use request conforming to HTTP/1.0 protocol in send string
            * Update recv string to accept response code between 200 to 399
            * Set timeUntilUp using initialDelaySeconds from pod liveliness probe
            * Use path field from pod livenessprobe in send string of health monitor
            * Add autoMonitor and autoMonitorTimeout option in baseRouteSpec

**Fixes**: resolves #3041 

## General Checklist
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed