### PR TITLE
feat: add emptyDir volume for /tmp with readOnlyRootFilesystem

### DIFF
--- a/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
+++ b/helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml
@@ -94,6 +94,10 @@ spec:
         - name: bigip-creds
           mountPath: "/tmp/creds"
           readOnly: true
+        {{- if and .Values.podSecurityContext .Values.podSecurityContext.readOnlyRootFilesystem }}
+        - name: tmp
+          mountPath: /tmp
+        {{- end }}
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         command:
         - /app/bin/k8s-bigip-ctlr
@@ -135,5 +139,9 @@ spec:
           secretName: f5-bigip-ctlr-login
       {{- else }}
           secretName: {{ .Values.bigip_login_secret }}
+      {{- end }}
+      {{- if and .Values.podSecurityContext .Values.podSecurityContext.readOnlyRootFilesystem }}
+      - name: tmp
+        emptyDir: {}
       {{- end }}
 {{- end }}

--- a/helm-charts/f5-bigip-ctlr/values.yaml
+++ b/helm-charts/f5-bigip-ctlr/values.yaml
@@ -88,3 +88,4 @@ version: latest
 #   runAsUser: 1000
 #   runAsGroup: 1000
 #   privileged: true
+#   readOnlyRootFilesystem: true


### PR DESCRIPTION
## Summary
This PR adds support for an emptyDir volume mount for the `/tmp` directory when `readOnlyRootFilesystem` is enabled in the pod security context. This fixes the critical error that occurs when the application tries to create temporary files:

```
Failed creating ConfigWriter tool: could not create unique config directory: mkdir /tmp/k8s-bigip-ctlr.config1413516199: read-only file system
```

## Problem
When `podSecurityContext.readOnlyRootFilesystem: true` is set for enhanced security, the k8s-bigip-ctlr container cannot write to `/tmp` to create its configuration directory, causing the controller to fail at startup.

## Solution
- Added conditional emptyDir volume when `readOnlyRootFilesystem` is set to `true`
- Added corresponding volume mount for `/tmp` directory
- The volume and mount are only created when `readOnlyRootFilesystem` is explicitly enabled, maintaining backward compatibility

## Changes
- Updated `helm-charts/f5-bigip-ctlr/values.yaml` to include `readOnlyRootFilesystem` in the podSecurityContext example
- Updated `helm-charts/f5-bigip-ctlr/templates/f5-bigip-ctlr-deploy.yaml` to conditionally add tmp volume and mount

## Testing
Comprehensive testing has been performed:

### Test 1: Default behavior (without readOnlyRootFilesystem)
```bash
helm template test-release . --set args.bigip_url=10.10.10.10 --set args.bigip_partition=test
```
**Result:** No tmp volume or mount added - backward compatible ✅

### Test 2: With readOnlyRootFilesystem enabled
```bash
helm template test-release . \
  --set args.bigip_url=10.10.10.10 \
  --set args.bigip_partition=test \
  --set podSecurityContext.readOnlyRootFilesystem=true
```
**Result:** tmp emptyDir volume and mount added correctly ✅

**Generated volumeMounts:**
```yaml
volumeMounts:
- name: bigip-creds
  mountPath: "/tmp/creds"
  readOnly: true
- name: tmp
  mountPath: /tmp
```

**Generated volumes:**
```yaml
volumes:
- name: bigip-creds
  secret:
    secretName: f5-bigip-ctlr-login
- name: tmp
  emptyDir: {}
```

### Test 3: Complete security context configuration
```yaml
podSecurityContext:
  runAsUser: 1000
  runAsGroup: 1000
  readOnlyRootFilesystem: true
  allowPrivilegeEscalation: false
  capabilities:
    drop:
      - ALL
```
**Result:** All security settings applied correctly with tmp volume ✅

### Test 4: kubectl validation
```bash
helm template ... | kubectl apply --dry-run=client -f -
```
**Result:** All manifests validated successfully ✅

## Backward Compatibility
This change is fully backward compatible:
- The emptyDir volume and mount are **only added** when `podSecurityContext.readOnlyRootFilesystem` is explicitly set to `true`
- Existing deployments without this setting are not affected
- No breaking changes to the chart API