### PR TITLE
#3438 support FTP Profile for transport server

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -442,6 +442,7 @@ type ProfileSpec struct {
 	AnalyticsProfiles     AnalyticsProfiles `json:"analyticsProfiles,omitempty"`
 	ProfileWebSocket      string            `json:"profileWebSocket,omitempty"`
 	HTMLProfile           string            `json:"htmlProfile,omitempty"`
+	FTPProfile            string            `json:"ftpProfile,omitempty"`
 }
 
 type ProfileVSSpec struct {

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -10,8 +10,9 @@ Added Functionality
 **What's new:**
     * Multi Cluster
     * CRD
-        * `Issue 3471 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3471>`_ Support for loadBalancerClass for service type lb. See `Example <https://github.com/F5Networks/k8s-bigip-ctlr/blob/2.x-master/docs/config_examples/customResource/serviceTypeLB/>`_
-    * `Issue 3430 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3430>`_ Support for CIS deployment parameters "ipam-namespace" to configure the namespace for IPAM CR
+        * `Issue 3471 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3471>`_: Support for loadBalancerClass for service type lb. See `Example <https://github.com/F5Networks/k8s-bigip-ctlr/blob/2.x-master/docs/config_examples/customResource/serviceTypeLB/>`_
+        * `Issue 3430 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3430>`_: Support for CIS deployment parameters "ipam-namespace" to configure the namespace for IPAM CR
+        * `Issue 3438 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3438>`_: Support for FTP Profile in Policy CR. See `Example <https://github.com/F5Networks/k8s-bigip-ctlr/blob/2.x-master/docs/config_examples/customResource/Policy/policy-with-ftp-profile.yaml>`_
 Bug Fixes
 ````````````
 * `Issue 3401 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3401>`_: Fix for invalid iRule generation for HTTP/2 full proxy mode

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -11,8 +11,8 @@ Added Functionality
     * Multi Cluster
     * CRD
         * `Issue 3471 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3471>`_: Support for loadBalancerClass for service type lb. See `Example <https://github.com/F5Networks/k8s-bigip-ctlr/blob/2.x-master/docs/config_examples/customResource/serviceTypeLB/>`_
-        * `Issue 3430 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3430>`_: Support for CIS deployment parameters "ipam-namespace" to configure the namespace for IPAM CR
-        * `Issue 3438 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3438>`_: Support for FTP Profile in Policy CR. See `Example <https://github.com/F5Networks/k8s-bigip-ctlr/blob/2.x-master/docs/config_examples/customResource/Policy/policy-with-ftp-profile.yaml>`_
+        * `Issue 3438 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3438>`_: Support for FTP Profile in Policy CR. See `Example <config_examples/customResource/Policy/policy-with-ftp-profile.yaml>`_
+    * `Issue 3430 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3430>`_: Support for CIS deployment parameters "ipam-namespace" to configure the namespace for IPAM CR
 Bug Fixes
 ````````````
 * `Issue 3401 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3401>`_: Fix for invalid iRule generation for HTTP/2 full proxy mode

--- a/docs/config_examples/customResource/Policy/README.md
+++ b/docs/config_examples/customResource/Policy/README.md
@@ -82,7 +82,7 @@ Policy is used to apply existing BIG-IP profiles and policy with Routes, Virtual
 | analyticsProfiles     | Object         | Optional | N/A                                                               | Configures different analytics profiles on BIGIP virtual server.                                                                                                                                                                           |
 | profileWebSocket      | String         | Optional | N/A                                                               | Reference to existing BIG-IP websocket profile                                                                                                                                                                                             |
 | htmlProfile           | String         | Optional | NA                                                                | Pathname of existing BIG-IP HTML profile. VirtualServer CRD resource takes precedence over Policy CRD. Allowed values are existing BIG-IP HTML profiles.                                                                                   |
- 
+| ftpProfile      | String         | Optional | N/A                                                               | Reference to existing BIG-IP FTP profile and is supported only for Transport Server                                                                                                                                                                                             |
 
 **Note**:
 * sslProfiles is only applicable to NextGen routes

--- a/docs/config_examples/customResource/Policy/policy-with-ftp-profile.yaml
+++ b/docs/config_examples/customResource/Policy/policy-with-ftp-profile.yaml
@@ -1,0 +1,14 @@
+# FTP Profile is supported only for Transport Server
+apiVersion: cis.f5.com/v1
+kind: Policy
+metadata:
+  labels:
+    f5cr: "true"
+  name: cr-policy1
+  namespace: test
+spec:
+  iRules: {}
+  l3Policies: {}
+  l7Policies: {}
+  profiles:
+    ftpProfile: /Common/ftpProfile

--- a/docs/config_examples/customResourceDefinitions/incubator/customresourcedefinitions.yml
+++ b/docs/config_examples/customResourceDefinitions/incubator/customresourcedefinitions.yml
@@ -1231,6 +1231,9 @@ spec:
                     htmlProfile:
                       type: string
                       pattern: '^\/[a-zA-Z]+([A-z0-9-_+]+\/)+([-A-z0-9_.:]+\/?)*$'
+                    ftpProfile:
+                      type: string
+                      pattern: '^\/[a-zA-Z]+([A-z0-9-_+]+\/)+([-A-z0-9_.:]+\/?)*$'
                 autoLastHop:
                   type: string
                   enum: [ default, auto, disable ]

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -989,6 +989,11 @@ func createServiceDecl(cfg *ResourceConfig, sharedApp as3Application, tenant str
 		}
 	}
 
+	//set ftp profile for only TS
+	if cfg.Virtual.FTPProfile != "" {
+		log.Warningf("FTP Profile is not supported for Virtual Server")
+	}
+
 	if cfg.MetaData.Protocol == "https" {
 		if len(cfg.Virtual.HTTP2.Client) > 0 || len(cfg.Virtual.HTTP2.Server) > 0 {
 			if cfg.Virtual.HTTP2.Client == "" {
@@ -1702,6 +1707,12 @@ func createTransportServiceDecl(cfg *ResourceConfig, sharedApp as3Application, t
 			svc.Class = "Service_SCTP"
 		} else {
 			svc.Class = "Service_TCP"
+			//set ftp profile for only TCP
+			if cfg.Virtual.FTPProfile != "" {
+				svc.ProfileFTP = &as3ResourcePointer{
+					BigIP: cfg.Virtual.FTPProfile,
+				}
+			}
 		}
 	} else if cfg.Virtual.Mode == "performance" {
 		svc.Class = "Service_L4"

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -989,11 +989,6 @@ func createServiceDecl(cfg *ResourceConfig, sharedApp as3Application, tenant str
 		}
 	}
 
-	//set ftp profile for only TS
-	if cfg.Virtual.FTPProfile != "" {
-		log.Warningf("FTP Profile is not supported for Virtual Server")
-	}
-
 	if cfg.MetaData.Protocol == "https" {
 		if len(cfg.Virtual.HTTP2.Client) > 0 || len(cfg.Virtual.HTTP2.Server) > 0 {
 			if cfg.Virtual.HTTP2.Client == "" {

--- a/pkg/controller/backend_test.go
+++ b/pkg/controller/backend_test.go
@@ -57,7 +57,6 @@ var _ = Describe("Backend Tests", func() {
 			rsCfg.Virtual.Destination = "/test/172.13.14.5:8080"
 			rsCfg.Virtual.AllowVLANs = []string{"flannel_vxlan"}
 			rsCfg.Virtual.IpIntelligencePolicy = "/Common/ip-intelligence-policy"
-			rsCfg.Virtual.FTPProfile = "/Common/ftpProfile1"
 			rsCfg.Virtual.Policies = []nameRef{
 				{
 					Name:      "policy1",
@@ -254,7 +253,6 @@ var _ = Describe("Backend Tests", func() {
 			Expect(string(decl)).ToNot(Equal(""), "Failed to Create AS3 Declaration")
 			Expect(strings.Contains(string(decl), "pool1")).To(BeTrue())
 			Expect(strings.Contains(string(decl), "default_pool_svc2")).To(BeTrue())
-			Expect(strings.Contains(string(decl), "profileFTP")).To(BeFalse())
 		})
 		It("TransportServer Declaration", func() {
 			rsCfg := &ResourceConfig{}

--- a/pkg/controller/backend_test.go
+++ b/pkg/controller/backend_test.go
@@ -57,6 +57,7 @@ var _ = Describe("Backend Tests", func() {
 			rsCfg.Virtual.Destination = "/test/172.13.14.5:8080"
 			rsCfg.Virtual.AllowVLANs = []string{"flannel_vxlan"}
 			rsCfg.Virtual.IpIntelligencePolicy = "/Common/ip-intelligence-policy"
+			rsCfg.Virtual.FTPProfile = "/Common/ftpProfile1"
 			rsCfg.Virtual.Policies = []nameRef{
 				{
 					Name:      "policy1",
@@ -253,6 +254,7 @@ var _ = Describe("Backend Tests", func() {
 			Expect(string(decl)).ToNot(Equal(""), "Failed to Create AS3 Declaration")
 			Expect(strings.Contains(string(decl), "pool1")).To(BeTrue())
 			Expect(strings.Contains(string(decl), "default_pool_svc2")).To(BeTrue())
+			Expect(strings.Contains(string(decl), "profileFTP")).To(BeFalse())
 		})
 		It("TransportServer Declaration", func() {
 			rsCfg := &ResourceConfig{}
@@ -261,6 +263,7 @@ var _ = Describe("Backend Tests", func() {
 			rsCfg.Virtual.Name = "crd_vs_172.13.14.16"
 			rsCfg.Virtual.Mode = "standard"
 			rsCfg.Virtual.IpProtocol = "tcp"
+			rsCfg.Virtual.FTPProfile = "/Common/ftpProfile1"
 			rsCfg.Virtual.TranslateServerAddress = true
 			rsCfg.Virtual.TranslateServerPort = true
 			rsCfg.Virtual.AllowVLANs = []string{"flannel_vxlan"}
@@ -290,6 +293,7 @@ var _ = Describe("Backend Tests", func() {
 			Expect(string(decl)).ToNot(Equal(""), "Failed to Create AS3 Declaration")
 			Expect(strings.Contains(string(decl), "adminState")).To(BeTrue())
 			Expect(strings.Contains(string(decl), "connectionLimit")).To(BeTrue())
+			Expect(strings.Contains(string(decl), "profileFTP")).To(BeTrue())
 
 		})
 		It("Delete partition", func() {

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -2475,6 +2475,9 @@ func (ctlr *Controller) handleVSResourceConfigForPolicy(
 	rsCfg.Virtual.AllowVLANs = plc.Spec.L3Policies.AllowVlans
 	rsCfg.Virtual.IpIntelligencePolicy = plc.Spec.L3Policies.IpIntelligencePolicy
 	rsCfg.Virtual.AutoLastHop = plc.Spec.AutoLastHop
+	if plc.Spec.Profiles.FTPProfile != "" {
+		log.Warningf("FTP Profile is not supported for Virtual Server")
+	}
 	if plc.Spec.L7Policies.ProfileAccess != "" {
 		rsCfg.Virtual.ProfileAccess = plc.Spec.L7Policies.ProfileAccess
 		if plc.Spec.L7Policies.PolicyPerRequestAccess != "" {
@@ -2550,6 +2553,7 @@ func (ctlr *Controller) handleTSResourceConfigForPolicy(
 	rsCfg.Virtual.ProfileL4 = plc.Spec.Profiles.ProfileL4
 	rsCfg.Virtual.ProfileDOS = plc.Spec.L3Policies.DOS
 	rsCfg.Virtual.ProfileBotDefense = plc.Spec.L3Policies.BotDefense
+	rsCfg.Virtual.FTPProfile = plc.Spec.Profiles.FTPProfile
 	rsCfg.Virtual.TCP.Client = plc.Spec.Profiles.TCP.Client
 	rsCfg.Virtual.TCP.Server = plc.Spec.Profiles.TCP.Server
 	rsCfg.Virtual.AllowVLANs = plc.Spec.L3Policies.AllowVlans

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -251,6 +251,7 @@ type (
 		HTMLProfile                string                `json:"htmlProfile,omitempty"`
 		ProfileAccess              string                `json:"profileAccess,omitempty"`
 		PolicyPerRequestAccess     string                `json:"policyPerRequestAccess,omitempty"`
+		FTPProfile                 string                `json:"ftpProfile,omitempty"`
 	}
 	MultiPoolPersistence struct {
 		Method  string `json:"method,omitempty"`
@@ -1065,6 +1066,7 @@ type (
 		ProfileHTML            as3MultiTypeParam    `json:"profileHTML,omitempty"`
 		ProfileAccess          as3MultiTypeParam    `json:"profileAccess,omitempty"`
 		PolicyPerRequestAccess as3MultiTypeParam    `json:"policyPerRequestAccess,omitempty"`
+		ProfileFTP             as3MultiTypeParam    `json:"profileFTP,omitempty"`
 	}
 
 	// as3ServiceAddress maps to VirtualAddress in AS3 Resources

--- a/pkg/controller/worker_test.go
+++ b/pkg/controller/worker_test.go
@@ -1877,7 +1877,7 @@ var _ = Describe("Worker Tests", func() {
 				Expect(len(mockCtlr.resources.ltmConfig[mockCtlr.Partition].ResourceMap[rsname].Virtual.IRules)).To(Equal(4), "irules not propely attached")
 				//check websocket profile
 				Expect(mockCtlr.resources.ltmConfig[mockCtlr.Partition].ResourceMap[rsname].Virtual.ProfileWebSocket).To(Equal("/Common/websocket"))
-				//check websocket profile
+				//check html profile
 				Expect(mockCtlr.resources.ltmConfig[mockCtlr.Partition].ResourceMap[rsname].Virtual.HTMLProfile).To(Equal("/Common/htmlProfile"))
 				for _, rule := range mockCtlr.resources.ltmConfig[mockCtlr.Partition].ResourceMap[rsname].Policies[0].Rules {
 					if rule.Name == "vs_test_com_foo_svc1_80_default_test_com" {


### PR DESCRIPTION
**Description**:  Add support for FTP profile in policy CR

**Changes Proposed in PR**: Added support for FTP Profile in Transport server 

**Fixes**: resolves #3438

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema