### PR TITLE
add host group validations for vsAddress and ipamLabel

### DIFF
--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -1423,19 +1423,19 @@ func (ctlr *Controller) getAssociatedVirtualServers(
 
 		// skip the virtuals in other HostGroups
 		if vrt.Spec.HostGroup != currentVS.Spec.HostGroup {
-			if currentVS.Spec.VirtualServerAddress != "" && currentVS.Spec.VirtualServerAddress == vrt.Spec.VirtualServerAddress {
+			if currentVS.Spec.VirtualServerAddress != "" && vrt.Spec.VirtualServerAddress != "" && currentVS.Spec.VirtualServerAddress == vrt.Spec.VirtualServerAddress {
 				log.Errorf("Multiple Virtual Servers %v, %v are configured with same VirtualServerAddress: %v", currentVS.Name, vrt.Name, vrt.Spec.VirtualServerAddress)
 				return nil
 			}
 			continue
 		}
 
-		if vrt.Spec.HostGroup == currentVS.Spec.HostGroup {
-			if currentVS.Spec.VirtualServerAddress != vrt.Spec.VirtualServerAddress {
+		if vrt.Spec.HostGroup != "" && currentVS.Spec.HostGroup != "" && vrt.Spec.HostGroup == currentVS.Spec.HostGroup {
+			if currentVS.Spec.VirtualServerAddress != "" && vrt.Spec.VirtualServerAddress != "" && currentVS.Spec.VirtualServerAddress != vrt.Spec.VirtualServerAddress {
 				log.Errorf("Multiple Virtual Servers %v, %v are configured with different VirtualServerAddress: %v %v", currentVS.Name, vrt.Name, currentVS.Spec.VirtualServerAddress, vrt.Spec.VirtualServerAddress)
 				return nil
 			}
-			if currentVS.Spec.IPAMLabel != vrt.Spec.IPAMLabel {
+			if currentVS.Spec.IPAMLabel != "" && vrt.Spec.IPAMLabel != "" && currentVS.Spec.IPAMLabel != vrt.Spec.IPAMLabel {
 				log.Errorf("Multiple Virtual Servers %v, %v are configured with different IPAM Labels: %v %v", currentVS.Name, vrt.Name, currentVS.Spec.IPAMLabel, vrt.Spec.IPAMLabel)
 				return nil
 			}

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -1423,7 +1423,22 @@ func (ctlr *Controller) getAssociatedVirtualServers(
 
 		// skip the virtuals in other HostGroups
 		if vrt.Spec.HostGroup != currentVS.Spec.HostGroup {
+			if currentVS.Spec.VirtualServerAddress != "" && currentVS.Spec.VirtualServerAddress == vrt.Spec.VirtualServerAddress {
+				log.Errorf("Multiple Virtual Servers %v, %v are configured with same VirtualServerAddress: %v", currentVS.Name, vrt.Name, vrt.Spec.VirtualServerAddress)
+				return nil
+			}
 			continue
+		}
+
+		if vrt.Spec.HostGroup == currentVS.Spec.HostGroup {
+			if currentVS.Spec.VirtualServerAddress != vrt.Spec.VirtualServerAddress {
+				log.Errorf("Multiple Virtual Servers %v, %v are configured with different VirtualServerAddress: %v %v", currentVS.Name, vrt.Name, currentVS.Spec.VirtualServerAddress, vrt.Spec.VirtualServerAddress)
+				return nil
+			}
+			if currentVS.Spec.IPAMLabel != vrt.Spec.IPAMLabel {
+				log.Errorf("Multiple Virtual Servers %v, %v are configured with different IPAM Labels: %v %v", currentVS.Name, vrt.Name, currentVS.Spec.IPAMLabel, vrt.Spec.IPAMLabel)
+				return nil
+			}
 		}
 
 		if currentVS.Spec.HostGroup != "" && vrt.Spec.HostGroup == currentVS.Spec.HostGroup && vrt.Spec.HostGroupVirtualServerName != currentVS.Spec.HostGroupVirtualServerName {

--- a/pkg/controller/worker_test.go
+++ b/pkg/controller/worker_test.go
@@ -651,6 +651,7 @@ var _ = Describe("Worker Tests", func() {
 				vrt2.Spec.HostGroup = "test"
 				vrt3.Spec.HostGroup = "test"
 				vrt3.Spec.Host = "test3.com"
+				vrt4.Spec.VirtualServerAddress = ""
 
 				virts := mockCtlr.getAssociatedVirtualServers(vrt2,
 					[]*cisapiv1.VirtualServer{vrt2, vrt3, vrt4},
@@ -665,6 +666,7 @@ var _ = Describe("Worker Tests", func() {
 				vrt3.Spec.HostGroup = "test"
 				vrt3.Spec.Host = "test3.com"
 				vrt3.Spec.VirtualServerAddress = ""
+				vrt4.Spec.VirtualServerAddress = ""
 
 				virts := mockCtlr.getAssociatedVirtualServers(vrt2,
 					[]*cisapiv1.VirtualServer{vrt2, vrt3, vrt4},


### PR DESCRIPTION
**Description**:  Should throw an error when host group is configured with different vs address, ipamLabel and different host groups with same vs address

**Changes Proposed in PR**: Added extra validations in processAssociatedVirtualServers

## General Checklist
- [x] Smoke testing completed