### PR TITLE
Fix for invalid iRule generation for HTTP/2 full proxy mode

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -12,6 +12,7 @@ Added Functionality
     * CRD
 Bug Fixes
 ````````````
+* `Issue 3401 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3401>`_: Fix for invalid iRule generation for HTTP/2 full proxy mode
 
 
 2.17.1

--- a/pkg/controller/routing.go
+++ b/pkg/controller/routing.go
@@ -962,6 +962,12 @@ func (ctlr *Controller) getTLSIRule(rsVSName string, partition string, allowSour
                 reject ; event disable all; return;
                 }
             set sslpath [lindex [split [SSL::payload]] 1]
+			# for http2 protocol we receive the sslpath as '*', hence replacing it with root path,
+			# however it will not handle the http2 path based routing for now.
+			# for http2 currently only host based routing is supported.
+			if { $sslpath equals "*" } { 
+				set sslpath "/"
+			}
 			set domainpath $sslpath
             set routepath ""
             set wc_routepath ""


### PR DESCRIPTION
**Description**:  For http2 protocol we receive the sslpath as '*', hence replacing it with root path, however it will not handle the http2 path based routing for now. Only HTTP/2 full proxy mode is supported.

**Fixes**: resolves #3401 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed