### PR TITLE
fix to disable default uid in F5 BIG-IP Controller Operator

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -48,6 +48,7 @@ Bug Fixes
 * `Issue 3396 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3396>`_: Fix adding pool members from external clusters in nodeportLocal mc mode
 * `Issue 3351 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3351>`_: improve message handling when getting HTTP/401 from AS3
 * Fix pool members not getting updated for VS/TS on re-deployment of application with different servicePort and targetPort.
+* `Issue 3508 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3508>`_: Fix to disable default uid in F5 BIG-IP Controller Operator
 
 
 Upgrade notes

--- a/f5-bigip-ctlr-operator/Dockerfile
+++ b/f5-bigip-ctlr-operator/Dockerfile
@@ -17,4 +17,6 @@ COPY f5-bigip-ctlr-operator/licenses /licenses
 
 COPY f5-bigip-ctlr-operator/watches.yaml ${HOME}/watches.yaml
 COPY helm-charts/f5-bigip-ctlr  ${HOME}/helm-charts/f5-bigip-ctlr
+COPY f5-bigip-ctlr-operator/watches.yaml ${HOME}/helm-charts/f5-bigip-ctlr/oscp-operator.txt
+
 WORKDIR ${HOME}

--- a/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
+++ b/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
@@ -45,21 +45,22 @@ spec:
 {{- end }}
       securityContext:
         {{- $securityContext := .Values.securityContext | default dict }}
+        {{- $oscpOperator := .Files.Glob "oscp-operator.txt"  }}
         {{- if $securityContext.runAsUser }}
         runAsUser: {{ $securityContext.runAsUser }}
-        {{- else }}
+        {{- else if (not $oscpOperator) }}
         runAsUser: 1000
         {{- end }}
         {{- $securityContext := .Values.securityContext | default dict }}
         {{- if $securityContext.runAsGroup }}
         runAsGroup: {{ $securityContext.runAsGroup }}
-        {{- else }}
+        {{- else if (not $oscpOperator) }}
         runAsGroup: 1000
         {{- end }}
         {{- $securityContext := .Values.securityContext | default dict }}
         {{- if $securityContext.fsGroup }}
         fsGroup: {{ $securityContext.fsGroup }}
-        {{- else }}
+        {{- else if (not $oscpOperator) }}
         fsGroup: 1000
         {{- end }}
       containers:


### PR DESCRIPTION
**Description**:  fix to disable default uid in F5 BIG-IP Controller Operator

**Changes Proposed in PR**: fix to disable default uid in F5 BIG-IP Controller Operator

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema