### PR TITLE
#3406 fix defaultroutedomain on resources delete

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -8,7 +8,7 @@ Added Functionality
 ```````````````````
 **What's new:**
     * CRD
-        * `Issue 3337 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3378>`_: Support to control ciphers groups and ssl options in TLSProfile CRD
+        * `Issue 3378 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3378>`_: Support to control ciphers groups and ssl options in TLSProfile CRD
     * Improved performance for Hub Mode using the isTenantNameServiceNamespace label in the AS3 configmap, See `Example <https://github.com/F5Networks/k8s-bigip-ctlr/blob/2.x-master/docs/config_examples/configmap/user-defined-configmap/hubmode-configmap/hubmode-cmap.yaml>`_
     * Pod Graceful Shutdown support for AS3 ConfigMap using CIS deployment parameter *pod-graceful-shutdown*
 
@@ -17,6 +17,7 @@ Bug Fixes
 * `Issue 3395 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3395>`_: BIGIP controller 2.16.0 removes F5 configuration when removing Kubernetes resources in namespace.
 * `Issue 3424 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3424>`_: Static routes not added if a label not added to a namespace when --namespace-label used.
 * `Issue 3443 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3443>`_: Fix issue with IPAM IP allocation on resource recreation
+* `Issue 3406 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3406>`_: Upon deleting all the CRD resources, the default route domain of CIS-managed Partition resets to 0
 
 Upgrade notes
 ``````````````

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -644,7 +644,7 @@ func (agent *Agent) createAS3LTMConfigADC(config ResourceConfigRequest) as3ADC {
 	for tenant := range agent.cachedTenantDeclMap {
 		if _, ok := config.ltmConfig[tenant]; !ok && !agent.isGTMTenant(tenant) {
 			// Remove partition
-			adc[tenant] = getDeletedTenantDeclaration(agent.Partition, tenant, cisLabel)
+			adc[tenant] = getDeletedTenantDeclaration(agent.Partition, tenant, cisLabel, config)
 		}
 	}
 	for tenantName, partitionConfig := range config.ltmConfig {
@@ -656,7 +656,7 @@ func (agent *Agent) createAS3LTMConfigADC(config ResourceConfigRequest) as3ADC {
 		partitionConfig.PriorityMutex.RUnlock()
 		if len(partitionConfig.ResourceMap) == 0 {
 			// Remove partition
-			adc[tenantName] = getDeletedTenantDeclaration(agent.Partition, tenantName, cisLabel)
+			adc[tenantName] = getDeletedTenantDeclaration(agent.Partition, tenantName, cisLabel, config)
 			continue
 		}
 		// Create Shared as3Application object
@@ -689,7 +689,7 @@ func (agent *Agent) createAS3LTMConfigADC(config ResourceConfigRequest) as3ADC {
 	return adc
 }
 
-func getDeletedTenantDeclaration(defaultPartition, tenant, cisLabel string) as3Tenant {
+func getDeletedTenantDeclaration(defaultPartition, tenant, cisLabel string, config ResourceConfigRequest) as3Tenant {
 	if defaultPartition == tenant {
 		// Flush Partition contents
 		sharedApp := as3Application{}
@@ -698,6 +698,7 @@ func getDeletedTenantDeclaration(defaultPartition, tenant, cisLabel string) as3T
 		return as3Tenant{
 			"class":              "Tenant",
 			as3SharedApplication: sharedApp,
+			"defaultRouteDomain": config.defaultRouteDomain,
 			"label":              cisLabel,
 		}
 	}

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -644,7 +644,7 @@ func (agent *Agent) createAS3LTMConfigADC(config ResourceConfigRequest) as3ADC {
 	for tenant := range agent.cachedTenantDeclMap {
 		if _, ok := config.ltmConfig[tenant]; !ok && !agent.isGTMTenant(tenant) {
 			// Remove partition
-			adc[tenant] = getDeletedTenantDeclaration(agent.Partition, tenant, cisLabel, config)
+			adc[tenant] = getDeletedTenantDeclaration(agent.Partition, tenant, cisLabel, &config)
 		}
 	}
 	for tenantName, partitionConfig := range config.ltmConfig {
@@ -656,7 +656,7 @@ func (agent *Agent) createAS3LTMConfigADC(config ResourceConfigRequest) as3ADC {
 		partitionConfig.PriorityMutex.RUnlock()
 		if len(partitionConfig.ResourceMap) == 0 {
 			// Remove partition
-			adc[tenantName] = getDeletedTenantDeclaration(agent.Partition, tenantName, cisLabel, config)
+			adc[tenantName] = getDeletedTenantDeclaration(agent.Partition, tenantName, cisLabel, &config)
 			continue
 		}
 		// Create Shared as3Application object
@@ -689,7 +689,7 @@ func (agent *Agent) createAS3LTMConfigADC(config ResourceConfigRequest) as3ADC {
 	return adc
 }
 
-func getDeletedTenantDeclaration(defaultPartition, tenant, cisLabel string, config ResourceConfigRequest) as3Tenant {
+func getDeletedTenantDeclaration(defaultPartition, tenant, cisLabel string, config *ResourceConfigRequest) as3Tenant {
 	if defaultPartition == tenant {
 		// Flush Partition contents
 		sharedApp := as3Application{}

--- a/pkg/controller/backend_test.go
+++ b/pkg/controller/backend_test.go
@@ -481,9 +481,9 @@ var _ = Describe("Backend Tests", func() {
 				defaultRouteDomain: 1,
 			}
 			cisLabel := "test"
-			deletedPartition := getDeletedTenantDeclaration("test", "test", cisLabel, config)
+			deletedPartition := getDeletedTenantDeclaration("test", "test", cisLabel, &config)
 			Expect(deletedPartition[as3SharedApplication]).NotTo(BeNil())
-			deletedPartition = getDeletedTenantDeclaration("test", "default", cisLabel, config)
+			deletedPartition = getDeletedTenantDeclaration("test", "default", cisLabel, &config)
 			Expect(deletedPartition[as3SharedApplication]).To(BeNil())
 		})
 	})

--- a/pkg/controller/backend_test.go
+++ b/pkg/controller/backend_test.go
@@ -474,10 +474,16 @@ var _ = Describe("Backend Tests", func() {
 			Expect(val).NotTo(BeNil())
 		})
 		It("Test Deleted Partition", func() {
+			config := ResourceConfigRequest{
+				ltmConfig:          make(LTMConfig),
+				shareNodes:         true,
+				gtmConfig:          GTMConfig{},
+				defaultRouteDomain: 1,
+			}
 			cisLabel := "test"
-			deletedPartition := getDeletedTenantDeclaration("test", "test", cisLabel)
+			deletedPartition := getDeletedTenantDeclaration("test", "test", cisLabel, config)
 			Expect(deletedPartition[as3SharedApplication]).NotTo(BeNil())
-			deletedPartition = getDeletedTenantDeclaration("test", "default", cisLabel)
+			deletedPartition = getDeletedTenantDeclaration("test", "default", cisLabel, config)
 			Expect(deletedPartition[as3SharedApplication]).To(BeNil())
 		})
 	})


### PR DESCRIPTION
**Description**: After deleting all IngressLink CRs from the cluster, CIS would push bare AS3 declaration with no defaultRouteDomain parameter, resetting the Partition default RD to 0 and breaking subsequent Static Route push.

**Changes Proposed in PR**: set defaultRouteDomain on tenant delete.

**Fixes**: resolves #3406

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed
