### PR TITLE
Fix CIS removing config on VS deletion from different namespace

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -14,6 +14,7 @@ Added Functionality
 
 Bug Fixes
 ````````````
+* `Issue 3395 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3395>`_: BIGIP controller 2.16.0 removes F5 configuration when removing Kubernetes resources in namespace.
 
 Upgrade notes
 ``````````````

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -22,16 +22,17 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"fmt"
-	"github.com/F5Networks/k8s-bigip-ctlr/v2/pkg/clustermanager"
-	"github.com/F5Networks/k8s-bigip-ctlr/v2/pkg/resource"
-	"gopkg.in/yaml.v2"
-	listerscorev1 "k8s.io/client-go/listers/core/v1"
-	"k8s.io/client-go/tools/cache"
 	"os"
 	"reflect"
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/F5Networks/k8s-bigip-ctlr/v2/pkg/clustermanager"
+	"github.com/F5Networks/k8s-bigip-ctlr/v2/pkg/resource"
+	"gopkg.in/yaml.v2"
+	listerscorev1 "k8s.io/client-go/listers/core/v1"
+	"k8s.io/client-go/tools/cache"
 
 	"k8s.io/apimachinery/pkg/util/intstr"
 
@@ -1416,7 +1417,7 @@ func (ctlr *Controller) getAssociatedVirtualServers(
 
 	for _, vrt := range allVirtuals {
 		// skip the deleted virtual in the event of deletion
-		if isVSDeleted && vrt.Name == currentVS.Name {
+		if isVSDeleted && vrt.Name == currentVS.Name && vrt.ObjectMeta.Namespace == currentVS.ObjectMeta.Namespace {
 			continue
 		}
 


### PR DESCRIPTION
**Description**:  Fix CIS removing config on VS deletion from different namespace

**Changes Proposed in PR**: Fix CIS removing config on VS deletion from different namespace

**Fixes**: resolves #3395

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema