### PR TITLE
fix: improving the ltm and gtm server comparison

### DIFF
--- a/pkg/controller/gtmBackend_test.go
+++ b/pkg/controller/gtmBackend_test.go
@@ -84,3 +84,32 @@ var _ = Describe("Backend Tests", func() {
 		})
 	})
 })
+
+var _ = Describe("normalizeURL", func() {
+	It("returns empty string for empty or whitespace-only input", func() {
+		Expect(normalizeURL("")).To(Equal(""))
+		Expect(normalizeURL("   \t\n  ")).To(Equal(""))
+	})
+
+	It("lowercases scheme/host and removes trailing slash and path", func() {
+		Expect(normalizeURL("HTTPS://EXAMPLE.COM/")).To(Equal("https://example.com"))
+		Expect(normalizeURL("HTTPS://EXAMPLE.COM/Some/Path/")).To(Equal("https://example.com"))
+	})
+
+	It("removes :443 for https scheme", func() {
+		Expect(normalizeURL("https://example.com:443")).To(Equal("https://example.com"))
+		Expect(normalizeURL("HTTPS://EXAMPLE.COM:443/")).To(Equal("https://example.com"))
+		// IPv6 host with default https port
+		Expect(normalizeURL("https://[2001:db8::1]:443")).To(Equal("https://[2001:db8::1]"))
+	})
+
+	It("preserves non-default ports", func() {
+		Expect(normalizeURL("http://example.com:80")).To(Equal("http://example.com:80"))
+		Expect(normalizeURL("https://example.com:8443")).To(Equal("https://example.com:8443"))
+	})
+
+	It("returns lowercased, trimmed string for unparsable URLs", func() {
+		// url.Parse fails for strings like "://FOO/"; function falls back to lowercase and trim trailing slash
+		Expect(normalizeURL("://FOO/")).To(Equal("://foo"))
+	})
+})


### PR DESCRIPTION
**Description**: improving the ltm and gtm server comparison

**Changes Proposed in PR**: There may be a chance that server urls, usernames and password are given differently in CIS deployment. Hence added the normalisation and string sanitisation before comparing the urls, username and password.

## General Checklist
- [ ] Updated Added functionality/ bug fix in release notes
- [ ] Added examples for new feature
- [ ] Updated the documentation
- [ ] Smoke testing completed

## CRD Checklist
- [ ] Updated required CR schema