### PR TITLE
Fix logic for node not ready check

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -14,6 +14,7 @@ Bug Fixes
 ````````````
 * ``Issue 3057 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3057>`_: Support for pool settings for reslect with policy CR.
 * `https://github.com/F5Networks/k8s-bigip-ctlr/issues/3061`_: Provide stable pool name in multi cluster mode
+* `Issue 3079<https://github.com/F5Networks/k8s-bigip-ctlr/issues/3079>`_: Fix logic for node not ready check
 
 2.14.0
 -------------

--- a/pkg/appmanager/appManager.go
+++ b/pkg/appmanager/appManager.go
@@ -3179,9 +3179,10 @@ func (appMgr *Manager) getNodes(
 	for _, node := range nodes {
 		// Ignore the Nodes with status NotReady
 		var notExecutable bool
-		for _, t := range node.Spec.Taints {
-			if v1.TaintEffectNoExecute == t.Effect {
+		for _, nodeCondition := range node.Status.Conditions {
+			if nodeCondition.Type == v1.NodeReady && nodeCondition.Status != v1.ConditionTrue {
 				notExecutable = true
+				break
 			}
 		}
 		if notExecutable == true {
@@ -3753,9 +3754,10 @@ func (appMgr *Manager) processStaticRouteUpdate(
 		node := obj.(*v1.Node)
 		// Ignore the Nodes with status NotReady
 		var notExecutable bool
-		for _, t := range node.Spec.Taints {
-			if v1.TaintEffectNoExecute == t.Effect {
+		for _, nodeCondition := range node.Status.Conditions {
+			if nodeCondition.Type == v1.NodeReady && nodeCondition.Status != v1.ConditionTrue {
 				notExecutable = true
+				break
 			}
 		}
 		if notExecutable == true {

--- a/pkg/appmanager/appManager_test.go
+++ b/pkg/appmanager/appManager_test.go
@@ -735,7 +735,7 @@ var _ = Describe("AppManager Tests", func() {
 
 			expectedNodes := []*v1.Node{
 				test.NewNode("node0", "0", true, []v1.NodeAddress{
-					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}, nil),
 				test.NewNode("node1", "1", false, []v1.NodeAddress{
 					{Type: "ExternalIP", Address: "127.0.0.1"}},
 					[]v1.Taint{
@@ -743,7 +743,7 @@ var _ = Describe("AppManager Tests", func() {
 							Key:    "node-role.kubernetes.io/worker",
 							Effect: v1.TaintEffectPreferNoSchedule,
 						},
-					}),
+					}, nil),
 				test.NewNode("node2", "2", false, []v1.NodeAddress{
 					{Type: "ExternalIP", Address: "127.0.0.2"}},
 					[]v1.Taint{
@@ -751,9 +751,9 @@ var _ = Describe("AppManager Tests", func() {
 							Key:    "node-role.kubernetes.io/worker",
 							Effect: v1.TaintEffectNoSchedule,
 						},
-					}),
+					}, nil),
 				test.NewNode("node3", "3", false, []v1.NodeAddress{
-					{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}, nil),
 			}
 
 			expectedReturn := []Node{
@@ -783,7 +783,7 @@ var _ = Describe("AppManager Tests", func() {
 			// Existing Node data
 			expectedNodes := []*v1.Node{
 				test.NewNode("node0", "0", true, []v1.NodeAddress{
-					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}, nil),
 				test.NewNode("node1", "1", false, []v1.NodeAddress{
 					{Type: "ExternalIP", Address: "127.0.0.1"}},
 					[]v1.Taint{
@@ -791,15 +791,15 @@ var _ = Describe("AppManager Tests", func() {
 							Key:    "node-role.kubernetes.io/worker",
 							Effect: v1.TaintEffectPreferNoSchedule,
 						},
-					}),
+					}, nil),
 				test.NewNode("node2", "2", false, []v1.NodeAddress{
-					{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}, nil),
 				test.NewNode("node3", "3", false, []v1.NodeAddress{
-					{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}, nil),
 				test.NewNode("node4", "4", false, []v1.NodeAddress{
-					{Type: "InternalIP", Address: "127.0.0.4"}}, []v1.Taint{}),
+					{Type: "InternalIP", Address: "127.0.0.4"}}, []v1.Taint{}, nil),
 				test.NewNode("node5", "5", false, []v1.NodeAddress{
-					{Type: "Hostname", Address: "127.0.0.5"}}, []v1.Taint{}),
+					{Type: "Hostname", Address: "127.0.0.5"}}, []v1.Taint{}, nil),
 				test.NewNode("node6", "6", false, []v1.NodeAddress{
 					{Type: "ExternalIP", Address: "127.0.0.6"}},
 					[]v1.Taint{
@@ -807,7 +807,7 @@ var _ = Describe("AppManager Tests", func() {
 							Key:    "node-role.kubernetes.io/worker",
 							Effect: v1.TaintEffectNoSchedule,
 						},
-					}),
+					}, nil),
 			}
 
 			expectedReturn := []Node{
@@ -862,17 +862,17 @@ var _ = Describe("AppManager Tests", func() {
 		It("should process node updates", func() {
 			originalSet := []v1.Node{
 				*test.NewNode("node0", "0", true, []v1.NodeAddress{
-					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}, nil),
 				*test.NewNode("node1", "1", false, []v1.NodeAddress{
-					{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}, nil),
 				*test.NewNode("node2", "2", false, []v1.NodeAddress{
-					{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}, nil),
 				*test.NewNode("node3", "3", false, []v1.NodeAddress{
-					{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}),
+					{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}, nil),
 				*test.NewNode("node4", "4", false, []v1.NodeAddress{
-					{Type: "InternalIP", Address: "127.0.0.4"}}, []v1.Taint{}),
+					{Type: "InternalIP", Address: "127.0.0.4"}}, []v1.Taint{}, nil),
 				*test.NewNode("node5", "5", false, []v1.NodeAddress{
-					{Type: "Hostname", Address: "127.0.0.5"}}, []v1.Taint{}),
+					{Type: "Hostname", Address: "127.0.0.5"}}, []v1.Taint{}, nil),
 				*test.NewNode("node6", "6", false, []v1.NodeAddress{
 					{Type: "ExternalIP", Address: "127.0.0.6"}},
 					[]v1.Taint{
@@ -880,7 +880,7 @@ var _ = Describe("AppManager Tests", func() {
 							Key:    "node-role.kubernetes.io/worker",
 							Effect: v1.TaintEffectNoSchedule,
 						},
-					}),
+					}, nil),
 				*test.NewNode("node7", "7", false, []v1.NodeAddress{
 					{Type: "ExternalIP", Address: "127.0.0.7"}},
 					[]v1.Taint{
@@ -888,7 +888,7 @@ var _ = Describe("AppManager Tests", func() {
 							Key:    "node-role.kubernetes.io/worker",
 							Effect: v1.TaintEffectNoExecute,
 						},
-					}),
+					}, []v1.NodeCondition{{Type: v1.NodeReady, Status: v1.ConditionFalse}}),
 			}
 			// should ignore nodes with NotReady state(v1.TaintEffectNoExecute)
 			expectedOgSet := []Node{
@@ -929,11 +929,11 @@ var _ = Describe("AppManager Tests", func() {
 
 			// add some nodes
 			_, err = fakeClient.CoreV1().Nodes().Create(context.TODO(), test.NewNode("nodeAdd", "nodeAdd", false,
-				[]v1.NodeAddress{{Type: "ExternalIP", Address: "127.0.0.6"}}, []v1.Taint{}), metav1.CreateOptions{})
+				[]v1.NodeAddress{{Type: "ExternalIP", Address: "127.0.0.6"}}, []v1.Taint{}, nil), metav1.CreateOptions{})
 			Expect(err).To(BeNil(), "Create should not return err.")
 
 			_, err = fakeClient.CoreV1().Nodes().Create(context.TODO(), test.NewNode("nodeExclude", "nodeExclude",
-				true, []v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.7"}}, []v1.Taint{}), metav1.CreateOptions{})
+				true, []v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.7"}}, []v1.Taint{}, nil), metav1.CreateOptions{})
 
 			appMgr.useNodeInternal = false
 			nodes, err = fakeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
@@ -1123,7 +1123,7 @@ var _ = Describe("AppManager Tests", func() {
 
 				nodeSet := []v1.Node{
 					*test.NewNode("node0", "0", false, []v1.NodeAddress{
-						{Type: "InternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
+						{Type: "InternalIP", Address: "127.0.0.0"}}, []v1.Taint{}, nil),
 				}
 
 				mockMgr.processNodeUpdate(nodeSet)
@@ -1275,14 +1275,14 @@ var _ = Describe("AppManager Tests", func() {
 					[]v1.ServicePort{{Port: 80, NodePort: 37001}})
 				nodes := []*v1.Node{
 					test.NewNode("node0", "0", true, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}, nil),
 					test.NewNode("node1", "1", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}, nil),
 					test.NewNode("node2", "2", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}, nil),
 				}
 				extraNode := test.NewNode("node3", "3", false,
-					[]v1.NodeAddress{{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
+					[]v1.NodeAddress{{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}, nil)
 
 				nodeCh := make(chan struct{})
 				mapCh := make(chan struct{})
@@ -1405,9 +1405,9 @@ var _ = Describe("AppManager Tests", func() {
 
 				nodes := []*v1.Node{
 					test.NewNode("node0", "0", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}, nil),
 					test.NewNode("node1", "1", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}, nil),
 				}
 				for _, node := range nodes {
 					n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
@@ -1554,14 +1554,14 @@ var _ = Describe("AppManager Tests", func() {
 					[]v1.ServicePort{{Port: 80, NodePort: 37001}})
 				nodes := []v1.Node{
 					*test.NewNode("node0", "0", true, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}, nil),
 					*test.NewNode("node1", "1", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}, nil),
 					*test.NewNode("node2", "2", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}, nil),
 				}
 				extraNode := test.NewNode("node3", "3", false,
-					[]v1.NodeAddress{{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
+					[]v1.NodeAddress{{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}, nil)
 
 				addrs := []string{"127.0.0.0", "127.0.0.1", "127.0.0.2"}
 
@@ -1872,7 +1872,7 @@ var _ = Describe("AppManager Tests", func() {
 				wrongNamespace := "wrongnamespace"
 
 				node := test.NewNode("node3", "3", false,
-					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
+					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{}, nil)
 				_, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
 				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
@@ -1974,16 +1974,16 @@ var _ = Describe("AppManager Tests", func() {
 					[]v1.ServicePort{{Port: 80, NodePort: 20202}})
 				nodes := []v1.Node{
 					*test.NewNode("node0", "0", true, []v1.NodeAddress{
-						{Type: "InternalIP", Address: "192.168.0.0"}}, []v1.Taint{}),
+						{Type: "InternalIP", Address: "192.168.0.0"}}, []v1.Taint{}, nil),
 					*test.NewNode("node1", "1", false, []v1.NodeAddress{
-						{Type: "InternalIP", Address: "192.168.0.1"}}, []v1.Taint{}),
+						{Type: "InternalIP", Address: "192.168.0.1"}}, []v1.Taint{}, nil),
 					*test.NewNode("node2", "2", false, []v1.NodeAddress{
-						{Type: "InternalIP", Address: "192.168.0.2"}}, []v1.Taint{}),
+						{Type: "InternalIP", Address: "192.168.0.2"}}, []v1.Taint{}, nil),
 					*test.NewNode("node3", "3", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "192.168.0.3"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "192.168.0.3"}}, []v1.Taint{}, nil),
 				}
 				extraNode := test.NewNode("node4", "4", false, []v1.NodeAddress{
-					{Type: "InternalIP", Address: "192.168.0.4"}}, []v1.Taint{})
+					{Type: "InternalIP", Address: "192.168.0.4"}}, []v1.Taint{}, nil)
 
 				addrs := []string{"192.168.0.0", "192.168.0.1", "192.168.0.2"}
 
@@ -2230,13 +2230,13 @@ var _ = Describe("AppManager Tests", func() {
 
 				nodes := []*v1.Node{
 					test.NewNode("node0", "0", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}, nil),
 					test.NewNode("node1", "1", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}, nil),
 					test.NewNode("node2", "2", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}, nil),
 					test.NewNode("node3", "3", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}, nil),
 				}
 				for _, node := range nodes {
 					n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
@@ -2319,17 +2319,17 @@ var _ = Describe("AppManager Tests", func() {
 
 				nodes := []*v1.Node{
 					test.NewNode("node0", "0", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}, nil),
 					test.NewNode("node1", "1", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.1"}}, []v1.Taint{}, nil),
 					test.NewNode("node2", "2", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.2"}}, []v1.Taint{}, nil),
 					test.NewNode("node3", "3", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.3"}}, []v1.Taint{}, nil),
 					test.NewNode("node4", "4", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.4"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.4"}}, []v1.Taint{}, nil),
 					test.NewNode("node5", "5", false, []v1.NodeAddress{
-						{Type: "ExternalIP", Address: "127.0.0.5"}}, []v1.Taint{}),
+						{Type: "ExternalIP", Address: "127.0.0.5"}}, []v1.Taint{}, nil),
 				}
 				for _, node := range nodes {
 					n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
@@ -2413,7 +2413,7 @@ var _ = Describe("AppManager Tests", func() {
 				svcPodIps := []string{"10.2.96.0", "10.2.96.1", "10.2.96.2"}
 
 				node := test.NewNode("node0", "0", false, []v1.NodeAddress{
-					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{})
+					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}, nil)
 				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 				Expect(err).To(BeNil(), "Should not fail creating node.")
 				Expect(n).To(Equal(node))
@@ -2480,7 +2480,7 @@ var _ = Describe("AppManager Tests", func() {
 				svcPodIps := []string{"10.2.96.0", "10.2.96.1", "10.2.96.2"}
 
 				node := test.NewNode("node0", "0", false, []v1.NodeAddress{
-					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{})
+					{Type: "ExternalIP", Address: "127.0.0.0"}}, []v1.Taint{}, nil)
 				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 				Expect(err).To(BeNil(), "Should not fail creating node.")
 				Expect(n).To(Equal(node))
@@ -2642,7 +2642,7 @@ var _ = Describe("AppManager Tests", func() {
 				mockMgr.appMgr.useNodeInternal = true
 				// Create Node so we get endpoints
 				node := test.NewNode("node1", "1", false,
-					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.1"}}, []v1.Taint{})
+					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.1"}}, []v1.Taint{}, nil)
 				_, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
 				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
@@ -3594,7 +3594,7 @@ var _ = Describe("AppManager Tests", func() {
 				err := mockMgr.startNonLabelMode([]string{ns1, ns2})
 				Expect(err).To(BeNil())
 				node := test.NewNode("node1", "1", false,
-					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
+					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{}, nil)
 				_, err = mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
 				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
@@ -3675,7 +3675,7 @@ var _ = Describe("AppManager Tests", func() {
 				err := mockMgr.startNonLabelMode([]string{ns1, ns2})
 				Expect(err).To(BeNil())
 				node := test.NewNode("node1", "1", false,
-					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
+					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{}, nil)
 				_, err = mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
 				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})
@@ -3776,7 +3776,7 @@ var _ = Describe("AppManager Tests", func() {
 				ns3 := test.NewNamespace("ns3", "1", map[string]string{nsLabel: "yes"})
 
 				node := test.NewNode("node1", "1", false,
-					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{})
+					[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.3"}}, []v1.Taint{}, nil)
 				_, err = mockMgr.appMgr.kubeClient.CoreV1().Nodes().Create(context.TODO(), node, metav1.CreateOptions{})
 				Expect(err).To(BeNil())
 				n, err := mockMgr.appMgr.kubeClient.CoreV1().Nodes().List(context.TODO(), metav1.ListOptions{})

--- a/pkg/appmanager/ingress_test.go
+++ b/pkg/appmanager/ingress_test.go
@@ -1068,7 +1068,7 @@ var _ = Describe("V1 Ingress Tests", func() {
 			}
 			// Create Node so we get endpoints
 			node := test.NewNode("node1", "1", false,
-				[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.1"}}, []v1.Taint{})
+				[]v1.NodeAddress{{Type: "InternalIP", Address: "127.0.0.1"}}, []v1.Taint{}, nil)
 			mockMgr.addNode(node, namespace)
 			Expect(len(mockMgr.appMgr.nodeInformer.nodeInformer.GetIndexer().List())).To(Equal(1))
 

--- a/pkg/controller/node_poll_handler.go
+++ b/pkg/controller/node_poll_handler.go
@@ -149,9 +149,10 @@ func (ctlr *Controller) getNodes(
 	for _, node := range nodes {
 		// Ignore the Nodes with status NotReady
 		var notExecutable bool
-		for _, t := range node.Spec.Taints {
-			if v1.TaintEffectNoExecute == t.Effect {
+		for _, nodeCondition := range node.Status.Conditions {
+			if nodeCondition.Type == v1.NodeReady && nodeCondition.Status != v1.ConditionTrue {
 				notExecutable = true
+				break
 			}
 		}
 		if notExecutable == true {
@@ -221,9 +222,10 @@ func (ctlr *Controller) processStaticRouteUpdate(
 		node := obj.(*v1.Node)
 		// Ignore the Nodes with status NotReady
 		var notExecutable bool
-		for _, t := range node.Spec.Taints {
-			if v1.TaintEffectNoExecute == t.Effect {
+		for _, nodeCondition := range node.Status.Conditions {
+			if nodeCondition.Type == v1.NodeReady && nodeCondition.Status != v1.ConditionTrue {
 				notExecutable = true
+				break
 			}
 		}
 		if notExecutable == true {

--- a/pkg/controller/node_poll_handler_test.go
+++ b/pkg/controller/node_poll_handler_test.go
@@ -45,18 +45,14 @@ var _ = Describe("Node Poller Handler", func() {
 			Type:    v1.NodeInternalIP,
 			Address: "1.2.3.6",
 		}
+		nodecondition := v1.NodeCondition{Type: v1.NodeReady, Status: v1.ConditionFalse}
 		nodeObjs := []v1.Node{
 			*test.NewNode("worker1", "1", false,
-				[]v1.NodeAddress{nodeAddr1}, nil),
+				[]v1.NodeAddress{nodeAddr1}, nil, nil),
 			*test.NewNode("worker2", "1", false,
-				[]v1.NodeAddress{nodeAddr2}, nil),
+				[]v1.NodeAddress{nodeAddr2}, nil, nil),
 			*test.NewNode("worker3", "1", false,
-				[]v1.NodeAddress{nodeAddr3}, []v1.Taint{
-					{
-						Key:    "node-role.kubernetes.io/worker",
-						Effect: v1.TaintEffectNoExecute,
-					},
-				}),
+				[]v1.NodeAddress{nodeAddr3}, nil, []v1.NodeCondition{nodecondition}),
 		}
 
 		for _, node := range nodeObjs {
@@ -111,7 +107,7 @@ var _ = Describe("Node Poller Handler", func() {
 		}
 		nodeObjs := []v1.Node{
 			*test.NewNode("worker1", "1", false,
-				[]v1.NodeAddress{nodeAddr1}, nil),
+				[]v1.NodeAddress{nodeAddr1}, nil, nil),
 		}
 		for _, node := range nodeObjs {
 			mockCtlr.addNode(&node)

--- a/pkg/test/utils.go
+++ b/pkg/test/utils.go
@@ -196,6 +196,7 @@ func NewNode(
 	unsched bool,
 	addresses []v1.NodeAddress,
 	taints []v1.Taint,
+	conditions []v1.NodeCondition,
 ) *v1.Node {
 	return &v1.Node{
 		TypeMeta: metav1.TypeMeta{
@@ -211,7 +212,8 @@ func NewNode(
 			Taints:        taints,
 		},
 		Status: v1.NodeStatus{
-			Addresses: addresses,
+			Addresses:  addresses,
+			Conditions: conditions,
 		},
 	}
 }

--- a/pkg/vxlan/vxlanMgr.go
+++ b/pkg/vxlan/vxlanMgr.go
@@ -114,9 +114,10 @@ func (vxm *VxlanMgr) ProcessNodeUpdate(obj interface{}) {
 	for _, node := range nodes {
 		// Ignore the Nodes with status NotReady
 		var notExecutable bool
-		for _, t := range node.Spec.Taints {
-			if v1.TaintEffectNoExecute == t.Effect {
+		for _, nodeCondition := range node.Status.Conditions {
+			if nodeCondition.Type == v1.NodeReady && nodeCondition.Status != v1.ConditionTrue {
 				notExecutable = true
+				break
 			}
 		}
 		if notExecutable == true {


### PR DESCRIPTION
**Description**:  Fix logic for node not ready check
**Changes Proposed in PR**: Previously we are looking for  "NoExecute" taint added by kubernetes node controller in node not ready check to determine "NotReady" nodes. But this taint could be added in other scenarios in different distributions and is not reliable to check nodeready check. This is changed to look for nodecondition in node status with ready check not true to determine "NotReady" nodes.

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed

