### PR TITLE
Add support to avoid service pool creation for clusters under maintenance

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -9,6 +9,7 @@ Added Functionality
 **What's new:**
     * Multi Cluster
       * Streamline the naming convention for extended service references and multi cluster references annotations.
+      * `Issue 3284 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3284>`_: Add support to avoid service pool creation for clusters under maintenance
     * CRD
       * Support for mix of k8s Secret and bigip reference in TLSProfile.
       * Support for setting sslProfile with https monitor in virtualServer and nextgen routes.

--- a/docs/config_examples/multicluster/README.md
+++ b/docs/config_examples/multicluster/README.md
@@ -311,7 +311,7 @@ Following is the sample deployment for primary CIS deployment:
 | clusterName | String | Mandatory | Name of the cluster                                                       | -       | cluster1                |
 | secret      | String | Mandatory | Name of the secret created for kubeconfig (format: namespace/secret-name) | -       | test/secret-kubeconfig1 |
 | ratio       | int    | Optional  | Ratio at which the traffic has to be distributed over clusters            | 1       | 3                       |
-| adminState  | String | Optional  | adminState can be used to disable/enable/offline clusters           | 1       | 3                       |
+| adminState  | String | Optional  | adminState can be used to disable/enable/offline/no-pool clusters         | enable  | disable                 |
 
 
 **Note:** Avoid specifying HA cluster(Primary/Secondary cluster) configs in externalClustersConfig.
@@ -350,7 +350,7 @@ Specifies whether the CIS HA cluster is configured with active-active mode, acti
 | clusterName | String | Mandatory | Name of the cluster                                                       | -       | cluster1                |
 | secret      | String | Mandatory | Name of the secret created for kubeconfig (format: namespace/secret-name) | -       | test/secret-kubeconfig1 |
 | ratio       | int    | Optional  | Ratio at which the traffic has to be distributed over clusters            | 1       | 3                       |
-| adminState  | String | Optional  | adminState can be used to disable/enable/offline clusters           | 1       | 3                       |
+| adminState  | String | Optional  | adminState can be used to disable/enable/offline/no-pool clusters         | enable  | disable                 |
 
 
 **Note**: In order to run CIS in high availability mode, multi-cluster-mode parameter (primary/secondary) needs to be set in the CIS deployment arguments.
@@ -533,11 +533,13 @@ while computing the final ratio.<br>
 
 ### Cluster adminState to enable/disable/offline a cluster
 adminState can be provided for a cluster to dictate the state of a particular cluster.
-Supported values for adminState are [enable, disable, offline]<br>
+Supported values for adminState are [enable, disable, offline, no-pool]<br>
 By default clusters are in enabled state.<br>
 **adminState: enable**, all new connections are allowed to the pool members from the cluster.<br>
 **adminState: disable**, all new connections except those which match an existing persistence session are not allowed for the pool members from the cluster.<br>
 **adminState: offline**, no new connections are allowed to the pool members from the cluster, even if they match an existing persistence session.
+**adminState: no-pool**, in ratio mode, a service pool is not created for the affected cluster. For all other modes, pool members from the cluster are not added to the service pool. This configuration is helpful when we don't want to add pool or pool members from a particular cluster due to any reasons(for example cluster is under maintenance).<br>
+
 
 **Note**:
 * For HA mode [namely Active-Standby, Active-Active, Ratio], CIS monitored resource manifests(such as routes, CRDs, extendedConfigmaps) must be available in both the clusters.

--- a/docs/config_examples/multicluster/extendedConfigmap/global-spec-config-for-multicluster-with-cluster-admin-state.yaml
+++ b/docs/config_examples/multicluster/extendedConfigmap/global-spec-config-for-multicluster-with-cluster-admin-state.yaml
@@ -4,6 +4,8 @@
 # adminState: enable, all new connections are allowed to the pool members from the cluster.
 # adminState: disable, all new connections except those which match an existing persistence session are not allowed for the pool members from the cluster.
 # adminState: offline, no new connections are allowed to the pool members from the cluster, even if they match an existing persistence session.
+# adminState: in ratio mode, a service pool is not created for the affected cluster. For all other modes, pool members from the cluster are not added to the service pool. This configuration is helpful when we don't want to add pool or pool members from a particular cluster due to any reasons(for example cluster is under maintenance).
+
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -33,7 +35,7 @@ data:
       secret: default/kubeconfig4
     - clusterName: cluster5
       secret: default/kubeconfig5
-      adminState: enable
+      adminState: no-pool
     extendedRouteSpec:
     - allowOverride: false
       namespace: foo

--- a/pkg/clustermanager/types.go
+++ b/pkg/clustermanager/types.go
@@ -10,6 +10,7 @@ const (
 	Disable AdminState = "disable"
 	Enable  AdminState = "enable"
 	Offline AdminState = "offline"
+	NoPool  AdminState = "no-pool"
 )
 
 type (

--- a/pkg/controller/nativeResourceWorker.go
+++ b/pkg/controller/nativeResourceWorker.go
@@ -587,8 +587,10 @@ func (ctlr *Controller) prepareResourceConfigFromRoute(
 		if rules == nil {
 			return fmt.Errorf("failed to create LTM Rules")
 		}
-		policyName := formatPolicyName(route.Spec.Host, route.Namespace, rsCfg.Virtual.Name)
-		rsCfg.AddRuleToPolicy(policyName, rsCfg.Virtual.Partition, rules)
+		if *rules != nil && len(*rules) > 0 {
+			policyName := formatPolicyName(route.Spec.Host, route.Namespace, rsCfg.Virtual.Name)
+			rsCfg.AddRuleToPolicy(policyName, rsCfg.Virtual.Partition, rules)
+		}
 	}
 	return nil
 }
@@ -2435,11 +2437,11 @@ func (ctlr *Controller) readAndUpdateClusterAdminState(cluster interface{}, loca
 		mcc := cluster.(ExternalClusterConfig)
 		if mcc.AdminState != "" {
 			if mcc.AdminState == clustermanager.Enable || mcc.AdminState == clustermanager.Disable ||
-				mcc.AdminState == clustermanager.Offline {
+				mcc.AdminState == clustermanager.Offline || mcc.AdminState == clustermanager.NoPool {
 				ctlr.clusterAdminState[mcc.ClusterName] = mcc.AdminState
 			} else {
 				log.Warningf("[MultiCluster] Invalid cluster adminState: %v specified for cluster: %v, supported "+
-					"values (enable, disable, offline). Defaulting to enable", mcc.AdminState, mcc.ClusterName)
+					"values (enable, disable, offline, no-pool). Defaulting to enable", mcc.AdminState, mcc.ClusterName)
 				ctlr.clusterAdminState[mcc.ClusterName] = clustermanager.Enable
 			}
 		} else {
@@ -2455,11 +2457,11 @@ func (ctlr *Controller) readAndUpdateClusterAdminState(cluster interface{}, loca
 		}
 		if clusterData.AdminState != "" {
 			if clusterData.AdminState == clustermanager.Enable || clusterData.AdminState == clustermanager.Disable ||
-				clusterData.AdminState == clustermanager.Offline {
+				clusterData.AdminState == clustermanager.Offline || clusterData.AdminState == clustermanager.NoPool {
 				ctlr.clusterAdminState[clusterNameKey] = clusterData.AdminState
 			} else {
 				log.Warningf("[MultiCluster] Invalid cluster adminState: %v specified for cluster: %v, supported "+
-					"values (enable, disable, offline). Defaulting to enable", clusterData.AdminState, clusterData.ClusterName)
+					"values (enable, disable, offline, no-pool). Defaulting to enable", clusterData.AdminState, clusterData.ClusterName)
 				ctlr.clusterAdminState[clusterNameKey] = clustermanager.Enable
 			}
 		} else {

--- a/pkg/controller/responseHandler.go
+++ b/pkg/controller/responseHandler.go
@@ -86,9 +86,11 @@ func (ctlr *Controller) responseHandler(respChan chan resourceStatusMeta) {
 								} else {
 									svcNamespace = virtual.Namespace
 								}
-								svc := ctlr.GetService(svcNamespace, pool.Service)
-								if svc != nil && svc.Spec.Type == v1.ServiceTypeLoadBalancer {
-									ctlr.setLBServiceIngressStatus(svc, virtual.Status.VSAddress)
+								if !ctlr.isAddingPoolRestricted(ctlr.multiClusterConfigs.LocalClusterName) {
+									svc := ctlr.GetService(svcNamespace, pool.Service)
+									if svc != nil && svc.Spec.Type == v1.ServiceTypeLoadBalancer {
+										ctlr.setLBServiceIngressStatus(svc, virtual.Status.VSAddress)
+									}
 								}
 							}
 						}
@@ -122,9 +124,11 @@ func (ctlr *Controller) responseHandler(respChan chan resourceStatusMeta) {
 							} else {
 								svcNamespace = virtual.Namespace
 							}
-							svc := ctlr.GetService(svcNamespace, virtual.Spec.Pool.Service)
-							if svc != nil && svc.Spec.Type == v1.ServiceTypeLoadBalancer {
-								ctlr.setLBServiceIngressStatus(svc, virtual.Status.VSAddress)
+							if !ctlr.isAddingPoolRestricted(ctlr.multiClusterConfigs.LocalClusterName) {
+								svc := ctlr.GetService(svcNamespace, virtual.Spec.Pool.Service)
+								if svc != nil && svc.Spec.Type == v1.ServiceTypeLoadBalancer {
+									ctlr.setLBServiceIngressStatus(svc, virtual.Status.VSAddress)
+								}
 							}
 						}
 					}

--- a/pkg/controller/worker_test.go
+++ b/pkg/controller/worker_test.go
@@ -3910,4 +3910,32 @@ extendedRouteSpec:
 
 		})
 	})
+
+	Describe("Verify helper functions", func() {
+		BeforeEach(func() {
+			mockCtlr = newMockController()
+		})
+		It("Verify isAddingPoolRestricted is correctly checking whether to add pool or not", func() {
+			// Don't skip pool addition in non-multiCluster mode
+			Expect(mockCtlr.isAddingPoolRestricted("")).To(BeFalse(),
+				"Always pool should be added in non-multiCluster mode")
+			Expect(mockCtlr.isAddingPoolRestricted("cluster1")).To(BeFalse(),
+				"Always pool should be added in non-multiCluster mode")
+			// Skip pool addition in multiCluster mode if adminState is set to no-pool for a cluster
+			mockCtlr.multiClusterMode = PrimaryCIS
+			mockCtlr.clusterAdminState = make(map[string]clustermanager.AdminState)
+			mockCtlr.clusterAdminState[""] = clustermanager.NoPool
+			Expect(mockCtlr.isAddingPoolRestricted("")).To(BeTrue(),
+				"Pool should be skipped in multiCluster mode if adminState is set to no-pool for a cluster")
+			Expect(mockCtlr.isAddingPoolRestricted("cluster1")).To(BeFalse(),
+				"Pool should be not skipped in multiCluster mode if adminState is set to no-pool for a cluster")
+			mockCtlr.clusterAdminState["cluster2"] = clustermanager.Offline
+			Expect(mockCtlr.isAddingPoolRestricted("cluster2")).To(BeFalse(),
+				"Pool should be not skipped in multiCluster mode if adminState is not set to no-pool for a cluster")
+			mockCtlr.clusterAdminState["cluster3"] = clustermanager.NoPool
+			Expect(mockCtlr.isAddingPoolRestricted("")).To(BeTrue(),
+				"Pool should be skipped in multiCluster mode if adminState is set to no-pool for a cluster")
+
+		})
+	})
 })


### PR DESCRIPTION
**Description**:  Add support to avoid service pool creation for clusters under maintenance

**Changes Proposed in PR**: Added support for no-pool as a value for adminState for clusters. If specified CIS doesn't add pool members from the affected cluster to the service pool.

**Fixes**: resolves #3284

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed
