### PR TITLE
feat: support for exponential timeout when bigip is busy

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -19,6 +19,7 @@ Bug Fixes
 ````````````
 * `Issue 3762 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3762>`_: TCP/UDP Loadbalancer doesn't work in 2.19.0 and 2.19.1
 * `Issue 3755 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3755>`_: Upgrade to 2.19 - Unexpected error: 'config'
+* `Issue 3766 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3766>`_: CIS doesn't gracefully handle 503 error from F5
 * `Issue 3767 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3767>`_: HTTPS support for primaryEndPoint url
 * `Issue 3768 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3768>`_: INFO logging for CIS HA secondary when primary CIS is down
 

--- a/pkg/controller/apiHandler.go
+++ b/pkg/controller/apiHandler.go
@@ -78,11 +78,19 @@ func (api *BaseAPIHandler) postConfig(cfg *agentPostConfig) {
 	}
 
 	httpResp, responseMap := api.PostManager.postConfig(cfg)
-	if httpResp == nil || responseMap == nil {
+	if httpResp == nil {
+		return
+	}
+
+	if responseMap == nil {
+		// handle the cases where we are not able to unmarshall the response
+		// BIG IP sometime responds with error hence we are unable to marshall the response
+		api.APIHandler.handleNilResponseMap(httpResp.StatusCode, cfg)
 		return
 	}
 
 	var unknownResponse = false
+
 	switch httpResp.StatusCode {
 	case http.StatusOK:
 		log.Infof("%v[%s]%v post resulted in SUCCESS", getRequestPrefix(cfg.reqMeta.id), api.apiType, api.postManagerPrefix)

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -105,6 +105,10 @@ func (agent *Agent) agentWorker() {
 			poll for its status continuously and block incoming requests
 		*/
 		agent.LTM.APIHandler.pollTenantStatus(agentConfig)
+
+		// update the tenant cache
+		agent.LTM.APIHandler.getApiHandler().updateTenantCache(agentConfig)
+
 		// notify resourceStatusUpdate response handler on successful tenant update
 		agent.LTM.PostManager.respChan <- agentConfig
 	}
@@ -191,4 +195,13 @@ func extractVirtualAddressAndPort(str string) (string, int) {
 		return "", 0
 	}
 
+}
+
+func (agentConfig *agentPostConfig) increaseTimeout() {
+	// Increase the timeout exponential till timeoutMax
+	if agentConfig.timeout < timeoutMax {
+		agentConfig.timeout = agentConfig.timeout * 2
+	} else {
+		agentConfig.timeout = timeoutMax
+	}
 }

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -171,7 +171,7 @@ func NewController(params Params, startController bool, agentParams AgentParams,
 		clusterRatio:                make(map[string]*int),
 		clusterAdminState:           make(map[string]clustermanager.AdminState),
 		ResourceStatusVSAddressMap:  make(map[resourceRef]string),
-		respChan:                    make(chan *agentPostConfig),
+		respChan:                    make(chan *agentPostConfig, 1),
 		multiClusterHandler:         NewClusterHandler(params.LocalClusterName),
 	}
 	if handler == nil {

--- a/pkg/controller/gtmBackend.go
+++ b/pkg/controller/gtmBackend.go
@@ -27,6 +27,10 @@ func (agent *Agent) gtmWorker() {
 			poll for its status continuously and block incoming requests
 		*/
 		agent.GTM.APIHandler.pollTenantStatus(agentConfig)
+
+		// update the tenant cache
+		agent.GTM.APIHandler.getApiHandler().updateTenantCache(agentConfig)
+
 		// notify resourceStatusUpdate response handler on successful tenant update
 		agent.GTM.respChan <- agentConfig
 	}

--- a/pkg/controller/postManager_test.go
+++ b/pkg/controller/postManager_test.go
@@ -225,7 +225,7 @@ var _ = Describe("PostManager", func() {
 
 			It("should return nil response and nil map", func() {
 				resp, respMap := mockPM.postConfig(cfg)
-				Expect(resp).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusNotFound))
 				Expect(respMap).To(BeNil())
 			})
 		})
@@ -243,7 +243,7 @@ var _ = Describe("PostManager", func() {
 
 			It("should return nil response and nil map", func() {
 				resp, respMap := mockPM.httpPOST(request)
-				Expect(resp).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(respMap).To(BeNil())
 			})
 		})
@@ -260,7 +260,7 @@ var _ = Describe("PostManager", func() {
 
 			It("should return nil response and nil map", func() {
 				resp, respMap := mockPM.httpPOST(request)
-				Expect(resp).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusOK))
 				Expect(respMap).To(BeNil())
 			})
 		})
@@ -277,7 +277,7 @@ var _ = Describe("PostManager", func() {
 
 			It("should return nil response and nil map", func() {
 				resp, respMap := mockPM.httpPOST(request)
-				Expect(resp).To(BeNil())
+				Expect(resp.StatusCode).To(Equal(http.StatusUnauthorized))
 				Expect(respMap).To(BeNil())
 			})
 		})

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -21,6 +21,7 @@ import (
 	"github.com/F5Networks/k8s-bigip-ctlr/v2/pkg/tokenmanager"
 	"net/http"
 	"sync"
+	"time"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic"
@@ -859,6 +860,8 @@ type (
 		deleted               bool
 		agentKind             string
 		rscConfigRequest      ResourceConfigRequest
+		// timeout is used in BIG IP API is busy
+		timeout time.Duration
 	}
 
 	Agent struct {
@@ -978,7 +981,6 @@ type (
 
 	tenantResponse struct {
 		agentResponseCode int
-		taskId            string
 		isDeleted         bool
 		message           string
 	}


### PR DESCRIPTION
**Description**:  support for exponential timeout when bigip is busy

**Changes Proposed in PR**: As part of this PR, We are embedding the timeouts in the agentPostConfig itself and timeout is increased for each config request when BigIP is busy upto max timeout of 240 sec.


**Fixes**: resolves #3766 

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed