### PR TITLE
Fix hostname check for the certificates using canonical name

### DIFF
--- a/pkg/controller/nativeResourceWorker.go
+++ b/pkg/controller/nativeResourceWorker.go
@@ -1723,7 +1723,7 @@ func (ctlr *Controller) checkValidRoute(route *routeapi.Route, plcSSLProfiles rg
 		ok := checkCertificateHost(route.Spec.Host, Route, routeKey, []byte(route.Spec.TLS.Certificate), []byte(route.Spec.TLS.Key))
 		if !ok {
 			//Invalid certificate and key
-			message := fmt.Sprintf("Invalid certificate and key for route: %v", route.ObjectMeta.Name)
+			message := fmt.Sprintf("Invalid certificate or key for %v in route: %v", route.Spec.Host, route.ObjectMeta.Name)
 			go ctlr.updateRouteAdmitStatus(routeKey, "ExtendedValidationFailed", message, v1.ConditionFalse)
 			return false
 		}

--- a/pkg/controller/worker_test.go
+++ b/pkg/controller/worker_test.go
@@ -3491,8 +3491,15 @@ extendedRouteSpec:
 				route1.Spec.Host = "test.com"
 				delete(route1.Annotations, resource.F5ClientSslProfileAnnotation)
 
-				checkCertificateHost(route1.Spec.Host, Route, fmt.Sprintf("%s/%s", route1.Namespace, route1.Name), []byte(route1.Spec.TLS.Certificate), []byte(route1.Spec.TLS.Key))
+				ok := checkCertificateHost(route1.Spec.Host, Route, fmt.Sprintf("%s/%s", route1.Namespace, route1.Name), []byte(route1.Spec.TLS.Certificate), []byte(route1.Spec.TLS.Key))
+				Expect(ok).To(BeTrue(), "Certificate host check failed")
 
+				Expect(verifyCertificateCommonName("foo.com", "foo.com")).To(BeTrue(), "Certificate common name check failed")
+				Expect(verifyCertificateCommonName("foo.com", "*.foo.com")).To(BeFalse(), "Certificate common name check failed")
+				Expect(verifyCertificateCommonName("*.foo.com", "foo.com")).To(BeFalse(), "Certificate common name check failed")
+				Expect(verifyCertificateCommonName("foo.com", "bar_foo.com")).To(BeFalse(), "Certificate common name check failed")
+				Expect(verifyCertificateCommonName("foo.com", "foo?.com")).To(BeFalse(), "Certificate common name check failed")
+				Expect(verifyCertificateCommonName("foo", "foo")).To(BeTrue(), "Certificate common name check failed")
 				mockCtlr.addRoute(route1)
 				mockCtlr.resources.invertedNamespaceLabelMap[routeGroup] = routeGroup
 				mockCtlr.processResources()
@@ -3581,7 +3588,7 @@ extendedRouteSpec:
 				mockCtlr.enqueueDeletedNamespace(ns)
 				mockCtlr.processResources()
 
-				_, ok := mockCtlr.nsInformers[namespace]
+				_, ok = mockCtlr.nsInformers[namespace]
 				Expect(ok).To(Equal(false), "Namespace not deleted")
 
 				// mockCtlr.Agent.retryFailedTenant()


### PR DESCRIPTION
**Description**: Fix hostname check for the certificates using canonical name

**Fixes**: resolves #3268 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed
