### PR TITLE
Fix service pool update issue with A/B NextGenRoute

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -15,6 +15,8 @@ Added Functionality
 Bug Fixes
 ````````````
 * `Issue 3324 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3324>`_: Fix for Service LoadBalancer with targetPort set to name of containerPort creates emtpy BIG-IP Pool
+* `Issue 3326 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3326>`_: Multi-cluster: Services in blue-green deployments don´t get updated
+
 
 Upgrade notes
 ``````````````

--- a/pkg/controller/nativeResourceWorker.go
+++ b/pkg/controller/nativeResourceWorker.go
@@ -377,22 +377,9 @@ func (ctlr *Controller) getServicePort(
 		return fmt.Errorf("Informer not found for namespace: %v", route.Namespace), port
 	}
 	svcIndexer := nrInf.svcInformer.GetIndexer()
-	svcName := route.Spec.To.Name
-	if route.Spec.Port != nil {
-		strVal := route.Spec.Port.TargetPort.StrVal
-		if strVal == "" {
-			port = route.Spec.Port.TargetPort.IntVal
-		} else {
-			port, err = ctlr.getResourceServicePort(route.Namespace, svcName, svcIndexer, strVal, resource.ResourceTypeRoute)
-			if nil != err {
-				return fmt.Errorf("Error while processing port for route %s: %v", route.Name, err), port
-			}
-		}
-	} else {
-		port, err = ctlr.getResourceServicePort(route.Namespace, svcName, svcIndexer, "", resource.ResourceTypeRoute)
-		if nil != err {
-			return fmt.Errorf("Error while processing port for route %s: %v", route.Name, err), port
-		}
+	port, err = ctlr.getResourceServicePortForRoute(svcIndexer, route)
+	if nil != err {
+		return fmt.Errorf("Error while processing port for route %s: %v", route.Name, err), port
 	}
 	log.Debugf("Port %v found for route %s", port, route.Name)
 	return nil, port


### PR DESCRIPTION
**Description**:  Fix service pool update issue with A/B NextGenRoute

**Changes Proposed in PR**: 
The strategy used to get the service port number for A/B NextGenRoute is as follows:
Step 1: Try to fetch the port number from the base service in the local cluster
Step 2: If the base service is not found, try to fetch the port number from the base service in the HA peer cluster(in case of multi-cluster active-active)
Step 3: If the base service is not found in HA peer cluster, try to fetch the port number from the alternate backend services in the local cluster
Step 4: If the A/B services are not found in local cluster, try to fetch the port number from the alternate backend services in the HA peer cluster(in case of multi-cluster active-active)


**Fixes**: resolves #3326 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed