### PR TITLE
Fix empty pool issue when VS/TS created before service

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -26,6 +26,8 @@ Bug Fixes
 * `Issue 3432 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3432>`_: Show meaningful logs for exceptions occured from controller agent
 * `Issue 3396 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3396>`_: Fix adding pool members from external clusters in nodeportLocal mc mode
 * `Issue 3351 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3351>`_: improve message handling when getting HTTP/401 from AS3
+* Fix pool members not getting updated for VS/TS on re-deployment of application with different servicePort and targetPort.
+
 
 Upgrade notes
 ``````````````

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -547,8 +547,10 @@ func (ctlr *Controller) prepareRSConfigFromVirtualServer(
 				svcNamespace = SvcBackend.SvcNamespace
 			}
 			targetPort := ctlr.fetchTargetPort(svcNamespace, SvcBackend.Name, pl.ServicePort, SvcBackend.Cluster)
+			svcPortUsed := false // svcPortUsed is true only when the target port could not be fetched
 			if (intstr.IntOrString{}) == targetPort {
 				targetPort = pl.ServicePort
+				svcPortUsed = true
 			}
 			pool := Pool{
 				Name:              poolName,
@@ -556,6 +558,7 @@ func (ctlr *Controller) prepareRSConfigFromVirtualServer(
 				ServiceName:       SvcBackend.Name,
 				ServiceNamespace:  svcNamespace,
 				ServicePort:       targetPort,
+				ServicePortUsed:   svcPortUsed,
 				NodeMemberLabel:   pl.NodeMemberLabel,
 				Balance:           pl.Balance,
 				MinimumMonitors:   pl.MinimumMonitors,
@@ -2189,8 +2192,10 @@ func (ctlr *Controller) prepareRSConfigFromTransportServer(
 		svcNamespace = vs.Spec.Pool.ServiceNamespace
 	}
 	targetPort := ctlr.fetchTargetPort(svcNamespace, vs.Spec.Pool.Service, vs.Spec.Pool.ServicePort, "")
+	svcPortUsed := false // svcPortUsed is true only when the target port could not be fetched
 	if (intstr.IntOrString{}) == targetPort {
 		targetPort = vs.Spec.Pool.ServicePort
+		svcPortUsed = true
 	}
 	pool := Pool{
 		Name:              poolName,
@@ -2198,6 +2203,7 @@ func (ctlr *Controller) prepareRSConfigFromTransportServer(
 		ServiceName:       vs.Spec.Pool.Service,
 		ServiceNamespace:  svcNamespace,
 		ServicePort:       targetPort,
+		ServicePortUsed:   svcPortUsed,
 		NodeMemberLabel:   vs.Spec.Pool.NodeMemberLabel,
 		Balance:           vs.Spec.Pool.Balance,
 		ReselectTries:     vs.Spec.Pool.ReselectTries,

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -437,6 +437,7 @@ type (
 		ServiceName            string                                  `json:"-"`
 		ServiceNamespace       string                                  `json:"-"`
 		ServicePort            intstr.IntOrString                      `json:"-"`
+		ServicePortUsed        bool                                    `json:"-"`
 		Balance                string                                  `json:"loadBalancingMethod,omitempty"`
 		Members                []PoolMember                            `json:"members"`
 		NodeMemberLabel        string                                  `json:"-"`

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -2083,7 +2083,12 @@ func (ctlr *Controller) updatePoolMembersForService(svcKey MultiClusterServiceKe
 					freshRsCfg.copyConfig(rsCfg)
 					for index, pool := range freshRsCfg.Pools {
 						if pool.Name == poolId.poolName && pool.Partition == poolId.partition {
-							if pool.ServicePort.IntVal == 0 || svcPortUpdated {
+							// Reprocess the resources if:
+							// 1. service port has been updated or
+							// 2. ServicePort.IntVal is 0 or ServicePortUsed is true which happens when endpoints have not been created at the time of resource processing,
+							// cis needs to process the Resource again to make sure that servicePort in pool is updated with the target port,
+							// which handled the scenario where VS/TS is process first then service(with different servicePort and target port) and app are created.
+							if pool.ServicePort.IntVal == 0 || svcPortUpdated || pool.ServicePortUsed {
 								switch poolId.rsKey.kind {
 								case Route:
 									// this case happens when a route does not contain a target port and service is created after route creation


### PR DESCRIPTION
**Description**:  Fix empty pool issue when VS/TS created before service

**Changes Proposed in PR**: Fix empty pool issue when VS/TS created before service

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema