### PR TITLE
#3279 add disable partition check for cleanup

### DIFF
--- a/cmd/k8s-bigip-ctlr/main.go
+++ b/cmd/k8s-bigip-ctlr/main.go
@@ -1192,7 +1192,7 @@ func main() {
 	}
 	defer appMgr.AgentCIS.DeInit()
 
-	if *filterTenants {
+	if *filterTenants && !disableDefaultPartition {
 		appMgr.AgentCIS.Clean(resource.DEFAULT_PARTITION)
 	}
 	if *agent == cisAgent.AS3Agent && !(*disableTeems) {


### PR DESCRIPTION
**Description**:  k8s default partition is getting created when filter tenants and disable partition are true

**Changes Proposed in PR**: Added disable partition check when cleaning up default partition k8s

**Fixes**: resolves #3279

## General Checklist
- [x] Smoke testing completed
