### PR TITLE
feat: add supplementalGroups support to helm chart security context

### DIFF
--- a/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
+++ b/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
@@ -63,6 +63,10 @@ spec:
         {{- else if (not $oscpOperator) }}
         fsGroup: 1000
         {{- end }}
+        {{- if $securityContext.supplementalGroups }}
+        supplementalGroups:
+{{ toYaml $securityContext.supplementalGroups | indent 10 }}
+        {{- end }}
       containers:
       - name: {{ template "f5-bigip-ctlr.name" . }}
         image: "{{ .Values.image.user }}/{{ .Values.image.repo }}:{{ .Values.version }}"

--- a/helm-charts/f5-bigip-ctlr/values.yaml
+++ b/helm-charts/f5-bigip-ctlr/values.yaml
@@ -78,6 +78,7 @@ version: latest
 #   runAsUser: 1000
 #   runAsGroup: 3000
 #   fsGroup: 2000
+#   supplementalGroups: [1000]
 # If you want to specify resources, uncomment the following
 # limits_cpu: 100m
 # limits_memory: 512Mi


### PR DESCRIPTION
## Summary
This PR adds support for the `supplementalGroups` field in the pod security context configuration for the f5-bigip-ctlr helm chart. This allows users to specify additional group IDs that should be applied to the container process.

## Changes
- Added `supplementalGroups` example in values.yaml
- Updated deployment template to render `supplementalGroups` when specified
- Tested with helm template and kubectl dry-run validation

## Testing
The changes have been tested using:
- `helm template` without supplementalGroups (validates default behavior remains unchanged)
- `helm template` with supplementalGroups set via `--set` flag
- `helm template` with supplementalGroups specified in a custom values file
- `kubectl apply --dry-run=client` to validate the generated YAML

## Test Results
### Without supplementalGroups (default behavior):
```yaml
securityContext:
  runAsUser: 1000
  runAsGroup: 1000
  fsGroup: 1000
```

### With supplementalGroups enabled:
```yaml
securityContext:
  runAsUser: 1000
  runAsGroup: 1000
  fsGroup: 1000
  supplementalGroups:
    - 1000
```

All tests passed successfully with valid Kubernetes manifests.