### PR TITLE
Poolname and monitor name not updated when service port is updated with servicetypeLB and transport server

### DIFF
--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -2380,6 +2380,12 @@ func (ctlr *Controller) prepareRSConfigFromTransportServer(
 		if SvcBackend.Name == "" {
 			continue
 		}
+		SvcBackend.SvcPort = ctlr.fetchTargetPort(SvcBackend.SvcNamespace, SvcBackend.Name, pl.ServicePort, "")
+		svcPortUsed := false // svcPortUsed is true only when the target port could not be fetched
+		if (intstr.IntOrString{}) == SvcBackend.SvcPort {
+			SvcBackend.SvcPort = pl.ServicePort
+			svcPortUsed = true
+		}
 		poolName := ctlr.framePoolNameForTS(vs.Namespace, pl, SvcBackend)
 		if _, ok := framedPools[poolName]; ok {
 			// Pool with same name framed earlier, so skipping this pool
@@ -2391,18 +2397,12 @@ func (ctlr *Controller) prepareRSConfigFromTransportServer(
 		if SvcBackend.SvcNamespace != "" {
 			svcNamespace = SvcBackend.SvcNamespace
 		}
-		targetPort := ctlr.fetchTargetPort(svcNamespace, SvcBackend.Name, pl.ServicePort, "")
-		svcPortUsed := false // svcPortUsed is true only when the target port could not be fetched
-		if (intstr.IntOrString{}) == targetPort {
-			targetPort = pl.ServicePort
-			svcPortUsed = true
-		}
 		pool := Pool{
 			Name:              poolName,
 			Partition:         rsCfg.Virtual.Partition,
 			ServiceName:       SvcBackend.Name,
 			ServiceNamespace:  svcNamespace,
-			ServicePort:       targetPort,
+			ServicePort:       SvcBackend.SvcPort,
 			ServicePortUsed:   svcPortUsed,
 			NodeMemberLabel:   pl.NodeMemberLabel,
 			Balance:           pl.Balance,

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -542,7 +542,9 @@ func (ctlr *Controller) processResources() bool {
 					clusterName: rKey.clusterName,
 				}
 				// clean the CIS cache
-				ctlr.deleteStaleVirtualserverForService(svcKey, svc.Spec.Ports)
+				if rKey.svcPortUpdated != false {
+					ctlr.deleteStaleVirtualserverForService(svcKey, svc.Spec.Ports)
+				}
 				ctlr.deleteResourceExternalClusterSvcRouteReference(rsRef)
 			} else {
 				//For creation of service check for duplicate ip on serviceTypeLB Resource

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -824,7 +824,7 @@ func (ctlr *Controller) processResources() bool {
 }
 
 // Delete the virtual-server rsname from the associated service
-func (ctlr *Controller) deleteStaleVirtualserverForService(svcKey MultiClusterServiceKey, curPorts []v1.ServicePort) string {
+func (ctlr *Controller) deleteStaleVirtualserverForService(svcKey MultiClusterServiceKey, curPorts []v1.ServicePort) {
 	if serviceKey, ok := ctlr.multiClusterResources.clusterSvcMap[svcKey.clusterName]; ok {
 		curPortsMap := make(map[int32]struct{}, len(curPorts))
 		for _, port := range curPorts {
@@ -849,7 +849,6 @@ func (ctlr *Controller) deleteStaleVirtualserverForService(svcKey MultiClusterSe
 			}
 		}
 	}
-	return ""
 }
 
 // getServiceForEndpoints returns the service associated with endpoints.


### PR DESCRIPTION

**Description**:  Poolname and monitor name not updated when service port is updated with servicetypeLB and transport server

**Changes Proposed in PR**: Handled the service port and target port modifications

**Fixes**: resolves #1172 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed
