### PR TITLE
customise console logger with micrsoseconds in the timestamp

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -175,7 +175,7 @@ func initLogger(logLevel, logFile string) error {
 	if len(logFile) > 0 {
 		logger = log.NewFileLogger(logFile)
 	} else {
-		logger = log.NewConsoleLogger()
+		logger = log.NewConsoleLoggerExt("", log.Ldate|log.Ltime|log.Lmicroseconds)
 	}
 	log.RegisterLogger(
 		log.LL_MIN_LEVEL, log.LL_MAX_LEVEL, logger)

--- a/pkg/vlogger/logger.go
+++ b/pkg/vlogger/logger.go
@@ -26,6 +26,17 @@ import (
 	"os"
 )
 
+const (
+	Ldate         = 1 << iota     // the date in the local time zone: 2009/01/23
+	Ltime                         // the time in the local time zone: 01:23:23
+	Lmicroseconds                 // microsecond resolution: 01:23:23.123123.  assumes Ltime.
+	Llongfile                     // full file name and line number: /a/b/c/d.go:23
+	Lshortfile                    // final file name element and line number: d.go:23. overrides Llongfile
+	LUTC                          // if Ldate or Ltime is set, use UTC rather than the local time zone
+	Lmsgprefix                    // move the "prefix" from the beginning of the line to before the message
+	LstdFlags     = Ldate | Ltime // initial values for the standard logger
+)
+
 type (
 	consoleLogger struct {
 		// slLogLevel uses syslog's definitions which have higher priority


### PR DESCRIPTION
**Description**:  Show logs with microseconds in the timestamp. Golang is not supporting milliseconds.

**Changes Proposed in PR**: Customised the console logger with flags

## General Checklist
- [ ] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation
- [ ] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema