### PR TITLE
Fix health monitor names in multiCluster ratio mode

### DIFF
--- a/pkg/controller/nativeResourceWorker_test.go
+++ b/pkg/controller/nativeResourceWorker_test.go
@@ -2318,6 +2318,20 @@ externalClustersConfig:
 			Expect(len(mockCtlr.multiClusterResources.clusterSvcMap["cluster3"])).To(Equal(1))
 			Expect(len(mockCtlr.multiClusterResources.clusterSvcMap)).To(Equal(3))
 
+			// Verify that distinct health monitors are created for all pools in ratio mode
+			expectedHealthMonitors := make(map[string]struct{})
+			expectedHealthMonitors = map[string]struct{}{
+				"svc1_default_test_com_foo":            struct{}{},
+				"svc1_default_test_com_foo_cluster2":   struct{}{},
+				"svc1_b_default_test_com_foo":          struct{}{},
+				"svc1_b_default_test_com_foo_cluster2": struct{}{},
+				"test_default_test_com_foo_cluster3":   struct{}{},
+			}
+			for _, hm := range rsCfg.Monitors {
+				_, ok := expectedHealthMonitors[hm.Name]
+				Expect(ok).To(Equal(true), "Expected health monitor %s not found while using "+
+					"ratio mode", hm.Name)
+			}
 			resourceKey := resourceRef{
 				kind:      VirtualServer,
 				namespace: vs.Namespace,

--- a/pkg/controller/resourceConfig_test.go
+++ b/pkg/controller/resourceConfig_test.go
@@ -114,7 +114,7 @@ var _ = Describe("Resource Config Tests", func() {
 			Expect(name).To(Equal("svc1_80_default_foo_app_test"), "Invalid Pool Name")
 		})
 		It("Monitor Name", func() {
-			name := formatMonitorName(namespace, "svc1", "http", intstr.IntOrString{IntVal: 80}, "foo.com", "path")
+			name := formatMonitorName(namespace, "svc1", "http", intstr.IntOrString{IntVal: 80}, "foo.com", "path", "")
 			Expect(name).To(Equal("svc1_default_foo_com_path_http_80"), "Invalid Monitor Name")
 		})
 		It("Rule Name", func() {


### PR DESCRIPTION
**Description**:  Fix health monitor names in multiCluster ratio mode

**Changes Proposed in PR**: In multiCluster ratio mode create health monitors with distinct names in case of Virtual Server CR.

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Smoke testing completed