### PR TITLE
handle kubeconfig update 

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -15,6 +15,7 @@ Bug Fixes
 * `Issue 3679 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3679>`_: Certificate, CA chain, and private key shown in debug logs
 * `Issue 3655 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3655>`_: Calico static routes not updated when nodes added/removed from cluster
 * `Issue 3717 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3717>`_: StaticRoute CNI calico doesn't detect multiple blockaffinities
+* `Issue 3727 <https://github.com/F5Networks/k8s-bigip-ctlr/pull/3738>`_: F5-cis needs a restart to use updated kubeconfig secret
 
 Upgrade notes
 ``````````````

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -413,16 +413,29 @@ func (ctlr *Controller) processResources() bool {
 			if err != nil {
 				log.Warningf(err.Error())
 			}
-			if !ctlr.initState && rKey.event == Create {
-				//for external clusters
-				if mcc.ServiceTypeLBDiscovery || mcc.ClusterName == ctlr.multiClusterHandler.LocalClusterName {
-					//start all informers for the cluster
-					ctlr.setupAndStartExternalClusterInformers(mcc.ClusterName)
-				} else {
-					//check cluster svc map to start required  namespace informers for cluster
-					ctlr.startInfomersForClusterReferencedSvcs(mcc.ClusterName)
+			if !ctlr.initState {
+				if rKey.event == Create {
+					//for external clusters
+					if mcc.ServiceTypeLBDiscovery || mcc.ClusterName == ctlr.multiClusterHandler.LocalClusterName {
+						//start all informers for the cluster
+						ctlr.setupAndStartExternalClusterInformers(mcc.ClusterName)
+					} else {
+						//check cluster svc map to start required  namespace informers for cluster
+						ctlr.startInfomersForClusterReferencedSvcs(mcc.ClusterName)
+					}
+				} else if rKey.event == Update {
+					log.Debugf("kubeconfig updated for cluster %s.Updating informers with new client", mcc.ClusterName)
+					ctlr.stopMultiClusterPoolInformers(mcc.ClusterName, true)
+					ctlr.stopMultiClusterNodeInformer(mcc.ClusterName)
+					//start the informers with updated client kubeconfig
+					if mcc.ServiceTypeLBDiscovery || mcc.ClusterName == ctlr.multiClusterHandler.LocalClusterName {
+						//start all informers for the cluster
+						ctlr.setupAndStartExternalClusterInformers(mcc.ClusterName)
+					} else {
+						//check cluster svc map to start required  namespace informers for cluster
+						ctlr.startInfomersForClusterReferencedSvcs(mcc.ClusterName)
+					}
 				}
-
 			}
 			break
 		}


### PR DESCRIPTION
**Description**:  handle kubeclient updates when kubeconfig secret is updated for external clusters.

**Changes Proposed in PR**:
1. handled kubeclient updates when kubeconfig secret is updated for external clusters.
2. For primary clusters(i.e local cluster) where cis is running, kubeconfig is read from inClusterConfig provided by Kubernetes. Secret update will have no impact on local cluster

**Fixes**: resolves #3727 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Smoke testing completed

