### PR TITLE
Upgrade python version to 3.11.5

### DIFF
--- a/build-tools/Dockerfile.ubi
+++ b/build-tools/Dockerfile.ubi
@@ -39,13 +39,17 @@ RUN mkdir -p "$APPPATH/bin" "$APPPATH/vendor/src/f5/schemas/" \
  && touch $APPPATH/vendor/src/f5/VERSION_BUILD.json
 
 RUN microdnf update -y && \
-    microdnf --enablerepo=ubi-9-baseos-rpms install --nodocs python39 python3-pip git shadow-utils -y && \
+    microdnf --enablerepo=ubi-9-baseos-rpms install --nodocs findutils gcc openssl-devel bzip2-devel libffi-devel zlib-devel git shadow-utils tar -y && \
     microdnf --enablerepo=ubi-9-baseos-rpms --enablerepo=ubi-9-appstream-rpms update nss-tools nss-softokn nss-util scl-utils -y && \
-    pip3 install --no-cache-dir --upgrade pip==20.0.2 && \
-    pip3 install --no-cache-dir -r /tmp/requirements.txt && \
-    python3 -m pip uninstall -y pip && \
+    curl -O https://www.python.org/ftp/python/3.11.5/Python-3.11.5.tgz  && \
+    tar xvf Python-3.11.5.tgz && \
+    pushd Python-3.11.5/ && ./configure --enable-optimizations && make altinstall && popd && \
+    rm -rf Python-3.11.5.tgz Python-3.11.5 && \
+    pip3.11 install --no-cache-dir --upgrade pip==20.0.2 && \
+    pip3.11 install --no-cache-dir -r /tmp/requirements.txt && \
+    python3.11 -m pip uninstall -y pip && \
     adduser ctlr && \
-    microdnf remove libedit openssh openssh-clients perl-Git  perl-TermReadKey git-core git-core-doc git less shadow-utils -y && \
+    microdnf remove findutils tar gcc openssl-devel bzip2-devel libffi-devel zlib-devel libedit openssh openssh-clients perl-Git  perl-TermReadKey git-core git-core-doc git less shadow-utils -y && \
     microdnf clean all && echo "{\"version\": \"${BUILD_VERSION}\", \"build\": \"${BUILD_INFO}\"}" > $APPPATH/vendor/src/f5/VERSION_BUILD.json && chown -R ctlr "$APPPATH" && chmod -R 755 "$APPPATH"
 
 USER ctlr

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
--e git+https://github.com/f5devcentral/f5-ctlr-agent.git@ce91b26ba7a90565d0a06829b0a2c16e96e8ccaa#egg=f5-ctlr-agent
--e git+https://github.com/f5devcentral/f5-cccl.git@ceb105b6df2f1099a5dbf364b9f30b64be4641ae#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-cccl.git@71da8f9bbdefc8095c0bf11c9ae1b393f2107c5c#egg=f5-cccl
+-e git+https://github.com/f5devcentral/f5-ctlr-agent.git@8a2eea0eb5e51fa4555aa8e8e58719b3864fb36d#egg=f5-ctlr-agent


### PR DESCRIPTION
**Description**:  Upgrade python version to 3.11.5 to mitigate CVE-2023-40217

**Changes Proposed in PR**:

**Fixes**: resolves #_Github issue id_

## General Checklist
- [ ] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation
- [ ] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema