### PR TITLE
increase the period seconds to 120 for the Helm values

### DIFF
--- a/docs/RELEASE-NOTES.rst
+++ b/docs/RELEASE-NOTES.rst
@@ -14,6 +14,7 @@ Added Functionality
 
 Bug Fixes
 ````````````
+* Issue 3852 <https://github.com/F5Networks/k8s-bigip-ctlr/issues/3852>`_: Improve logging when BIG-IP is not reachable during pod initialization
 
 Upgrade notes
 ``````````````

--- a/docs/config_examples/Install/k8s/sample-k8s-bigip-ctlr.yaml
+++ b/docs/config_examples/Install/k8s/sample-k8s-bigip-ctlr.yaml
@@ -35,7 +35,7 @@ spec:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 15
-            periodSeconds: 15
+            periodSeconds: 120
             successThreshold: 1
             timeoutSeconds: 15
           readinessProbe:
@@ -45,7 +45,7 @@ spec:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 120
             successThreshold: 1
             timeoutSeconds: 15
           volumeMounts:

--- a/docs/config_examples/Install/openshift/f5-k8s-bigip-ctlr-openshift.yaml
+++ b/docs/config_examples/Install/openshift/f5-k8s-bigip-ctlr-openshift.yaml
@@ -34,7 +34,7 @@ spec:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 15
-            periodSeconds: 15
+            periodSeconds: 120
             successThreshold: 1
             timeoutSeconds: 15
           readinessProbe:
@@ -44,7 +44,7 @@ spec:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 120
             successThreshold: 1
             timeoutSeconds: 15
           volumeMounts:

--- a/docs/config_examples/Install/openshift/quick-start-guides/HA/next-gen-route/cis/f5-bigip-ctlr-01-deployment.yaml
+++ b/docs/config_examples/Install/openshift/quick-start-guides/HA/next-gen-route/cis/f5-bigip-ctlr-01-deployment.yaml
@@ -34,7 +34,7 @@ spec:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 15
-            periodSeconds: 15
+            periodSeconds: 120
             successThreshold: 1
             timeoutSeconds: 15
           readinessProbe:
@@ -44,7 +44,7 @@ spec:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 120
             successThreshold: 1
             timeoutSeconds: 15
           volumeMounts:

--- a/docs/config_examples/Install/openshift/quick-start-guides/HA/next-gen-route/cis/f5-bigip-ctlr-02-deployment.yaml
+++ b/docs/config_examples/Install/openshift/quick-start-guides/HA/next-gen-route/cis/f5-bigip-ctlr-02-deployment.yaml
@@ -34,7 +34,7 @@ spec:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 15
-            periodSeconds: 15
+            periodSeconds: 120
             successThreshold: 1
             timeoutSeconds: 15
           readinessProbe:
@@ -44,7 +44,7 @@ spec:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 120
             successThreshold: 1
             timeoutSeconds: 15
           volumeMounts:

--- a/docs/config_examples/Install/openshift/quick-start-guides/StandAlone/f5-k8s-bigip-ctlr-openshift.yaml
+++ b/docs/config_examples/Install/openshift/quick-start-guides/StandAlone/f5-k8s-bigip-ctlr-openshift.yaml
@@ -34,7 +34,7 @@ spec:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 15
-            periodSeconds: 15
+            periodSeconds: 120
             successThreshold: 1
             timeoutSeconds: 15
           readinessProbe:
@@ -44,7 +44,7 @@ spec:
               port: 8080
               scheme: HTTP
             initialDelaySeconds: 30
-            periodSeconds: 30
+            periodSeconds: 120
             successThreshold: 1
             timeoutSeconds: 15
           volumeMounts:

--- a/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
+++ b/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
@@ -77,7 +77,7 @@ spec:
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 15
-          periodSeconds: 15
+          periodSeconds: 120
           successThreshold: 1
           timeoutSeconds: 15
         readinessProbe:
@@ -87,7 +87,7 @@ spec:
             port: 8080
             scheme: HTTP
           initialDelaySeconds: 30
-          periodSeconds: 30
+          periodSeconds: 120
           successThreshold: 1
           timeoutSeconds: 15
         volumeMounts:


### PR DESCRIPTION
**Description**:  Improve logging when BIG-IP is not reachable during pod initialization

**Changes Proposed in PR**: Increased the period seconds to 120 secs

**Fixes**: resolves #3895

## General Checklist
- [x] Smoke testing completed
