### PR TITLE
Rename extendedServiceReferences as multiClusterServices

### DIFF
--- a/config/apis/cis/v1/types.go
+++ b/config/apis/cis/v1/types.go
@@ -121,7 +121,7 @@ type VSPool struct {
 	HostRewrite          string                         `json:"hostRewrite,omitempty"`
 	Weight               *int32                         `json:"weight,omitempty"`
 	AlternateBackends    []AlternateBackend             `json:"alternateBackends"`
-	MultiClusterServices []MultiClusterServiceReference `json:"extendedServiceReferences,omitempty"`
+	MultiClusterServices []MultiClusterServiceReference `json:"multiClusterServices,omitempty"`
 }
 
 // TSPool defines a pool object for Transport Server in BIG-IP.
@@ -142,7 +142,7 @@ type TSPool struct {
 	HostRewrite          string                         `json:"hostRewrite,omitempty"`
 	Weight               *int32                         `json:"weight,omitempty"`
 	AlternateBackends    []AlternateBackend             `json:"alternateBackends,omitempty"`
-	MultiClusterServices []MultiClusterServiceReference `json:"extendedServiceReferences,omitempty"`
+	MultiClusterServices []MultiClusterServiceReference `json:"multiClusterServices,omitempty"`
 }
 
 // AlternateBackends lists backend svc of A/B

--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -8,7 +8,7 @@ Added Functionality
 ```````````````````
 **What's new:**
     * Multi Cluster
-        * Support to add HA services in extendedServiceReferences for Transport Servers. Yet to be supported with Virtual Server
+        * Support to add HA services in multiClusterServices for Transport Servers.
     * CRD
 
 Bug Fixes

--- a/docs/config_examples/customResource/TransportServer/ts-with-weight-alternate-backend/README.md
+++ b/docs/config_examples/customResource/TransportServer/ts-with-weight-alternate-backend/README.md
@@ -10,7 +10,7 @@ CIS supports a/b with the alternate backed. Weight can be specified for default 
       - service: svc-1-external-service
         serviceNamespace: default
         weight: 20
-    extendedServiceReferences:
+    multiClusterServices:
       - clusterName: cluster3
         namespace: default
         service: svc-1-external-service

--- a/docs/config_examples/customResource/TransportServer/ts-with-weight-alternate-backend/ts-with-weight-alternate-backend.yaml
+++ b/docs/config_examples/customResource/TransportServer/ts-with-weight-alternate-backend/ts-with-weight-alternate-backend.yaml
@@ -15,7 +15,7 @@ spec:
       - service: svc-1-external-service
         serviceNamespace: default
         weight: 20
-    extendedServiceReferences:
+    multiClusterServices:
       - clusterName: cluster3
         namespace: default
         service: svc-1-external-service

--- a/docs/config_examples/customResourceDefinitions/customresourcedefinitions.yml
+++ b/docs/config_examples/customResourceDefinitions/customresourcedefinitions.yml
@@ -370,7 +370,7 @@ spec:
                         maximum: 65535
                       serviceDownAction:
                         type: string
-                      extendedServiceReferences:
+                      multiClusterServices:
                         type: array
                         items:
                           type: object
@@ -766,7 +766,7 @@ spec:
                       maximum: 65535
                     serviceDownAction:
                       type: string
-                    extendedServiceReferences:
+                    multiClusterServices:
                       type: array
                       items:
                         type: object

--- a/docs/config_examples/customResourceDefinitions/incubator/customresourcedefinitions.yml
+++ b/docs/config_examples/customResourceDefinitions/incubator/customresourcedefinitions.yml
@@ -370,7 +370,7 @@ spec:
                         maximum: 65535
                       serviceDownAction:
                         type: string
-                      extendedServiceReferences:
+                      multiClusterServices:
                         type: array
                         items:
                           type: object
@@ -766,7 +766,7 @@ spec:
                       maximum: 65535
                     serviceDownAction:
                       type: string
-                    extendedServiceReferences:
+                    multiClusterServices:
                       type: array
                       items:
                         type: object

--- a/docs/config_examples/multicluster/README.md
+++ b/docs/config_examples/multicluster/README.md
@@ -35,7 +35,7 @@ Multi-Cluster Support in CIS allows users to expose multiple apps spread across 
 
 ### Standalone CIS
 
-In a Standalone deployment of CIS, CIS is only deployed in one cluster, then create a route resource with a Multi-Cluster annotation or CRD resource with extendedServiceReferences to expose the apps in different OpenShift/K8s clusters.
+In a Standalone deployment of CIS, CIS is only deployed in one cluster, then create a route resource with a Multi-Cluster annotation or CRD resource with multiClusterServices to expose the apps in different OpenShift/K8s clusters.
 
 ![architecture](images/standaloneMultiCluster.png)
 
@@ -433,7 +433,7 @@ Services running in any other OpenShift/Kubernetes clusters, apart from the HA c
     serviceNamespace: tea
     service: svc-2
     servicePort: 80
-    extendedServiceReferences:
+    multiClusterServices:
     - clusterName: cluster2
       namespace: ns1
       servicePort: 8080
@@ -450,7 +450,7 @@ Services running in any other OpenShift/Kubernetes clusters, apart from the HA c
   pool:
     service: svc-1
     servicePort: 8181
-    extendedServiceReferences:
+    multiClusterServices:
     - clusterName: cluster2
       service: svc-1
       namespace: ns1
@@ -663,14 +663,13 @@ Ok[root@cluster-1-worker0 ~]#
 where 10.244.1.213 is the CIS PodIP.
 
 
-### How extendedServiceReferences is different from multiClusterServices?
-extendedServiceReferences is applicable for Virtual Server CR or Transport Server CR and multiClusterServices is applicable for NextGen Routes.
-extendedServiceReferences is used to refer the services running in any other OpenShift/Kubernetes clusters, apart from the HA cluster pair, in the VS Pool or TS Pool.
+### How multiClusterServices is different from multiClusterServices?
+multiClusterServices is applicable for Virtual Server CR or Transport Server CR and multiClusterServices is applicable for NextGen Routes.
+multiClusterServices is used to refer the services running in any other OpenShift/Kubernetes clusters, apart from the HA cluster pair, in the VS Pool or TS Pool.
 multiClusterServices is used to refer the services running in any other OpenShift/Kubernetes clusters, apart from the HA cluster pair, in the Route annotation.
 
-### How multiClusterServices and extendedServiceReferences are similar?
-multiClusterServices and extendedServiceReferences are similar in terms of referring the services running in any other OpenShift/Kubernetes clusters, apart from the HA cluster pair.
-Both are applicable to refer services running in external Clusters, apart from the HA cluster pair
+### Which services can be provided as multiClusterServices?
+Any service running in any OpenShift/Kubernetes clusters which are part of the multiCluster setup can be provided as multiClusterServices.
 
 ### How to configure multiClusterServices in Route annotation?
 multiClusterServices is a Route annotation. Below is the sample Route annotation with multiClusterServices:
@@ -690,15 +689,15 @@ where clusterName is the name of the cluster where the service is running, names
 where cluster2 is the external cluster apart from the HA cluster pair.
 Note: External Clusters doesn't need to install CIS
 
-### How to configure extendedServiceReferences in Virtual Server CR or Transport Server CR?
-extendedServiceReferences is a field in Virtual Server CR or Transport Server CR. Below is the sample Virtual Server CR with extendedServiceReferences:
+### How to configure multiClusterServices in Virtual Server CR or Transport Server CR?
+multiClusterServices is a field in Virtual Server CR or Transport Server CR. Below is the sample Virtual Server CR with multiClusterServices:
 ```
   pools:
   - path: /tea
     serviceNamespace: tea
     service: svc-2
     servicePort: 80
-    extendedServiceReferences:
+    multiClusterServices:
     - clusterName: cluster3
       namespace: ns1
       servicePort: 8080
@@ -712,5 +711,5 @@ where clusterName is the name of the cluster where the service is running, names
 where cluster3 and cluster4 are the external clusters apart from the HA cluster pair.
 Note: External Clusters doesn't need to install CIS
 
-### Can I specify the services running in CIS HA cluster in extendedServiceReferences/multiClusterServices?
-No. ExtendedServiceReferences/multiClusterServices is only applicable to refer the services running in K8S/Openshift clusters which are not part of the HA cluster(Primary/Secondary Cluster).
+### Can I specify the services running in CIS HA cluster in multiClusterServices?
+Yes. multiClusterServices is applicable to refer the services running in K8S/Openshift clusters which are part of the HA cluster(Primary/Secondary Cluster) as well.

--- a/docs/config_examples/multicluster/customResource/transportServer/README.md
+++ b/docs/config_examples/multicluster/customResource/transportServer/README.md
@@ -10,7 +10,7 @@ This allows to distribute specific percentage of traffic to a specific service a
 `config`
 
 ```
-extendedServiceReferences:
+multiClusterServices:
   - clusterName: cluster3
     namespace: default
     service: svc-1-external-service

--- a/docs/config_examples/multicluster/customResource/transportServer/ts-with-extended-service-ha-svcs.yaml
+++ b/docs/config_examples/multicluster/customResource/transportServer/ts-with-extended-service-ha-svcs.yaml
@@ -11,7 +11,7 @@ spec:
     - /Common/test_rule2
   mode: standard
   pool:
-    extendedServiceReferences:
+    multiClusterServices:
     # CIS supports to refer svs from local cluster and ha cluster
       - clusterName: cluster1
         namespace: default

--- a/docs/config_examples/multicluster/customResource/transportServer/ts-with-external-services.yaml
+++ b/docs/config_examples/multicluster/customResource/transportServer/ts-with-external-services.yaml
@@ -17,7 +17,7 @@ spec:
       type: tcp
       interval: 10
       timeout: 10
-    extendedServiceReferences:
+    multiClusterServices:
     - clusterName: cluster2
       service: svc-1
       namespace: ns1

--- a/docs/config_examples/multicluster/customResource/transportServer/ts-with-weight-extended-service.yaml
+++ b/docs/config_examples/multicluster/customResource/transportServer/ts-with-weight-extended-service.yaml
@@ -15,7 +15,7 @@ spec:
       - service: svc-1-external-service
         serviceNamespace: default
         weight: 20
-    extendedServiceReferences:
+    multiClusterServices:
       - clusterName: cluster3
         namespace: default
         service: svc-1-external-service

--- a/docs/config_examples/multicluster/customResource/virtualServer/vs-with-extended-services-and-ab.yaml
+++ b/docs/config_examples/multicluster/customResource/virtualServer/vs-with-extended-services-and-ab.yaml
@@ -16,7 +16,7 @@ spec:
       alternateBackends:
         - service: svc-edge-b
           weight: 30
-      extendedServiceReferences:
+      multiClusterServices:
         - clusterName: cluster2
           namespace: ns1
           servicePort: 80

--- a/docs/config_examples/multicluster/customResource/virtualServer/vs-with-extended-services.yaml
+++ b/docs/config_examples/multicluster/customResource/virtualServer/vs-with-extended-services.yaml
@@ -15,7 +15,7 @@ spec:
     serviceNamespace: tea
     service: svc-2
     servicePort: 80
-    extendedServiceReferences:
+    multiClusterServices:
     - clusterName: cluster2
       namespace: ns1
       servicePort: 8080

--- a/pkg/controller/multiClusterWorker.go
+++ b/pkg/controller/multiClusterWorker.go
@@ -20,7 +20,7 @@ func (ctlr *Controller) processResourceExternalClusterServices(rscKey resourceRe
 	defer ctlr.multiClusterResources.Unlock()
 
 	for _, svc := range clusterSvcs {
-		if ctlr.checkValidExtendedService(svc, true) != nil {
+		if ctlr.checkValidMultiClusterService(svc, true) != nil {
 			// Skip processing invalid extended service
 			continue
 		}

--- a/pkg/controller/nativeResourceWorker.go
+++ b/pkg/controller/nativeResourceWorker.go
@@ -1820,7 +1820,7 @@ func (ctlr *Controller) checkValidRoute(route *routeapi.Route, plcSSLProfiles rg
 				ctlr.multiClusterResources.Lock()
 				defer ctlr.multiClusterResources.Unlock()
 				for _, svc := range clusterSvcs {
-					err := ctlr.checkValidExtendedService(svc, true)
+					err := ctlr.checkValidMultiClusterService(svc, true)
 					if err != nil {
 						// In case of invalid extendedServiceReference, just log the error and proceed
 						log.Errorf("[MultiCluster] invalid extendedServiceReference: %v for Route: %s: %v", svc, route.Name, err)

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -3037,7 +3037,7 @@ func (ctlr *Controller) GetPoolBackends(pool *cisapiv1.VSPool) []SvcBackendCxt {
 		//if svc.ClusterName == ctlr.multiClusterConfigs.LocalClusterName {
 		//	svc.ClusterName = ""
 		//}
-		if ctlr.checkValidExtendedService(svc, false) != nil || ctlr.isAddingPoolRestricted(svc.ClusterName) {
+		if ctlr.checkValidMultiClusterService(svc, false) != nil || ctlr.isAddingPoolRestricted(svc.ClusterName) {
 			continue
 		}
 		if _, ok := clusterSvcMap[svc.ClusterName]; !ok {
@@ -3150,7 +3150,7 @@ func (ctlr *Controller) GetPoolBackends(pool *cisapiv1.VSPool) []SvcBackendCxt {
 		//	svc.ClusterName = ""
 		//}
 		// Skip invalid extended service
-		if ctlr.checkValidExtendedService(svc, false) != nil || ctlr.isAddingPoolRestricted(svc.ClusterName) {
+		if ctlr.checkValidMultiClusterService(svc, false) != nil || ctlr.isAddingPoolRestricted(svc.ClusterName) {
 			continue
 		}
 		beIdx = beIdx + 1

--- a/pkg/controller/routing.go
+++ b/pkg/controller/routing.go
@@ -1586,7 +1586,7 @@ func (ctlr *Controller) GetRouteBackends(route *routeapi.Route, clusterSvcs []ci
 		// Skip the service if it's not valid
 		// This includes check for cis should be running in multiCluster mode, external server parameters validity and
 		// cluster credentials must be specified in the extended configmap
-		if ctlr.checkValidExtendedService(svc, false) != nil || ctlr.isAddingPoolRestricted(svc.ClusterName) {
+		if ctlr.checkValidMultiClusterService(svc, false) != nil || ctlr.isAddingPoolRestricted(svc.ClusterName) {
 			continue
 		}
 		if _, ok := clusterSvcMap[svc.ClusterName]; !ok {
@@ -1682,7 +1682,7 @@ func (ctlr *Controller) GetRouteBackends(route *routeapi.Route, clusterSvcs []ci
 	// External services
 	for _, svc := range clusterSvcs {
 		// Skip invalid extended service
-		if ctlr.checkValidExtendedService(svc, false) != nil || ctlr.isAddingPoolRestricted(svc.ClusterName) {
+		if ctlr.checkValidMultiClusterService(svc, false) != nil || ctlr.isAddingPoolRestricted(svc.ClusterName) {
 			continue
 		}
 		beIdx = beIdx + 1

--- a/pkg/controller/validate.go
+++ b/pkg/controller/validate.go
@@ -76,7 +76,7 @@ func (ctlr *Controller) checkValidVirtualServer(
 			continue
 		}
 		for _, mcs := range pool.MultiClusterServices {
-			err := ctlr.checkValidExtendedService(mcs, true)
+			err := ctlr.checkValidMultiClusterService(mcs, true)
 			if err != nil {
 				// In case of invalid extendedServiceReference, just log the error and proceed
 				log.Errorf("[MultiCluster] invalid extendedServiceReference: %v for VS: %s: %v", mcs, vsName, err)
@@ -139,7 +139,7 @@ func (ctlr *Controller) checkValidTransportServer(
 	}
 	if tsResource.Spec.Pool.MultiClusterServices != nil {
 		for _, mcs := range tsResource.Spec.Pool.MultiClusterServices {
-			err := ctlr.checkValidExtendedService(mcs, true)
+			err := ctlr.checkValidMultiClusterService(mcs, true)
 			if err != nil {
 				// In case of invalid extendedServiceReference, just log the error and proceed
 				log.Errorf("[MultiCluster] invalid extendedServiceReference: %v for TS: %s: %v", mcs, vsName, err)
@@ -193,8 +193,8 @@ func (ctlr *Controller) checkValidIngressLink(
 	return true
 }
 
-// checkValidExtendedService checks if extended service is valid or not
-func (ctlr *Controller) checkValidExtendedService(mcs cisapiv1.MultiClusterServiceReference, isSpec bool) error {
+// checkValidMultiClusterService checks if extended service is valid or not
+func (ctlr *Controller) checkValidMultiClusterService(mcs cisapiv1.MultiClusterServiceReference, isSpec bool) error {
 	// Check if cis running in multiCluster mode
 	if ctlr.multiClusterMode == "" {
 		return fmt.Errorf("CIS is not running in multiCluster mode")

--- a/pkg/controller/validate_test.go
+++ b/pkg/controller/validate_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Validation Tests", func() {
 
 		It("Validating ExtendedServiceReference in non multiCluster mode", func() {
 			mockCtlr.multiClusterMode = ""
-			Expect(mockCtlr.checkValidExtendedService(cisapiv1.MultiClusterServiceReference{
+			Expect(mockCtlr.checkValidMultiClusterService(cisapiv1.MultiClusterServiceReference{
 				SvcName:     "svc1",
 				Namespace:   "namespace1",
 				ServicePort: intstr.IntOrString{IntVal: 80},
@@ -42,19 +42,19 @@ var _ = Describe("Validation Tests", func() {
 
 		It("Validating ExtendedServiceReference for missing parameters", func() {
 			// Check for missing cluster name
-			Expect(mockCtlr.checkValidExtendedService(cisapiv1.MultiClusterServiceReference{
+			Expect(mockCtlr.checkValidMultiClusterService(cisapiv1.MultiClusterServiceReference{
 				SvcName:     "svc1",
 				Namespace:   "namespace1",
 				ServicePort: intstr.IntOrString{IntVal: 80},
 			}, true)).Error().To(Equal(fmt.Errorf("some of the mandatory parameters (clusterName/namespace/service/servicePort) are missing")))
 			// Check for missing service name
-			Expect(mockCtlr.checkValidExtendedService(cisapiv1.MultiClusterServiceReference{
+			Expect(mockCtlr.checkValidMultiClusterService(cisapiv1.MultiClusterServiceReference{
 				ClusterName: "cluster1",
 				Namespace:   "namespace1",
 				ServicePort: intstr.IntOrString{IntVal: 80},
 			}, true)).Error().To(Equal(fmt.Errorf("some of the mandatory parameters (clusterName/namespace/service/servicePort) are missing")))
 			// Check for missing ServicePort
-			Expect(mockCtlr.checkValidExtendedService(cisapiv1.MultiClusterServiceReference{
+			Expect(mockCtlr.checkValidMultiClusterService(cisapiv1.MultiClusterServiceReference{
 				ClusterName: "cluster1",
 				Namespace:   "namespace1",
 				SvcName:     "svc1",
@@ -63,7 +63,7 @@ var _ = Describe("Validation Tests", func() {
 
 		It("Validating ExtendedServiceReference running in HA and non-HA cluster", func() {
 			// Service running in cluster3 which is not defined in extended configmap
-			Expect(mockCtlr.checkValidExtendedService(cisapiv1.MultiClusterServiceReference{
+			Expect(mockCtlr.checkValidMultiClusterService(cisapiv1.MultiClusterServiceReference{
 				ClusterName: "cluster3",
 				SvcName:     "svc1",
 				Namespace:   "namespace1",
@@ -71,22 +71,22 @@ var _ = Describe("Validation Tests", func() {
 			}, true)).Error().To(Equal(fmt.Errorf("cluster config for the cluster cluster3 is not provided in extended configmap")))
 			// Service running in non HA cluster
 			mockCtlr.multiClusterConfigs.ClusterConfigs["cluster3"] = clustermanager.ClusterConfig{}
-			Expect(mockCtlr.checkValidExtendedService(cisapiv1.MultiClusterServiceReference{
+			Expect(mockCtlr.checkValidMultiClusterService(cisapiv1.MultiClusterServiceReference{
 				ClusterName: "cluster3",
 				Namespace:   "namespace1",
 				SvcName:     "svc1",
 				ServicePort: intstr.IntOrString{IntVal: 80},
 			}, true)).Error().To(BeNil())
 			//// Service running in primary cluster
-			//Expect(mockCtlr.checkValidExtendedService(cisapiv1.MultiClusterServiceReference{
+			//Expect(mockCtlr.checkValidMultiClusterService(cisapiv1.MultiClusterServiceReference{
 			//	ClusterName: "cluster1",
 			//	SvcName:     "svc1",
 			//	Namespace:   "namespace1",
 			//	ServicePort: intstr.IntOrString{IntVal: 80},
 			//}, true)).Error().To(Equal(fmt.Errorf("service is running in HA cluster, currently CIS doesn't support services running in " +
-			//	"HA clusters to be defined in extendedServiceReference")))
+			//	"HA clusters to be defined in checkValidMultiClusterService")))
 			// Service running in secondary cluster
-			//Expect(mockCtlr.checkValidExtendedService(cisapiv1.MultiClusterServiceReference{
+			//Expect(mockCtlr.checkValidMultiClusterService(cisapiv1.MultiClusterServiceReference{
 			//	ClusterName: "cluster2",
 			//	SvcName:     "svc1",
 			//	Namespace:   "namespace1",

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -2245,7 +2245,7 @@ func (ctlr *Controller) updatePoolMembersForResources(pool *Pool) {
 			clusterName = ""
 		}
 		// Skip invalid extended service or if adding pool member is restricted for the cluster
-		if ctlr.checkValidExtendedService(mcs, false) != nil || ctlr.isAddingPoolRestricted(mcs.ClusterName) ||
+		if ctlr.checkValidMultiClusterService(mcs, false) != nil || ctlr.isAddingPoolRestricted(mcs.ClusterName) ||
 			//(ctlr.haModeType == StandBy && ctlr.multiClusterMode == SecondaryCIS && clusterName == "") ||
 			(ctlr.haModeType == StandBy && clusterName == ctlr.multiClusterConfigs.HAPairClusterName) {
 			continue
@@ -2421,7 +2421,7 @@ func (ctlr *Controller) updatePoolMemberWeights(svcMemMap map[MultiClusterServic
 		}
 
 		for _, svc := range pool.MultiClusterServices {
-			if ctlr.checkValidExtendedService(svc, false) != nil || ctlr.isAddingPoolRestricted(svc.ClusterName) {
+			if ctlr.checkValidMultiClusterService(svc, false) != nil || ctlr.isAddingPoolRestricted(svc.ClusterName) {
 				continue
 			}
 			if _, ok := clusterSvcMap[svc.ClusterName]; !ok {


### PR DESCRIPTION
**Description**:  Rename extendedServiceReferences as multiClusterServices

**Changes Proposed in PR**: Rename extendedServiceReferences as multiClusterServices

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema