### PR TITLE
#JRA-4147 set loglevel to DEBUG when arg LogLevel with value AS3DEBUG

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -1077,6 +1077,10 @@ func main() {
 		DisableARP:        disableARP,
 		StaticRoutingMode: *staticRoutingMode,
 	}
+	// If AS3DEBUG is set, set log level to DEBUG
+	if gs.LogLevel == "AS3DEBUG" {
+		gs.LogLevel = "DEBUG"
+	}
 	if *ccclLogLevel != "" {
 		gs.LogLevel = *ccclLogLevel
 	}

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -121,6 +121,11 @@ func NewAgent(params AgentParams) *Agent {
 		MultiClusterMode:  params.MultiClusterMode,
 	}
 
+	// If AS3DEBUG is set, set log level to DEBUG
+	if gs.LogLevel == "AS3DEBUG" {
+		gs.LogLevel = "DEBUG"
+	}
+
 	bs := bigIPSection{
 		BigIPUsername:   params.PostParams.BIGIPUsername,
 		BigIPPassword:   params.PostParams.BIGIPPassword,


### PR DESCRIPTION
**Description**:  Undefined value specified for the "global:log-level" field in the configuration file

**Changes Proposed in PR**: Setting the log level value to DEBUG when deploy arg loglevel value is AS3DEBUG

**Fixes**: resolves [#1053](https://gitswarm.f5net.com/cc/docs/-/issues/1053)

## General Checklist
- [ ] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation
- [ ] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema