### PR TITLE
Fix issue of node informer for secondary cluster in default mode

### DIFF
--- a/pkg/controller/nativeResourceWorker.go
+++ b/pkg/controller/nativeResourceWorker.go
@@ -2056,8 +2056,8 @@ func (ctlr *Controller) readMultiClusterConfigFromGlobalCM(haClusterConfig HAClu
 				os.Exit(1)
 			}
 
-			// Setup and start informers for secondary cluster in case of active-active mode HA cluster
-			if ctlr.discoveryMode == Active || ctlr.discoveryMode == Ratio {
+			// Setup and start informers for secondary cluster in case of active-active/ratio/default mode HA cluster
+			if ctlr.discoveryMode != StandBy {
 				err := ctlr.setupAndStartHAClusterInformers(haClusterConfig.SecondaryCluster.ClusterName)
 				if err != nil {
 					return err
@@ -2089,8 +2089,8 @@ func (ctlr *Controller) readMultiClusterConfigFromGlobalCM(haClusterConfig HAClu
 				os.Exit(1)
 			}
 
-			// Setup and start informers for primary cluster in case of active-active mode HA cluster
-			if ctlr.discoveryMode == Active || ctlr.discoveryMode == Ratio {
+			// Setup and start informers for primary cluster in case of active-active/ratio/default mode HA cluster
+			if ctlr.discoveryMode != StandBy {
 				err := ctlr.setupAndStartHAClusterInformers(haClusterConfig.PrimaryCluster.ClusterName)
 				if err != nil {
 					return err


### PR DESCRIPTION
**Description**:  Fix issue of node informer for secondary cluster in default mode

**Changes Proposed in PR**:

**Fixes**: resolves #_Github issue id_

## General Checklist
- [ ] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation
- [ ] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema