### PR TITLE
[oscp][multicluster] cis not removing pool members on service deletion

### DIFF
--- a/pkg/controller/nativeResourceWorker.go
+++ b/pkg/controller/nativeResourceWorker.go
@@ -515,7 +515,7 @@ func (ctlr *Controller) prepareResourceConfigFromRoute(
 					pool.MultiClusterServices = multiClusterServices
 				}
 				// update the multicluster resource serviceMap with local cluster services
-				ctlr.updateMultiClusterResourceServiceMap(rsCfg, rsRef, bs.Name, route.Spec.Path, pool, servicePort, "")
+				ctlr.updateMultiClusterResourceServiceMap(rsCfg, rsRef, bs.Name, route.Spec.Path, pool, servicePort, ctlr.multiClusterHandler.LocalClusterName)
 				// update the multicluster resource serviceMap with HA pair cluster services
 				if ctlr.discoveryMode == Active && ctlr.multiClusterHandler.HAPairClusterName != "" {
 					ctlr.updateMultiClusterResourceServiceMap(rsCfg, rsRef, bs.Name, route.Spec.Path, pool, servicePort,


### PR DESCRIPTION
**Description**:  [oscp][multicluster] cis not removing pool members on service deletion

**Changes Proposed in PR**: Fixed by passing correct cluster name

**Fixes**: resolves #1211

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed
