### PR TITLE
Multi host support for VS CRD

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -28,6 +28,7 @@ type VirtualServerStatus struct {
 // VirtualServerSpec is the spec of the VirtualServer resource.
 type VirtualServerSpec struct {
 	Host                             string           `json:"host,omitempty"`
+	HostAliases                      []string         `json:"hostAliases,omitempty"`
 	HostGroup                        string           `json:"hostGroup,omitempty"`
 	HostGroupVirtualServerName       string           `json:"hostGroupVirtualServerName,omitempty"`
 	VirtualServerAddress             string           `json:"virtualServerAddress,omitempty"`

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -14,6 +14,7 @@ Added Functionality
       * Support for setting sslProfile with https monitor in virtualServer and nextgen routes.
       * `Issue 3225 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3225>`_:Support for Host Persistence to configure Persist session in VS Policy Rule action based on host in VirtualServer.
       * `Issue 3263 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3263>`_: Support for Host group virtual server name in virtual server to customise the virtual server name when Host Group exists.
+      * `Issue 3262 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3262>`_: Support for Host Aliases to allow defining multiple hosts in VS CRD. `Example <https://github.com/F5Networks/k8s-bigip-ctlr/blob/2.x-master/docs/config_examples/customResource/VirtualServer>`_
     * Support for pool-member-type auto for CRD, NextGen Routes and multiCluster mode
 
 Bug Fixes

--- a/docs/config_examples/customResource/VirtualServer/virtual-with-hostAliases/README.md
+++ b/docs/config_examples/customResource/VirtualServer/virtual-with-hostAliases/README.md
@@ -1,0 +1,47 @@
+# Virtual Server with Host Aliases
+
+This section demonstrates the option to configure virtual server using Host Aliases. 
+HostAliases is used to specify additional host names for a virtual server apart from the primary host.
+This is useful when you want to use a single virtual server to serve multiple domains and forward traffic 
+to the same pools.
+
+## tls-with-multiple-hosts.yaml
+By deploying this yaml file in your cluster, CIS will create a TLSProfile with multiple domain name.
+
+## virtual-with-hostAliases.yaml
+
+By deploying this yaml file in your cluster, CIS will create a Virtual Server on BIG-IP with multiple hosts or host aliases.
+
+## Recommendations
+- Provide the same host names in TLSProfile as provided in the Virtual Server CR.
+
+## Example showing the Virtual Server CR with Host Aliases and Primary Host
+```
+apiVersion: cis.f5.com/v1
+kind: VirtualServer
+metadata:
+  labels:
+    f5cr: "true"
+  name: cr-vs-foo-svc-1
+  namespace: default
+spec:
+  allowVlans: []
+  host: foo.com  <--------------- Primary Host
+  hostAliases: <----------------- Host Aliases
+    - dr.foo.com
+  httpTraffic: none
+  iRules: []
+  pools:
+    - monitor:
+        interval: 20
+        recv: ""
+        send: /
+        timeout: 10
+        type: http
+      path: /foo
+      service: svc-1
+      servicePort: 80
+  snat: auto
+  tlsProfileName: cr-tls-foo-svc-1
+  virtualServerAddress: 10.8.0.252
+```

--- a/docs/config_examples/customResource/VirtualServer/virtual-with-hostAliases/tls-with-multiple-hosts.yaml
+++ b/docs/config_examples/customResource/VirtualServer/virtual-with-hostAliases/tls-with-multiple-hosts.yaml
@@ -1,0 +1,15 @@
+apiVersion: cis.f5.com/v1
+kind: TLSProfile
+metadata:
+  labels:
+    f5cr: "true"
+  name: cr-tls-foo-svc-1
+  namespace: default
+spec:
+  hosts:
+    - foo.com
+    - dr.foo.com
+  tls:
+    clientSSL: foo-secret
+    reference: secret
+    termination: edge

--- a/docs/config_examples/customResource/VirtualServer/virtual-with-hostAliases/virtual-with-hostAliases.yaml
+++ b/docs/config_examples/customResource/VirtualServer/virtual-with-hostAliases/virtual-with-hostAliases.yaml
@@ -1,0 +1,27 @@
+apiVersion: cis.f5.com/v1
+kind: VirtualServer
+metadata:
+  labels:
+    f5cr: "true"
+  name: cr-vs-foo-svc-1
+  namespace: default
+spec:
+  allowVlans: []
+  host: foo.com
+  hostAliases:
+    - dr.foo.com
+  httpTraffic: none
+  iRules: []
+  pools:
+    - monitor:
+        interval: 20
+        recv: ""
+        send: /
+        timeout: 10
+        type: http
+      path: /foo
+      service: svc-1
+      servicePort: 80
+  snat: auto
+  tlsProfileName: cr-tls-foo-svc-1
+  virtualServerAddress: 10.8.0.252

--- a/docs/config_examples/customResourceDefinitions/incubator/customresourcedefinitions.yml
+++ b/docs/config_examples/customResourceDefinitions/incubator/customresourcedefinitions.yml
@@ -29,6 +29,11 @@ spec:
                 host:
                   type: string
                   pattern: '^(([a-zA-Z0-9\*]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$'
+                hostAliases:
+                  type: array
+                  items:
+                    type: string
+                    pattern: '^(([a-zA-Z0-9\*]|[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z0-9]|[A-Za-z0-9][A-Za-z0-9\-]*[A-Za-z0-9])$'
                 hostGroup:
                   type: string
                   pattern: '^[a-zA-Z]+[-A-z0-9_.:]*[A-z0-9]*$'

--- a/pkg/controller/informers.go
+++ b/pkg/controller/informers.go
@@ -785,6 +785,7 @@ func (ctlr *Controller) enqueueUpdatedVirtualServer(oldObj, newObj interface{}) 
 		oldVS.Spec.VirtualServerHTTPSPort != newVS.Spec.VirtualServerHTTPSPort ||
 		oldVS.Spec.VirtualServerName != newVS.Spec.VirtualServerName ||
 		oldVS.Spec.Host != newVS.Spec.Host ||
+		!reflect.DeepEqual(oldVS.Spec.HostAliases, newVS.Spec.HostAliases) ||
 		oldVS.Spec.IPAMLabel != newVS.Spec.IPAMLabel ||
 		oldVS.Spec.HostGroup != newVS.Spec.HostGroup ||
 		oldVSPartition != newVSPartition {


### PR DESCRIPTION
**Description**:  Multi host support for VS CRD
**Changes Proposed in PR**: Added hostAliases field where users can specify multiple host aliases for a Virtual Server CR.

**Fixes**: resolves #3262

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema