### PR TITLE
fix: tenant cache to avoid the concurrent read write

### DIFF
--- a/pkg/controller/as3Handler.go
+++ b/pkg/controller/as3Handler.go
@@ -533,6 +533,9 @@ func (am *AS3Handler) createAPIConfig(rsConfig ResourceConfigRequest, ccclGTMAge
 		rscConfigRequest:      rsConfig,
 		timeout:               timeoutMedium,
 	}
+	// get the Post Manager Lock to read the tenant declaration cache and compare the
+	// existing config with the latest desired config
+	am.PostManager.declUpdate.Lock()
 	for tenant, cfg := range am.createLTMAndGTMConfigADC(rsConfig, ccclGTMAgent) {
 		// this section is for gtm agent
 		if !reflect.DeepEqual(cfg, am.cachedTenantDeclMap[tenant]) {
@@ -540,6 +543,7 @@ func (am *AS3Handler) createAPIConfig(rsConfig ResourceConfigRequest, ccclGTMAge
 			as3cfg.tenantResponseMap[tenant] = tenantResponse{}
 		}
 	}
+	am.PostManager.declUpdate.Unlock()
 	as3cfg.data = string(am.createAS3Declaration(as3cfg.incomingTenantDeclMap, userAgent))
 	return as3cfg
 }

--- a/pkg/controller/as3Handler_test.go
+++ b/pkg/controller/as3Handler_test.go
@@ -6,6 +6,7 @@ import (
 	. "github.com/onsi/gomega"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"strings"
+	"sync"
 )
 
 var _ = Describe("Backend Tests", func() {
@@ -15,7 +16,8 @@ var _ = Describe("Backend Tests", func() {
 		var as3Handler AS3Handler
 		BeforeEach(func() {
 			as3Handler = AS3Handler{
-				AS3Parser: &AS3Parser{},
+				AS3Parser:   &AS3Parser{},
+				PostManager: &PostManager{declUpdate: sync.Mutex{}},
 			}
 			mem1 = PoolMember{
 				Address:         "1.2.3.5",
@@ -479,7 +481,8 @@ var _ = Describe("Backend Tests", func() {
 		var as3Handler AS3Handler
 		BeforeEach(func() {
 			as3Handler = AS3Handler{
-				AS3Parser: &AS3Parser{},
+				AS3Parser:   &AS3Parser{},
+				PostManager: &PostManager{declUpdate: sync.Mutex{}},
 			}
 		})
 		It("VirtualServer Declaration", func() {
@@ -500,7 +503,8 @@ var _ = Describe("Backend Tests", func() {
 		var as3Handler AS3Handler
 		BeforeEach(func() {
 			as3Handler = AS3Handler{
-				AS3Parser: &AS3Parser{},
+				AS3Parser:   &AS3Parser{},
+				PostManager: &PostManager{declUpdate: sync.Mutex{}},
 			}
 			DEFAULT_PARTITION = "default"
 		})
@@ -585,7 +589,8 @@ var _ = Describe("Backend Tests", func() {
 		var as3Handler AS3Handler
 		BeforeEach(func() {
 			as3Handler = AS3Handler{
-				AS3Parser: &AS3Parser{},
+				AS3Parser:   &AS3Parser{},
+				PostManager: &PostManager{declUpdate: sync.Mutex{}},
 			}
 		})
 		It("Service Address declaration", func() {

--- a/pkg/controller/backend.go
+++ b/pkg/controller/backend.go
@@ -98,7 +98,9 @@ func (agent *Agent) agentWorker() {
 			agent.LTM.PostManager.respChan <- agentConfig
 			continue
 		}
-
+		// this post manager lock prevents that tenant cache map is not read by other components
+		// while this post manager is processing this request
+		agent.LTM.PostManager.declUpdate.Lock()
 		agent.LTM.publishConfig(agentConfig)
 		/*
 			If there are any tenants with 201 response code,
@@ -108,7 +110,8 @@ func (agent *Agent) agentWorker() {
 
 		// update the tenant cache
 		agent.LTM.APIHandler.getApiHandler().updateTenantCache(agentConfig)
-
+		// unlock the PostManager lock after updating tenant cache
+		agent.LTM.PostManager.declUpdate.Unlock()
 		// notify resourceStatusUpdate response handler on successful tenant update
 		agent.LTM.PostManager.respChan <- agentConfig
 	}

--- a/pkg/controller/postManager.go
+++ b/pkg/controller/postManager.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"net/http"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/F5Networks/k8s-bigip-ctlr/v2/pkg/prometheus"
@@ -42,10 +43,11 @@ const (
 
 func NewPostManager(params AgentParams, kind string, respChan chan *agentPostConfig) *PostManager {
 	pm := &PostManager{
-		firstPost: true,
-		respChan:  respChan,
-		postChan:  make(chan *agentPostConfig, 1),
-		apiType:   params.ApiType,
+		firstPost:  true,
+		respChan:   respChan,
+		postChan:   make(chan *agentPostConfig, 1),
+		apiType:    params.ApiType,
+		declUpdate: sync.Mutex{},
 	}
 	switch kind {
 	case GTMBigIP:

--- a/pkg/controller/types.go
+++ b/pkg/controller/types.go
@@ -939,7 +939,7 @@ type (
 
 	PostManager struct {
 		tokenmanager.TokenManagerInterface
-		sync.RWMutex
+		declUpdate sync.Mutex
 		httpClient *http.Client
 		PostParams
 		firstPost         bool


### PR DESCRIPTION
**Description**:  There was a corner case where Agent is reading the cached tenants before it's update with the current BIGIP config, Hence some time it was reporting that there is no changes made to the config.


## General Checklist
- [x] Smoke testing completed
