### PR TITLE
Fix wording in NextGenRoute migration guide

### DIFF
--- a/docs/config_examples/next-gen-routes/migration-guide.md
+++ b/docs/config_examples/next-gen-routes/migration-guide.md
@@ -14,7 +14,7 @@
 
 
 ## Overview
-NextGenRoute Route uses extendedConfigMap for extending the native resources (routes). All the routes are group by namespaces or namespace-labels into RouteGroups. Each RouteGroup shares the same vsAddress, vsName and policy CR  which is specified in extendedConfigMap. 
+NextGenRoute uses extendedConfigMap for extending the native resources (routes). All the routes are group by namespaces or namespace-labels into RouteGroups. Each RouteGroup shares the same vsAddress, vsName and policy CR  which is specified in extendedConfigMap. 
 In order to migrate to nextGen we first need to create an extended ConfigMap and policy CR then modify the CIS deployment accordingly. Refer [NextGen Route Documentation](./README.md) for more details
 
 ## Migration using defaultRouteGroup


### PR DESCRIPTION
Corrected the introduction of NextGenRoute in the migration guide for clarity.

**Description**:  Fix wording in NextGenRoute migration guide

**Changes Proposed in PR**: NextGenRoute Route to NextGenRoute

**Fixes**: resolves #5496

## General Checklist
- [x] Updated Added functionality/ bug fix in release notes
- [x] Added examples for new feature
- [x] Updated the documentation
- [x] Smoke testing completed

## CRD Checklist
- [x] Updated required CR schema