### PR TITLE
Added support for readiness based auto monitoring

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -9,16 +9,21 @@ Added Functionality
 **What's new:**
     * Multi Cluster
     * Next Generation Routes
-        * Improvements in pod liveness probe based health monitor and autoMonitor support for NextGenRoutes. See `Example <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/next-gen-routes/configmap>`_
+        * Moved from pod liveness probe based health monitor to readiness probe based health monitor for autoMonitor
     * CRD
        * `Issue 3062<https://github.com/F5Networks/k8s-bigip-ctlr/issues/3062>`_: Support ConnectionMirroring in virtualserver and Transportserver CR
     * Support for AS3 GTM agent with separate GTM server
+
 Bug Fixes
 ````````````
 * ``Issue 3057 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3057>`_: Support for pool settings for reslect with policy CR.
 * `https://github.com/F5Networks/k8s-bigip-ctlr/issues/3061`_: Provide stable pool name in multi cluster mode
 * `Issue 3079<https://github.com/F5Networks/k8s-bigip-ctlr/issues/3079>`_: Fix logic for node not ready check
 * `Issue 3073<https://github.com/F5Networks/k8s-bigip-ctlr/issues/3073>`_: Fix AS3 config map multi port service issue
+
+Upgrade notes
+``````````````
+* Disabled default health monitoring with routes, use autoMonitor support for NextGenRoutes. See `Example <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/next-gen-routes/configmap/extendedRouteConfigwithBaseConfigWithAutoMonitor.yaml>`_
 
 Known Issues
 `````````````

--- a/docs/config_examples/next-gen-routes/configmap/extendedRouteConfigwithBaseConfigWithAutoMonitor.yaml
+++ b/docs/config_examples/next-gen-routes/configmap/extendedRouteConfigwithBaseConfigWithAutoMonitor.yaml
@@ -1,9 +1,9 @@
 # autoMonitor is used to configure whether CIS should automatically create health monitor the pool or not.
 # It's specified in baseRouteSpec which applies to all RouteGroups and used only when custom health monitors annotations
 # are not specified.
-# supported values are "none", "liveness-probe" (default) and "service-endpoint"
+# supported values are "none"(default), "readiness-probe" and "service-endpoint"
 # autoMonitor: none - CIS will not create health monitor for the pool
-# autoMonitor: liveness-probe - CIS will create health monitor for the pool based on the pod liveness probe configuration
+# autoMonitor: readiness-probe - CIS will create health monitor for the pool based on the pod readiness probe configuration
 # autoMonitor: service-endpoint - CIS will create a tcp health monitor for the pool
 apiVersion: v1
 kind: ConfigMap

--- a/docs/config_examples/next-gen-routes/deployment/deployment-pod-with-readinessprobe.yaml
+++ b/docs/config_examples/next-gen-routes/deployment/deployment-pod-with-readinessprobe.yaml
@@ -37,6 +37,15 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             timeoutSeconds: 10
+          readinessProbe:
+            failureThreshold: 3
+            httpGet:
+              path: /
+              port: 80
+              scheme: HTTP
+            periodSeconds: 10
+            successThreshold: 1
+            timeoutSeconds: 10
           name: svc-pytest-foo-1-com
           ports:
             - containerPort: 80

--- a/docs/upgradeProcess.md
+++ b/docs/upgradeProcess.md
@@ -339,3 +339,6 @@ Refer Release Notes for [CIS v2.13.1](https://github.com/F5Networks/k8s-bigip-ct
   |-------------|-------------|-------------|
   | *.foo.com   | *.foo.com   | yes         | 
   | *.foo.com   | abc.foo.com | not matched | 
+
+### **Upgrading from 2.14.0 to 2.15.0:**
+* Disabled default health monitoring with routes, use autoMonitor support for NextGenRoutes. See `Example <https://github.com/F5Networks/k8s-bigip-ctlr/tree/master/docs/config_examples/next-gen-routes/configmap/extendedRouteConfigwithBaseConfigWithAutoMonitor.yaml>`_

--- a/pkg/controller/nativeResourceWorker_test.go
+++ b/pkg/controller/nativeResourceWorker_test.go
@@ -1775,7 +1775,7 @@ extendedRouteSpec:
 
 		It("Verify autoMonitor Options", func() {
 			mockCtlr.Partition = "test"
-			// Verify autoMonitor defaults to liveness-probe when invalid value is provided
+			// Verify autoMonitor defaults to readiness-probe when invalid value is provided
 			data["extendedSpec"] = `
 baseRouteSpec: 
     autoMonitor: invalid-automonitor
@@ -1788,7 +1788,7 @@ extendedRouteSpec:
 			err, ok := mockCtlr.processConfigMap(cm, false)
 			Expect(err).To(BeNil())
 			Expect(ok).To(BeTrue())
-			Expect(mockCtlr.resources.baseRouteConfig.AutoMonitor).To(Equal(LivenessProbe))
+			Expect(mockCtlr.resources.baseRouteConfig.AutoMonitor).To(Equal(None))
 
 			// Verify autoMonitor is set to service-endpoint
 			data["extendedSpec"] = `

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -1299,7 +1299,7 @@ const (
 	StandBy         HAModeType      = "active-standby"
 	Ratio           HAModeType      = "ratio"
 	None            AutoMonitorType = "none"
-	LivenessProbe   AutoMonitorType = "liveness-probe"
+	ReadinessProbe  AutoMonitorType = "readiness-probe"
 	ServiceEndpoint AutoMonitorType = "service-endpoint"
 )
 


### PR DESCRIPTION
**Description**:  Add support for readiness based auto monitoring

**Changes Proposed in PR**:  Moved from pod liveness probe based health monitor to readiness probe based health monitor for autoMonitor. Added support for TCP probe with readiness.

**Fixes**: resolves #3089 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed
