### PR TITLE
Fix for pool members not updating when service port and target ports are different

### DIFF
--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -2330,7 +2330,8 @@ func (ctlr *Controller) updatePoolMembersForResources(pool *Pool) {
 		// isn't considered for updating the pool members as it may lead to duplicate pool members as it may have been
 		// already populated while updating the HA cluster pair service pool members above
 		if _, ok := ctlr.multiClusterPoolInformers[clusterName]; ok || clusterName == "" {
-			pms := ctlr.fetchPoolMembersForService(mcs.SvcName, mcs.Namespace, mcs.ServicePort,
+			targetPort := ctlr.fetchTargetPort(mcs.Namespace, mcs.SvcName, mcs.ServicePort, clusterName)
+			pms := ctlr.fetchPoolMembersForService(mcs.SvcName, mcs.Namespace, targetPort,
 				pool.NodeMemberLabel, clusterName, pool.ConnectionLimit, pool.BigIPRouteDomain)
 			poolMembers = append(poolMembers, pms...)
 


### PR DESCRIPTION

**Description**:  _Add Issue/Feature description_

**Changes Proposed in PR**:

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema