### PR TITLE
#3542 set adminstate to disable when pool weight is 0 for transport server

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -13,6 +13,7 @@ Bug Fixes
 ````````````
 * `Issue 3518 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3518>`_: CIS is reposting the declaration because of re-ordering of the pool-members
 * `Issue 3520 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3520>`_: [LOGS] improve log message Finished syncing virtual servers xxx in namespace yyy(199.218µs), 1/7
+* `Issue 3542 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3542>`_: Change of weight from primary to alternate backend is not graceful for Transport server
 * Remove pool members of GTM when host removed or updated on transport server, ingresslink, and, service type lb
 
 Upgrade notes

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -2309,14 +2309,15 @@ func (ctlr *Controller) updatePoolMemberWeights(svcMemMap map[MultiClusterServic
 				svcKey.namespace == pool.ServiceNamespace {
 				if pool.Weight > 0 {
 					ratio = int(float32(pool.Weight) / float32(len(plMem)))
-				} else {
-					continue
 				}
 				for idx, _ := range plMem {
-					plMem[idx].Ratio = ratio
+					if pool.Weight == 0 {
+						plMem[idx].AdminState = "disable"
+					} else {
+						plMem[idx].Ratio = ratio
+					}
 				}
 				poolMem = append(poolMem, plMem...)
-				continue
 			}
 
 			for _, svc := range pool.AlternateBackends {
@@ -2325,11 +2326,13 @@ func (ctlr *Controller) updatePoolMemberWeights(svcMemMap map[MultiClusterServic
 					svcKey.namespace == svc.ServiceNamespace {
 					if svc.Weight > 0 {
 						ratio = int(float32(svc.Weight) / float32(len(plMem)))
-					} else {
-						break
 					}
 					for idx, _ := range plMem {
-						plMem[idx].Ratio = ratio
+						if svc.Weight == 0 {
+							plMem[idx].AdminState = "disable"
+						} else {
+							plMem[idx].Ratio = ratio
+						}
 					}
 					poolMem = append(poolMem, plMem...)
 					break
@@ -2345,7 +2348,11 @@ func (ctlr *Controller) updatePoolMemberWeights(svcMemMap map[MultiClusterServic
 						ratio = int(float32(*mcSvc.Weight) / float32(len(plMem)))
 					}
 					for idx, _ := range plMem {
-						plMem[idx].Ratio = ratio
+						if ratio == 0 {
+							plMem[idx].AdminState = "disable"
+						} else {
+							plMem[idx].Ratio = ratio
+						}
 					}
 					poolMem = append(poolMem, plMem...)
 					break
@@ -2441,14 +2448,15 @@ func (ctlr *Controller) updatePoolMemberWeights(svcMemMap map[MultiClusterServic
 						cluster = ctlr.multiClusterConfigs.LocalClusterName
 					}
 					ratio = int((float64(pool.Weight) / float64(totalWeight*len(plMem))) * (float64(*ctlr.clusterRatio[cluster]) / totalClusterRatio) * 100)
-				} else {
-					continue
 				}
 				for idx, _ := range plMem {
-					plMem[idx].Ratio = ratio
+					if pool.Weight == 0 {
+						plMem[idx].AdminState = "disable"
+					} else {
+						plMem[idx].Ratio = ratio
+					}
 				}
 				poolMem = append(poolMem, plMem...)
-				continue
 			}
 
 			for _, svc := range pool.AlternateBackends {
@@ -2461,11 +2469,13 @@ func (ctlr *Controller) updatePoolMemberWeights(svcMemMap map[MultiClusterServic
 							cluster = ctlr.multiClusterConfigs.LocalClusterName
 						}
 						ratio = int((float64(svc.Weight) / float64(totalWeight*len(plMem))) * (float64(*ctlr.clusterRatio[cluster]) / totalClusterRatio) * 100)
-					} else {
-						break
 					}
 					for idx, _ := range plMem {
-						plMem[idx].Ratio = ratio
+						if svc.Weight == 0 {
+							plMem[idx].AdminState = "disable"
+						} else {
+							plMem[idx].Ratio = ratio
+						}
 					}
 					poolMem = append(poolMem, plMem...)
 					break
@@ -2481,7 +2491,11 @@ func (ctlr *Controller) updatePoolMemberWeights(svcMemMap map[MultiClusterServic
 						ratio = int((float64(*mcSvc.Weight) / float64(totalWeight*len(plMem))) * (float64(*ctlr.clusterRatio[svcKey.clusterName]) / totalClusterRatio) * 100)
 					}
 					for idx, _ := range plMem {
-						plMem[idx].Ratio = ratio
+						if ratio == 0 {
+							plMem[idx].AdminState = "disable"
+						} else {
+							plMem[idx].Ratio = ratio
+						}
 					}
 					poolMem = append(poolMem, plMem...)
 					break


### PR DESCRIPTION
**Description**: Change of weight from primary to alternate backend is not graceful for transport server

**Changes Proposed in PR**: Will set admin state to disable when pool weight is 0 for transport server

**Fixes**: resolves #3542

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed
