### PR TITLE
Added debugging flags to Go build process 2.x-master

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ dev-license: pre-build
 
 debug: pre-build
 	@echo "Building with debug support..."
-	docker build --build-arg RUN_TESTS=0 --build-arg BUILD_VERSION=$(BUILD_VERSION) --build-arg BUILD_INFO=$(BUILD_INFO) -t k8s-bigip-ctlr-dbg:latest -f build-tools/Dockerfile.debug .
+	docker build --build-arg RUN_TESTS=0 --build-arg BUILD_VERSION=$(BUILD_VERSION) --build-arg BUILD_INFO=$(BUILD_INFO) --platform linux/amd64 -t k8s-bigip-ctlr-dbg:latest -f build-tools/Dockerfile.debug .
 
 
 fmt:

--- a/build-tools/rel-build.sh
+++ b/build-tools/rel-build.sh
@@ -7,7 +7,7 @@ go mod download
 CGO_ENABLED=0
 GOOS=linux
 GOARCH=amd64
-go build -v -ldflags "-extldflags \"-static\" -X main.version=${BUILD_VERSION} -X main.buildInfo=${BUILD_INFO}" -o /bin/k8s-bigip-ctlr $REPOPATH/cmd/k8s-bigip-ctlr
+go build -gcflags="all=-N -l" -v -ldflags "-extldflags \"-static\" -X main.version=${BUILD_VERSION} -X main.buildInfo=${BUILD_INFO}" -o /bin/k8s-bigip-ctlr $REPOPATH/cmd/k8s-bigip-ctlr
 
 RUN_TESTS=${RUN_TESTS:-1}
 


### PR DESCRIPTION
…4851)

**Description**:  Added debugging flags to Go build process with -gcflags="all=-N -l (#4851)

**Changes Proposed in PR**:

**Fixes**: resolves #4851

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema