### PR TITLE
fix: replace svc name with vsAddress in monitor name

### DIFF
--- a/pkg/controller/nativeResourceWorker.go
+++ b/pkg/controller/nativeResourceWorker.go
@@ -180,7 +180,7 @@ func (ctlr *Controller) processRoutes(routeGroup string, triggerDelete bool) err
 							httpTraffic = strings.ToLower(string(rt.Spec.TLS.InsecureEdgeTerminationPolicy))
 						}
 					}
-					ctlr.handleDefaultPoolForPolicy(rsCfg, plc, rsRef, "", httpTraffic, isSecureRoute(rt))
+					ctlr.handleDefaultPoolForPolicy(rsCfg, plc, rsRef, "", httpTraffic, isSecureRoute(rt), extdSpec.VServerAddr)
 				}
 			}
 			if isSecureRoute(rt) {

--- a/pkg/controller/nativeResourceWorker_test.go
+++ b/pkg/controller/nativeResourceWorker_test.go
@@ -2501,7 +2501,8 @@ externalClustersConfig:
 				"SampleVS",
 				"default",
 				cisapiv1.VirtualServerSpec{
-					Host: "test.com",
+					VirtualServerAddress: "1.2.3.4",
+					Host:                 "test.com",
 					Pools: []cisapiv1.VSPool{
 						{
 							Path:             "/foo",
@@ -2563,6 +2564,7 @@ externalClustersConfig:
 			mockCtlr.addService(svc_1, "cluster3")
 			svc_1_b := test.NewService("svc1-b", "1", "default", "NodePort", fooPorts)
 			mockCtlr.addService(svc_1_b, "")
+			vs.Status.VSAddress = "1.2.3.4"
 			mockCtlr.prepareRSConfigFromVirtualServer(rsCfg, vs, false, "")
 			Expect(len(mockCtlr.multiClusterResources.clusterSvcMap[""])).To(Equal(2))
 			Expect(len(mockCtlr.multiClusterResources.clusterSvcMap["cluster3"])).To(Equal(1))
@@ -2571,7 +2573,7 @@ externalClustersConfig:
 			//Verify that distinct health monitors are created for all pools in ratio mode
 			expectedHealthMonitors := make(map[string]struct{})
 			expectedHealthMonitors = map[string]struct{}{
-				"svc1_default_test_com_foo": struct{}{},
+				"default_1_2_3_4_test_com_foo": struct{}{},
 			}
 			for _, hm := range rsCfg.Monitors {
 				_, ok := expectedHealthMonitors[hm.Name]
@@ -2715,6 +2717,7 @@ externalClustersConfig:
 				"SampleTS",
 				"default",
 				cisapiv1.TransportServerSpec{
+					VirtualServerAddress: "1.2.3.4",
 					Pool: cisapiv1.TSPool{
 						Service:          "svc1",
 						ServicePort:      intstr.IntOrString{IntVal: 80},
@@ -2771,12 +2774,13 @@ externalClustersConfig:
 					mockCtlr.multiClusterHandler.ClusterConfigs[clusterName].comInformers[namespace] = poolInfr
 				}
 			}
+			ts.Status.VSAddress = "1.2.3.4"
 			mockCtlr.prepareRSConfigFromTransportServer(rsCfg, ts)
 			Expect(len(rsCfg.Monitors)).To(Equal(2))
 			Expect(len(rsCfg.Pools)).To(Equal(2))
 			Expect(len(rsCfg.IRulesMap)).To(Equal(1))
-			Expect(rsCfg.Monitors[0].Name).To(Equal("svc_default_tcp_80"))
-			Expect(rsCfg.Monitors[1].Name).To(Equal("svc_default_tcp_8080"))
+			Expect(rsCfg.Monitors[0].Name).To(Equal("default_1_2_3_4_tcp_80"))
+			Expect(rsCfg.Monitors[1].Name).To(Equal("default_1_2_3_4_tcp_8080"))
 			Expect(mockCtlr.discoveryMode).To(Equal(DefaultMode))
 			Expect(len(mockCtlr.multiClusterResources.clusterSvcMap)).To(Equal(1))
 			Expect(len(mockCtlr.multiClusterResources.clusterSvcMap["cluster3"])).To(Equal(2))

--- a/pkg/controller/resourceConfig.go
+++ b/pkg/controller/resourceConfig.go
@@ -383,8 +383,9 @@ func (ctlr *Controller) formatPoolName(namespace, svc string, port intstr.IntOrS
 }
 
 // format the monitor name for an VirtualServer pool
-func formatMonitorName(namespace, svc string, monitorType string, port intstr.IntOrString, hostName string, path string) string {
-	monitorName := fmt.Sprintf("%s_%s", svc, namespace)
+func formatMonitorName(namespace, ip string, monitorType string, port intstr.IntOrString, hostName string, path string) string {
+	// monitor name should adhere to "^[A-Za-z]([0-9A-Za-z_.-]{0,188}[0-9A-Za-z_.])?$"
+	monitorName := fmt.Sprintf("%s_%s", namespace, AS3NameFormatter(ip))
 
 	if len(hostName) > 0 {
 		monitorName = monitorName + fmt.Sprintf("_%s", hostName)
@@ -556,7 +557,7 @@ func (ctlr *Controller) prepareRSConfigFromVirtualServer(
 			if len(monitorNames) == 0 {
 				if !reflect.DeepEqual(pl.Monitor, cisapiv1.Monitor{}) {
 					monitorName := ctlr.createVirtualServerMonitor(pl.Monitor, rsCfg, pl.ServicePort, vs.Spec.Host, pl.Path,
-						vs.ObjectMeta.Namespace+"/"+vs.ObjectMeta.Name, pl, vs.ObjectMeta.Namespace)
+						vs.ObjectMeta.Namespace+"/"+vs.ObjectMeta.Name, vs.Status.VSAddress, vs.ObjectMeta.Namespace)
 					if monitorName != (MonitorName{}) {
 						monitorNames = append(monitorNames, monitorName)
 					}
@@ -569,7 +570,7 @@ func (ctlr *Controller) prepareRSConfigFromVirtualServer(
 							formatPort = pl.ServicePort
 						}
 						monitorName := ctlr.createVirtualServerMonitor(monitor, rsCfg, formatPort, vs.Spec.Host, pl.Path,
-							vs.ObjectMeta.Namespace+"/"+vs.ObjectMeta.Name, pl, vs.ObjectMeta.Namespace)
+							vs.ObjectMeta.Namespace+"/"+vs.ObjectMeta.Name, vs.Status.VSAddress, vs.ObjectMeta.Namespace)
 						if monitorName != (MonitorName{}) {
 							monitorNames = append(monitorNames, monitorName)
 						}
@@ -826,7 +827,7 @@ func (ctlr *Controller) prepareRSConfigFromVirtualServer(
 }
 
 func (ctlr *Controller) createVirtualServerMonitor(monitor cisapiv1.Monitor, rsCfg *ResourceConfig,
-	formatPort intstr.IntOrString, host, path, vsName string, pl cisapiv1.VSPool, rscNamespace string) MonitorName {
+	formatPort intstr.IntOrString, host, path, vsName string, vsAddress string, rscNamespace string) MonitorName {
 	var monitorRefName MonitorName
 	if !reflect.DeepEqual(monitor, Monitor{}) {
 		if monitor.Reference == BIGIP {
@@ -841,18 +842,9 @@ func (ctlr *Controller) createVirtualServerMonitor(monitor cisapiv1.Monitor, rsC
 				log.Errorf("missing send string for monitor. skipping monitor for virtual server: %v", vsName)
 				return monitorRefName
 			}
-			poolSvc := pl.Service
-			poolSvcNamespace := pl.ServiceNamespace
-			if poolSvcNamespace == "" {
-				poolSvcNamespace = rscNamespace
-			}
-			if ctlr.discoveryMode == DefaultMode && pl.MultiClusterServices != nil && len(pl.MultiClusterServices) > 0 {
-				poolSvc = pl.MultiClusterServices[0].SvcName
-				poolSvcNamespace = pl.MultiClusterServices[0].Namespace
-			}
 			monitorName := monitor.Name
 			if monitorName == "" {
-				monitorName = formatMonitorName(poolSvcNamespace, poolSvc, monitor.Type, formatPort, host,
+				monitorName = formatMonitorName(rscNamespace, vsAddress, monitor.Type, formatPort, host,
 					path)
 			}
 			monitorRefName = MonitorName{Name: JoinBigipPath(rsCfg.Virtual.Partition, monitorName)}
@@ -874,7 +866,7 @@ func (ctlr *Controller) createVirtualServerMonitor(monitor cisapiv1.Monitor, rsC
 }
 
 func (ctlr *Controller) createTransportServerMonitor(monitor cisapiv1.Monitor, rsCfg *ResourceConfig,
-	formatPort intstr.IntOrString, vsNamespace, vsName string, pl cisapiv1.TSPool) MonitorName {
+	formatPort intstr.IntOrString, vsNamespace, vsName string, ip string) MonitorName {
 	var monitorRefName MonitorName
 	if !reflect.DeepEqual(monitor, Monitor{}) {
 		if monitor.Reference == BIGIP {
@@ -885,12 +877,12 @@ func (ctlr *Controller) createTransportServerMonitor(monitor cisapiv1.Monitor, r
 			}
 		} else {
 			monitorName := monitor.Name
-			poolSVC := pl.Service
-			if ctlr.discoveryMode == DefaultMode && pl.MultiClusterServices != nil && len(pl.MultiClusterServices) > 0 {
-				poolSVC = pl.MultiClusterServices[0].SvcName
-			}
+			//poolSVC := pl.Service
+			//if ctlr.discoveryMode == DefaultMode && pl.MultiClusterServices != nil && len(pl.MultiClusterServices) > 0 {
+			//	poolSVC = pl.MultiClusterServices[0].SvcName
+			//}
 			if monitorName == "" {
-				monitorName = formatMonitorName(vsNamespace, poolSVC, monitor.Type, formatPort, "", "")
+				monitorName = formatMonitorName(vsNamespace, ip, monitor.Type, formatPort, "", "")
 			}
 			monitorRefName = MonitorName{Name: JoinBigipPath(rsCfg.Virtual.Partition, monitorName)}
 			monitor := Monitor{
@@ -925,7 +917,7 @@ func (ctlr *Controller) CreateIngressLinkMonitor(monitor cisapiv1.Monitor, ilNam
 
 // createServiceTypeLBMonitor creates health monitor for the serviceTypeLB
 func (ctlr *Controller) createServiceTypeLBMonitor(monitor cisapiv1.Monitor, rsCfg *ResourceConfig,
-	svcPort v1.ServicePort, svc *v1.Service) MonitorName {
+	svcPort v1.ServicePort, svc *v1.Service, vsAddress string) MonitorName {
 	var monitorRefName MonitorName
 	var formatPort intstr.IntOrString
 	monitorType := strings.ToLower(string(svcPort.Protocol))
@@ -949,7 +941,7 @@ func (ctlr *Controller) createServiceTypeLBMonitor(monitor cisapiv1.Monitor, rsC
 		} else {
 			monitorName := monitor.Name
 			if monitorName == "" {
-				monitorName = formatMonitorName(svc.Namespace, svc.Name, monitorType, formatPort, "", "")
+				monitorName = formatMonitorName(svc.Namespace, vsAddress, monitorType, formatPort, "", "")
 			}
 			monitorRefName = MonitorName{Name: JoinBigipPath(rsCfg.Virtual.Partition, monitorName)}
 			monitor := Monitor{
@@ -1016,7 +1008,7 @@ func (ctlr *Controller) handleDefaultPool(
 							formatPort = vs.Spec.DefaultPool.ServicePort
 						}
 						if mtr.Name == "" {
-							monitorName = formatMonitorName(svcNamespace, rsCfg.Virtual.PoolName, mtr.Type, formatPort, vs.Spec.Host, "")
+							monitorName = formatMonitorName(vs.Namespace, vs.Status.VSAddress, mtr.Type, formatPort, vs.Spec.Host, "")
 						}
 						pool.MonitorNames = append(pool.MonitorNames, MonitorName{Name: JoinBigipPath(rsCfg.Virtual.Partition, monitorName)})
 						mntr := Monitor{
@@ -1049,6 +1041,7 @@ func (ctlr *Controller) handleDefaultPoolForPolicy(
 	host string,
 	httpTraffic string,
 	isTLS bool,
+	vsAddress string,
 ) {
 	// if it's an insecure virtual server and vs traffic is redirect or none, we should not add the default pool
 	if rsCfg.MetaData.Protocol == HTTP && isTLS && (httpTraffic == TLSRedirectInsecure || httpTraffic == TLSNoInsecure) {
@@ -1094,7 +1087,7 @@ func (ctlr *Controller) handleDefaultPoolForPolicy(
 							formatPort = plc.Spec.DefaultPool.ServicePort
 						}
 						if mtr.Name == "" {
-							monitorName = formatMonitorName(svcNamespace, rsCfg.Virtual.PoolName, mtr.Type, formatPort, host, "")
+							monitorName = formatMonitorName(rsRef.namespace, vsAddress, mtr.Type, formatPort, host, "")
 						}
 						pool.MonitorNames = append(pool.MonitorNames, MonitorName{Name: JoinBigipPath(rsCfg.Virtual.Partition, monitorName)})
 						mntr := Monitor{
@@ -2423,7 +2416,7 @@ func (ctlr *Controller) prepareRSConfigFromTransportServer(
 			formatPort = pl.ServicePort
 		}
 		monitorName := ctlr.createTransportServerMonitor(pl.Monitor, rsCfg, formatPort,
-			vs.ObjectMeta.Namespace, vs.ObjectMeta.Name, pl)
+			vs.ObjectMeta.Namespace, vs.ObjectMeta.Name, vs.Status.VSAddress)
 		if monitorName != (MonitorName{}) {
 			monitorNames = append(monitorNames, monitorName)
 		}
@@ -2436,7 +2429,7 @@ func (ctlr *Controller) prepareRSConfigFromTransportServer(
 				formatPort = pl.ServicePort
 			}
 			monitorName := ctlr.createTransportServerMonitor(monitor, rsCfg, formatPort,
-				vs.ObjectMeta.Namespace, vs.ObjectMeta.Name, pl)
+				vs.ObjectMeta.Namespace, vs.ObjectMeta.Name, vs.Status.VSAddress)
 			if monitorName != (MonitorName{}) {
 				monitorNames = append(monitorNames, monitorName)
 			}
@@ -2798,6 +2791,7 @@ func (ctlr *Controller) prepareRSConfigFromLBService(
 	svcPort v1.ServicePort,
 	clusterName string,
 	multiClusterServices []cisapiv1.MultiClusterServiceReference,
+	vsAddress string,
 ) error {
 	var pools Pools
 	var backendSvcs []SvcBackendCxt
@@ -2830,7 +2824,7 @@ func (ctlr *Controller) prepareRSConfigFromLBService(
 					"Unable to parse health monitor JSON array '%v': %v", hmStr, err)
 				log.Errorf("[CORE] %s", msg)
 			}
-			monitorName := ctlr.createServiceTypeLBMonitor(mon, rsCfg, svcPort, svc)
+			monitorName := ctlr.createServiceTypeLBMonitor(mon, rsCfg, svcPort, svc, vsAddress)
 			if monitorName != (MonitorName{}) {
 				monitorNames = append(monitorNames, monitorName)
 			}
@@ -2844,7 +2838,7 @@ func (ctlr *Controller) prepareRSConfigFromLBService(
 				log.Errorf("[CORE] %s", msg)
 			}
 			for _, mon := range mons {
-				monitorName := ctlr.createServiceTypeLBMonitor(mon, rsCfg, svcPort, svc)
+				monitorName := ctlr.createServiceTypeLBMonitor(mon, rsCfg, svcPort, svc, vsAddress)
 				if monitorName != (MonitorName{}) {
 					monitorNames = append(monitorNames, monitorName)
 				}

--- a/pkg/controller/resourceConfig_test.go
+++ b/pkg/controller/resourceConfig_test.go
@@ -147,8 +147,8 @@ var _ = Describe("Resource Config Tests", func() {
 			Expect(name).To(Equal("svc1_80_default_foo_app_test"), "Invalid Pool Name")
 		})
 		It("Monitor Name", func() {
-			name := formatMonitorName(namespace, "svc1", "http", intstr.IntOrString{IntVal: 80}, "foo.com", "path")
-			Expect(name).To(Equal("svc1_default_foo_com_path_http_80"), "Invalid Monitor Name")
+			name := formatMonitorName(namespace, "1.2.3.4", "http", intstr.IntOrString{IntVal: 80}, "foo.com", "path")
+			Expect(name).To(Equal("default_1_2_3_4_foo_com_path_http_80"), "Invalid Monitor Name")
 		})
 		It("Rule Name", func() {
 			name := formatVirtualServerRuleName("test.com", "", "", "sample_pool", false)
@@ -747,7 +747,7 @@ var _ = Describe("Resource Config Tests", func() {
 			svc.Annotations = make(map[string]string)
 			svc.Annotations[HealthMonitorAnnotation] = `{"interval": 5, "timeout": 10}`
 
-			err := mockCtlr.prepareRSConfigFromLBService(rsCfg, svc, svcPort, "", nil)
+			err := mockCtlr.prepareRSConfigFromLBService(rsCfg, svc, svcPort, "", nil, "1.2.3.4")
 			Expect(err).To(BeNil(), "Failed to Prepare Resource Config from Service")
 			Expect(len(rsCfg.Pools)).To(Equal(1), "Failed to Prepare Resource Config from Service")
 			Expect(len(rsCfg.Monitors)).To(Equal(1), "Failed to Prepare Resource Config from Service")
@@ -769,7 +769,7 @@ var _ = Describe("Resource Config Tests", func() {
 			It("Verifies multiple monitors support in LB Service", func() {
 				svc.Annotations = make(map[string]string)
 				svc.Annotations[HealthMonitorAnnotation] = `[{"interval": 5, "name": "mon1", "timeout": 10, "targetPort": 80},{"name": "mon2", "interval": 15, "timeout": 20, "targetPort": 8080}]`
-				err := mockCtlr.prepareRSConfigFromLBService(rsCfg, svc, svcPort, "", nil)
+				err := mockCtlr.prepareRSConfigFromLBService(rsCfg, svc, svcPort, "", nil, "1.2.3.4")
 				Expect(err).To(BeNil(), "Failed to Prepare Resource Config from Service")
 				Expect(len(rsCfg.Pools)).To(Equal(1), "Failed to Prepare Resource Config from Service")
 				Expect(len(rsCfg.Monitors)).To(Equal(2), "Failed to Prepare Resource Config from Service")
@@ -780,7 +780,7 @@ var _ = Describe("Resource Config Tests", func() {
 			It("Verifies support for bigip reference monitor in health annotation in LB Service", func() {
 				svc.Annotations = make(map[string]string)
 				svc.Annotations[HealthMonitorAnnotation] = `{"name": "/Common/tcp", "reference": "bigip"}`
-				err := mockCtlr.prepareRSConfigFromLBService(rsCfg, svc, svcPort, "", nil)
+				err := mockCtlr.prepareRSConfigFromLBService(rsCfg, svc, svcPort, "", nil, "1.2.3.4")
 				Expect(err).To(BeNil(), "Failed to Prepare Resource Config from Service")
 				Expect(len(rsCfg.Pools)).To(Equal(1), "Failed to Prepare Resource Config from Service")
 				Expect(rsCfg.Monitors).To(BeNil(), "Failed to Prepare Resource Config from Service")
@@ -792,7 +792,7 @@ var _ = Describe("Resource Config Tests", func() {
 				"annotation in LB Service", func() {
 				svc.Annotations = make(map[string]string)
 				svc.Annotations[HealthMonitorAnnotation] = `[{"interval": 5, "name": "mon1", "timeout": 10, "targetPort": 80},{"name": "/Common/udp", "reference": "bigip"}]`
-				err := mockCtlr.prepareRSConfigFromLBService(rsCfg, svc, svcPort, "", nil)
+				err := mockCtlr.prepareRSConfigFromLBService(rsCfg, svc, svcPort, "", nil, "1.2.3.4")
 				Expect(err).To(BeNil(), "Failed to Prepare Resource Config from Service")
 				Expect(len(rsCfg.Pools)).To(Equal(1), "Failed to Prepare Resource Config from Service")
 				Expect(rsCfg.Monitors).NotTo(BeNil(), "Failed to Prepare Resource Config from Service")
@@ -1966,7 +1966,7 @@ var _ = Describe("Resource Config Tests", func() {
 				namespace: "default",
 				kind:      VirtualServer,
 			}
-			mockCtlr.handleDefaultPoolForPolicy(rsCfg, plc, rsRef, "test.com", "allow", true)
+			mockCtlr.handleDefaultPoolForPolicy(rsCfg, plc, rsRef, "test.com", "allow", true, "")
 			Expect(rsCfg.Virtual.PoolName).To(Equal("svc1_80_default_test_com"), "Failed to set default pool from policy")
 			Expect(len(rsCfg.Pools)).To(Equal(1), "Failed to process default pool for VirtualServer")
 		})

--- a/pkg/controller/worker.go
+++ b/pkg/controller/worker.go
@@ -1551,6 +1551,7 @@ func (ctlr *Controller) processVirtualServers(
 
 		for _, vrt := range virtuals {
 			// Updating the virtual server IP Address status for all associated virtuals
+			// Additionally, this IP is used for health monitor name
 			vrt.Status.VSAddress = ip
 			ctlr.ResourceStatusVSAddressMap[resourceRef{
 				name:      vrt.Name,
@@ -1611,7 +1612,7 @@ func (ctlr *Controller) processVirtualServers(
 							namespace: virtual.Namespace,
 							kind:      VirtualServer,
 						}
-						ctlr.handleDefaultPoolForPolicy(rsCfg, plc, rsRef, virtual.Spec.Host, virtual.Spec.HTTPTraffic, isTLSVirtualServer(virtual))
+						ctlr.handleDefaultPoolForPolicy(rsCfg, plc, rsRef, virtual.Spec.Host, virtual.Spec.HTTPTraffic, isTLSVirtualServer(virtual), ip)
 					}
 				}
 			}
@@ -3197,6 +3198,7 @@ func (ctlr *Controller) processTransportServers(
 		ip = virtual.Spec.VirtualServerAddress
 	}
 	// Updating the virtual server IP Address status
+	// Additionally, this IP is used for health monitor name
 	virtual.Status.VSAddress = ip
 	ctlr.ResourceStatusVSAddressMap[resourceRef{
 		name:      virtual.Name,
@@ -3592,7 +3594,7 @@ func (ctlr *Controller) processLBServices(
 			}
 		}
 
-		_ = ctlr.prepareRSConfigFromLBService(rsCfg, svc, portSpec, clusterName, multiClusterServices)
+		_ = ctlr.prepareRSConfigFromLBService(rsCfg, svc, portSpec, clusterName, multiClusterServices, ip)
 
 		// handle pool settings from policy cr
 		if plc != nil {


### PR DESCRIPTION
**Description**:  replace svc name with vsAddress in monitor name

**Changes Proposed in PR**:

**Fixes**: resolves #_Github issue id_

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema